### PR TITLE
Changing `getConnectionToNode` structure, removing `ForwardProxy.openConnection` from `NodeConnection`

### DIFF
--- a/src/agent/GRPCClientAgent.ts
+++ b/src/agent/GRPCClientAgent.ts
@@ -51,7 +51,7 @@ class GRPCClientAgent extends GRPCClient<AgentServiceClient> {
 
   public async start({
     tlsConfig,
-    timeout = Infinity,
+    timeout = 25000,
   }: {
     tlsConfig?: TLSConfig;
     timeout?: number;

--- a/src/grpc/GRPCClient.ts
+++ b/src/grpc/GRPCClient.ts
@@ -59,7 +59,7 @@ class GRPCClient<T extends Client> {
     tlsConfig,
     secure,
     session,
-    timeout = Infinity,
+    timeout = 25000,
   }: {
     clientConstructor: new (
       address: string,

--- a/src/nodes/errors.ts
+++ b/src/nodes/errors.ts
@@ -23,6 +23,10 @@ class ErrorNodeConnectionNotStarted extends ErrorNodes {}
 
 class ErrorNodeConnectionDestroyed extends ErrorNodes {}
 
+class ErrorNodeConnectionTimeout extends ErrorNodes {
+  description: 'A node connection could not be established (timed out)';
+}
+
 class ErrorNodeConnectionNotExist extends ErrorNodes {}
 
 class ErrorNodeConnectionInfoNotExist extends ErrorNodes {}
@@ -51,6 +55,7 @@ export {
   ErrorNodeGraphInvalidBucketIndex,
   ErrorNodeConnectionNotStarted,
   ErrorNodeConnectionDestroyed,
+  ErrorNodeConnectionTimeout,
   ErrorNodeConnectionNotExist,
   ErrorNodeConnectionInfoNotExist,
   ErrorNodeConnectionPublicKeyNotFound,

--- a/tests/bin/nodes.test.ts
+++ b/tests/bin/nodes.test.ts
@@ -203,7 +203,7 @@ describe('CLI Nodes', () => {
         expect(result2.code).toBe(1); // Should fail with no response. for automation purposes.
         expect(result2.stdout).toContain('No response received');
       },
-      global.failedConnectionTimeout,
+      global.failedConnectionTimeout * 2,
     );
     test(
       "Should return failure if can't find the node",
@@ -223,7 +223,7 @@ describe('CLI Nodes', () => {
         expect(result2.stdout).toContain('message');
         expect(result2.stdout).toContain('Failed to resolve node ID');
       },
-      global.failedConnectionTimeout,
+      global.failedConnectionTimeout * 2,
     );
     test('Should return success when pinging a live node', async () => {
       const commands = genCommands(['ping', remoteOnlineNodeId]);
@@ -333,7 +333,7 @@ describe('CLI Nodes', () => {
         expect(result2.stdout).toContain('success');
         expect(result2.stdout).toContain('false');
       },
-      global.failedConnectionTimeout,
+      global.failedConnectionTimeout * 2,
     );
   });
   describe('commandAddNode', () => {


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->
Change `getConnectionToNode` over to the correct `ObjectMap` pattern from https://gist.github.com/CMCDragonkai/f58f08e7eaab0430ed4467ca35527a42

Based on our sprint meeting today, I'll also remove the `openConnection` call from `ForwardProxy` when we established a `NodeConnection` and ensure we don't run into any issues.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #282

### Tasks
<!-- List all tasks to be done by this PR. -->
1. [x] 1. Change `getConnectionToNode` to match `ObjectMap`
2. [x] 2. Re-run `NodeManager` tests
3. [x] 3. Remove `ForwardProxy.openConnection` call from `NodeConnection.start`
4. [x] 4. Re-run `NodeManager` + `NodeConnecton` tests
5. [x] 5. Update `ObjectMap` diagram with new structure

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [ ] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
