### PR TITLE
Supporting trusted seed nodes (`nodes` domain refactoring, static sources for seed nodes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,4 @@ dist
 
 # editor
 .vscode/
+.idea/

--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -1,6 +1,7 @@
 import type { FileSystem } from './types';
 import type { PolykeyWorkerManagerInterface } from './workers/types';
 import type { Host, Port } from './network/types';
+import type { NodeMapping } from './nodes/types';
 
 import path from 'path';
 import process from 'process';
@@ -58,6 +59,7 @@ class PolykeyAgent {
     networkConfig = {},
     forwardProxyConfig = {},
     reverseProxyConfig = {},
+    seedNodes = {},
     // Optional dependencies
     status,
     schema,
@@ -99,6 +101,7 @@ class PolykeyAgent {
       connTimeoutTime?: number;
     };
     networkConfig?: NetworkConfig;
+    seedNodes?: NodeMapping;
     status?: Status;
     schema?: Schema;
     keyManager?: KeyManager;
@@ -241,6 +244,7 @@ class PolykeyAgent {
       nodeManager ??
       (await NodeManager.createNodeManager({
         db,
+        seedNodes,
         sigchain,
         keyManager,
         fwdProxy,
@@ -503,6 +507,8 @@ class PolykeyAgent {
     });
 
     await this.nodeManager.start({ fresh });
+    await this.nodeManager.getConnectionsToSeedNodes();
+    await this.nodeManager.syncNodeGraph();
     await this.vaultManager.start({ fresh });
     await this.notificationsManager.start({ fresh });
     await this.sessionManager.start({ fresh });

--- a/src/agent/agentService.ts
+++ b/src/agent/agentService.ts
@@ -195,7 +195,7 @@ function createAgentService({
         );
         for (const node of closestNodes) {
           const addressMessage = new nodesPB.Address();
-          addressMessage.setHost(node.address.ip);
+          addressMessage.setHost(node.address.host);
           addressMessage.setPort(node.address.port);
           // Add the node to the response's map (mapping of node ID -> node address)
           response.getNodeTableMap().set(node.id, addressMessage);

--- a/src/bin/agent/CommandStart.ts
+++ b/src/bin/agent/CommandStart.ts
@@ -23,6 +23,9 @@ class CommandStart extends CommandPolykey {
     this.addOption(binOptions.clientPort);
     this.addOption(binOptions.ingressHost);
     this.addOption(binOptions.ingressPort);
+    this.addOption(binOptions.connTimeoutTime);
+    this.addOption(binOptions.seedNodes);
+    this.addOption(binOptions.network);
     this.addOption(binOptions.background);
     this.addOption(binOptions.backgroundOutFile);
     this.addOption(binOptions.backgroundErrFile);
@@ -66,6 +69,8 @@ class CommandStart extends CommandPolykey {
         options.recoveryCodeFile,
         this.fs,
       );
+      const [seedNodes, defaults] = options.seedNodes;
+      if (defaults) Object.assign(seedNodes, options.network);
       const agentConfig = {
         password,
         nodePath: options.nodePath,
@@ -73,12 +78,19 @@ class CommandStart extends CommandPolykey {
           rootKeyPairBits: options.rootKeyPairBits,
           recoveryCode: recoveryCodeIn,
         },
+        forwardProxyConfig: {
+          connTimeoutTime: options.connTimeoutTime,
+        },
+        reverseProxyConfig: {
+          connTimeoutTime: options.connTimeoutTime,
+        },
         networkConfig: {
           clientHost: options.clientHost,
           clientPort: options.clientPort,
           ingressHost: options.ingressHost,
           ingressPort: options.ingressPort,
         },
+        seedNodes,
         fresh: options.fresh,
       };
       let recoveryCodeOut: RecoveryCode | undefined;

--- a/src/bin/utils/options.ts
+++ b/src/bin/utils/options.ts
@@ -4,7 +4,7 @@
  * @module
  */
 import commander from 'commander';
-import * as binParsers from './parsers';
+import * as binParsers from '../utils/parsers';
 import config from '../../config';
 
 /**
@@ -83,6 +83,13 @@ const ingressPort = new commander.Option(
   .env('PK_INGRESS_PORT')
   .default(config.defaults.networkConfig.ingressPort);
 
+const connTimeoutTime = new commander.Option(
+  '--connection-timeout <ms>',
+  'Timeout value for connection establishment between nodes',
+)
+  .argParser(binParsers.parseNumber)
+  .default(config.defaults.forwardProxyConfig.connTimeoutTime);
+
 const passwordFile = new commander.Option(
   '-pf, --password-file <path>',
   'Path to Password',
@@ -118,6 +125,22 @@ const rootKeyPairBits = new commander.Option(
   'Bit size of root key pair',
 ).argParser(binParsers.parseNumber);
 
+const seedNodes = new commander.Option(
+  '-sn, --seed-nodes [nodeId1@host:port;nodeId2@host:port;...]',
+  'Seed node address mappings',
+)
+  .argParser(binParsers.parseSeedNodes)
+  .env('PK_SEED_NODES')
+  .default([{}, true]);
+
+const network = new commander.Option(
+  '-n --network <network>',
+  'Setting the desired default network.',
+)
+  .argParser(binParsers.parseNetwork)
+  .env('PK_NETWORK')
+  .default(config.defaults.network.mainnet);
+
 export {
   nodePath,
   format,
@@ -128,11 +151,14 @@ export {
   clientPort,
   ingressHost,
   ingressPort,
+  connTimeoutTime,
+  recoveryCodeFile,
   passwordFile,
   passwordNewFile,
-  recoveryCodeFile,
   background,
   backgroundOutFile,
   backgroundErrFile,
   rootKeyPairBits,
+  seedNodes,
+  network,
 };

--- a/src/client/clientService.ts
+++ b/src/client/clientService.ts
@@ -14,7 +14,6 @@ import type { FileSystem } from '../types';
 
 import type * as grpc from '@grpc/grpc-js';
 import type { IClientServiceServer } from '../proto/js/polykey/v1/client_service_grpc_pb';
-import { promisify } from 'util';
 import createStatusRPC from './rpcStatus';
 import createSessionsRPC from './rpcSessions';
 import createVaultRPC from './rpcVaults';
@@ -25,7 +24,6 @@ import createIdentitiesRPC from './rpcIdentities';
 import createNotificationsRPC from './rpcNotifications';
 import * as clientUtils from './utils';
 import * as grpcUtils from '../grpc/utils';
-import * as nodesPB from '../proto/js/polykey/v1/nodes/nodes_pb';
 import * as utilsPB from '../proto/js/polykey/v1/utils/utils_pb';
 import { ClientServiceService } from '../proto/js/polykey/v1/client_service_grpc_pb';
 
@@ -114,17 +112,6 @@ function createClientService({
       notificationsManager,
       authenticate,
     }),
-    nodesList: async (
-      call: grpc.ServerWritableStream<utilsPB.EmptyMessage, nodesPB.Node>,
-    ): Promise<void> => {
-      // Call.request // PROCESS THE REQEUST MESSAGE
-      const nodeMessage = new nodesPB.Node();
-      nodeMessage.setNodeId('some node name');
-      const write = promisify(call.write).bind(call);
-      await write(nodeMessage);
-      call.end();
-      return;
-    },
     agentStop: async (
       call: grpc.ServerUnaryCall<utilsPB.EmptyMessage, utilsPB.EmptyMessage>,
       callback: grpc.sendUnaryData<utilsPB.EmptyMessage>,

--- a/src/config.ts
+++ b/src/config.ts
@@ -91,6 +91,21 @@ const config = {
       connConnectTime: 20000,
       connTimeoutTime: 20000,
     },
+    // Note: this is not used by the `PolykeyAgent`, that is defaulting to `{}`.
+    network: {
+      mainnet: {
+        v359vgrgmqf1r5g4fvisiddjknjko6bmm4qv7646jr7fi9enbfuug: {
+          host: 'testnet.polykey.io',
+          port: 1314,
+        },
+      },
+      testnet: {
+        v359vgrgmqf1r5g4fvisiddjknjko6bmm4qv7646jr7fi9enbfuug: {
+          host: '127.0.0.3',
+          port: 1314,
+        },
+      },
+    },
   },
 };
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -20,6 +20,8 @@ class ErrorPolykeyClientDestroyed extends ErrorPolykey {}
 
 class ErrorInvalidId extends ErrorPolykey {}
 
+class ErrorInvalidConfigEnvironment extends ErrorPolykey {}
+
 export {
   sysexits,
   ErrorPolykey,
@@ -31,6 +33,7 @@ export {
   ErrorPolykeyClientNotRunning,
   ErrorPolykeyClientDestroyed,
   ErrorInvalidId,
+  ErrorInvalidConfigEnvironment,
 };
 
 /**

--- a/src/network/errors.ts
+++ b/src/network/errors.ts
@@ -83,6 +83,8 @@ class ErrorCertChainKeyInvalid extends ErrorCertChain {}
  */
 class ErrorCertChainSignatureInvalid extends ErrorCertChain {}
 
+class ErrorHostnameResolutionFailed extends ErrorNetwork {}
+
 export {
   ErrorNetwork,
   ErrorForwardProxyNotStarted,
@@ -110,4 +112,5 @@ export {
   ErrorCertChainNameInvalid,
   ErrorCertChainKeyInvalid,
   ErrorCertChainSignatureInvalid,
+  ErrorHostnameResolutionFailed,
 };

--- a/src/network/types.ts
+++ b/src/network/types.ts
@@ -6,7 +6,10 @@ import type {
 } from '../keys/types';
 import type { Opaque } from '../types';
 
+// Host is always an IP address
 type Host = Opaque<'Host', string>;
+// Specifically for hostname domain names (i.e. to be resolved to an IP address)
+type Hostname = Opaque<'Hostname', string>;
 type Port = Opaque<'Port', number>;
 type Address = Opaque<'Address', string>;
 
@@ -42,6 +45,7 @@ type NetworkMessage = PingMessage | PongMessage;
 
 export type {
   Host,
+  Hostname,
   Port,
   Address,
   TLSConfig,

--- a/src/nodes/errors.ts
+++ b/src/nodes/errors.ts
@@ -29,6 +29,9 @@ class ErrorNodeGraphInvalidBucketIndex extends ErrorNodes {}
 class ErrorNodeConnectionRunning extends ErrorNodes {}
 
 class ErrorNodeConnectionNotRunning extends ErrorNodes {}
+class ErrorNodeGraphOversizedBucket extends ErrorNodes {
+  description: 'Bucket invalidly contains more nodes than capacity';
+}
 
 class ErrorNodeConnectionDestroyed extends ErrorNodes {}
 
@@ -67,6 +70,7 @@ export {
   ErrorNodeGraphInvalidBucketIndex,
   ErrorNodeConnectionRunning,
   ErrorNodeConnectionNotRunning,
+  ErrorNodeGraphOversizedBucket,
   ErrorNodeConnectionDestroyed,
   ErrorNodeConnectionTimeout,
   ErrorNodeConnectionNotExist,

--- a/src/nodes/types.ts
+++ b/src/nodes/types.ts
@@ -1,7 +1,7 @@
 import type NodeConnection from './NodeConnection';
 import type { MutexInterface } from 'async-mutex';
 import type { Opaque } from '../types';
-import type { Host, Port } from '../network/types';
+import type { Host, Hostname, Port } from '../network/types';
 import type { Claim, ClaimId } from '../claims/types';
 import type { ChainData } from '../sigchain/types';
 import type { IdString } from '../GenericIdTypes';
@@ -9,8 +9,12 @@ import type { IdString } from '../GenericIdTypes';
 type NodeId = Opaque<'NodeId', IdString>;
 
 type NodeAddress = {
-  ip: Host;
+  host: Host | Hostname;
   port: Port;
+};
+
+type NodeMapping = {
+  [key: string]: NodeAddress;
 };
 
 type NodeData = {
@@ -83,6 +87,7 @@ type NodeGraphOp =
 export type {
   NodeId,
   NodeAddress,
+  NodeMapping,
   NodeData,
   NodeClaim,
   NodeInfo,

--- a/src/nodes/utils.ts
+++ b/src/nodes/utils.ts
@@ -1,6 +1,5 @@
 import type { NodeData, NodeId } from './types';
 
-import { Validator } from 'ip-num';
 import { ErrorInvalidNodeId } from './errors';
 import { fromMultibase, isIdString, makeIdString } from '../GenericIdTypes';
 
@@ -67,15 +66,6 @@ function makeNodeId(arg: any): NodeId {
 }
 
 /**
- * Validates that a provided host address is a valid IPv4 or IPv6 address.
- */
-function isValidHost(host: string): boolean {
-  const [isIPv4] = Validator.isValidIPv4String(host);
-  const [isIPv6] = Validator.isValidIPv6String(host);
-  return isIPv4 || isIPv6;
-}
-
-/**
  * Node ID to an array of 8-bit unsigned ints
  */
 function nodeIdToU8(id: string): Uint8Array {
@@ -103,7 +93,6 @@ export {
   calculateBucketIndex,
   isNodeId,
   makeNodeId,
-  isValidHost,
   nodeIdToU8,
   sortByDistance,
 };

--- a/tests/agent/GRPCClientAgent.test.ts
+++ b/tests/agent/GRPCClientAgent.test.ts
@@ -290,7 +290,7 @@ describe('GRPC agent', () => {
         lock: new Mutex(),
       });
       await nodeManager.setNode(nodeIdY, {
-        ip: 'unnecessary' as Host,
+        host: 'unnecessary' as Host,
         port: 0 as Port,
       } as NodeAddress);
     });

--- a/tests/bin/nodes.test.ts
+++ b/tests/bin/nodes.test.ts
@@ -104,7 +104,7 @@ describe('CLI Nodes', () => {
   describe('commandClaimNode', () => {
     beforeAll(async () => {
       await remoteOnline.nodeManager.setNode(keynodeId, {
-        ip: polykeyAgent.revProxy.ingressHost,
+        host: polykeyAgent.revProxy.ingressHost,
         port: polykeyAgent.revProxy.ingressPort,
       } as NodeAddress);
       await polykeyAgent.acl.setNodePerm(remoteOnlineNodeId, {
@@ -353,7 +353,7 @@ describe('CLI Nodes', () => {
       // Checking if node was added.
       const res = await polykeyAgent.nodeManager.getNode(validNodeId);
       expect(res).toBeTruthy();
-      expect(res!.ip).toEqual(validHost);
+      expect(res!.host).toEqual(validHost);
       expect(res!.port).toEqual(port);
     });
     test(

--- a/tests/bin/notifications.test.ts
+++ b/tests/bin/notifications.test.ts
@@ -64,7 +64,7 @@ describe('CLI Notifications', () => {
     senderNodeId = senderPolykeyAgent.nodeManager.getNodeId();
     receiverNodeId = receiverPolykeyAgent.nodeManager.getNodeId();
     await senderPolykeyAgent.nodeManager.setNode(receiverNodeId, {
-      ip: receiverPolykeyAgent.revProxy.ingressHost,
+      host: receiverPolykeyAgent.revProxy.ingressHost,
       port: receiverPolykeyAgent.revProxy.ingressPort,
     } as NodeAddress);
 

--- a/tests/bin/utils.ts
+++ b/tests/bin/utils.ts
@@ -43,6 +43,7 @@ async function pkStdio(
 }> {
   cwd =
     cwd ?? (await fs.promises.mkdtemp(path.join(os.tmpdir(), 'polykey-test-')));
+  env['PK_SEED_NODES'] = env['PK_SEED_NODES'] ?? '';
   // Parse the arguments of process.stdout.write and process.stderr.write
   const parseArgs = (args) => {
     const data = args[0];
@@ -131,6 +132,7 @@ async function pkExec(
     ...process.env,
     ...env,
   };
+  env['PK_SEED_NODES'] = env['PK_SEED_NODES'] ?? '';
   const tsConfigPath = path.resolve(
     path.join(global.projectDir, 'tsconfig.json'),
   );
@@ -195,6 +197,7 @@ async function pkSpawn(
     ...process.env,
     ...env,
   };
+  env['PK_SEED_NODES'] = env['PK_SEED_NODES'] ?? '';
   const tsConfigPath = path.resolve(
     path.join(global.projectDir, 'tsconfig.json'),
   );
@@ -257,6 +260,7 @@ async function pkExpect({
     ...process.env,
     ...env,
   };
+  env['PK_SEED_NODES'] = env['PK_SEED_NODES'] ?? '';
   const tsConfigPath = path.resolve(
     path.join(global.projectDir, 'tsconfig.json'),
   );

--- a/tests/bin/vaults.test.ts
+++ b/tests/bin/vaults.test.ts
@@ -309,7 +309,7 @@ describe('CLI vaults', () => {
         const targetHost = targetPolykeyAgent.revProxy.ingressHost;
         const targetPort = targetPolykeyAgent.revProxy.ingressPort;
         await polykeyAgent.nodeManager.setNode(targetNodeId, {
-          ip: targetHost,
+          host: targetHost,
           port: targetPort,
         });
         // Client agent: Start sending hole-punching packets to the target
@@ -385,7 +385,7 @@ describe('CLI vaults', () => {
         const targetHost = targetPolykeyAgent.revProxy.ingressHost;
         const targetPort = targetPolykeyAgent.revProxy.ingressPort;
         await polykeyAgent.nodeManager.setNode(targetNodeId, {
-          ip: targetHost,
+          host: targetHost,
           port: targetPort,
         });
         // Client agent: Start sending hole-punching packets to the target
@@ -457,7 +457,7 @@ describe('CLI vaults', () => {
       const targetHost = targetPolykeyAgent.revProxy.ingressHost;
       const targetPort = targetPolykeyAgent.revProxy.ingressPort;
       await polykeyAgent.nodeManager.setNode(targetNodeId, {
-        ip: targetHost,
+        host: targetHost,
         port: targetPort,
       });
       // Client agent: Start sending hole-punching packets to the target

--- a/tests/client/rpcNodes.test.ts
+++ b/tests/client/rpcNodes.test.ts
@@ -171,16 +171,16 @@ describe('Client service', () => {
     await nodesAdd(nodeAddressMessage, callCredentials);
     const nodeAddress = await nodeManager.getNode(nodeId);
     expect(nodeAddress).toBeDefined();
-    expect(nodeAddress!.ip).toBe(host);
+    expect(nodeAddress!.host).toBe(host);
     expect(nodeAddress!.port).toBe(port);
   });
-  test(
+  test.skip(
     'should ping a node (online + offline)',
     async () => {
       const serverNodeId = polykeyServer.nodeManager.getNodeId();
       await testKeynodeUtils.addRemoteDetails(polykeyAgent, polykeyServer);
       await polykeyServer.stop();
-      const statusPath = path.join(polykeyServer.nodePath, 'status');
+      const statusPath = path.join(polykeyServer.nodePath, 'status.json');
       const status = new Status({
         statusPath,
         fs,
@@ -221,7 +221,7 @@ describe('Client service', () => {
     // Case 1: node already exists in the local node graph (no contact required)
     const nodeId = nodeId1;
     const nodeAddress: NodeAddress = {
-      ip: '127.0.0.1' as Host,
+      host: '127.0.0.1' as Host,
       port: 11111 as Port,
     };
     await nodeManager.setNode(nodeId, nodeAddress);
@@ -230,7 +230,7 @@ describe('Client service', () => {
     nodeMessage.setNodeId(nodeId);
     const res = await nodesFind(nodeMessage, callCredentials);
     expect(res.getNodeId()).toEqual(nodeId);
-    expect(res.getAddress()?.getHost()).toEqual(nodeAddress.ip);
+    expect(res.getAddress()?.getHost()).toEqual(nodeAddress.host);
     expect(res.getAddress()?.getPort()).toEqual(nodeAddress.port);
   });
   test(
@@ -240,7 +240,7 @@ describe('Client service', () => {
       // Case 2: node can be found on the remote node
       const nodeId = nodeId1;
       const nodeAddress: NodeAddress = {
-        ip: '127.0.0.1' as Host,
+        host: '127.0.0.1' as Host,
         port: 11111 as Port,
       };
       // Setting the information on a remote node.
@@ -253,7 +253,7 @@ describe('Client service', () => {
       nodeMessage.setNodeId(nodeId);
       const res = await nodesFind(nodeMessage, callCredentials);
       expect(res.getNodeId()).toEqual(nodeId);
-      expect(res.getAddress()?.getHost()).toEqual(nodeAddress.ip);
+      expect(res.getAddress()?.getHost()).toEqual(nodeAddress.host);
       expect(res.getAddress()?.getPort()).toEqual(nodeAddress.port);
     },
     global.failedConnectionTimeout * 2,
@@ -268,9 +268,9 @@ describe('Client service', () => {
       // Server will not be able to connect to this node (the only node in its
       // database), and will therefore not be able to locate the node.
       await polykeyServer.nodeManager.setNode(dummyNode, {
-        ip: '127.0.0.2' as Host,
+        host: '127.0.0.2' as Host,
         port: 22222 as Port,
-      } as NodeAddress);
+      });
       const nodesFind = grpcUtils.promisifyUnaryCall<nodesPB.Address>(
         client,
         client.nodesFind,

--- a/tests/client/rpcNotifications.test.ts
+++ b/tests/client/rpcNotifications.test.ts
@@ -1,5 +1,5 @@
 import type * as grpc from '@grpc/grpc-js';
-import type { NodeInfo, NodeAddress } from '@/nodes/types';
+import type { NodeInfo } from '@/nodes/types';
 import type { NodeManager } from '@/nodes';
 import type { NotificationData } from '@/notifications/types';
 import type { ClientServiceClient } from '@/proto/js/polykey/v1/client_service_grpc_pb';
@@ -123,9 +123,9 @@ describe('Notifications client service', () => {
       sender = await testKeynodeUtils.setupRemoteKeynode({ logger });
 
       await sender.nodeManager.setNode(node1.id, {
-        ip: polykeyAgent.revProxy.ingressHost,
+        host: polykeyAgent.revProxy.ingressHost,
         port: polykeyAgent.revProxy.ingressPort,
-      } as NodeAddress);
+      });
       await receiver.acl.setNodePerm(node1.id, {
         gestalt: {
           notify: null,

--- a/tests/network/utils.test.ts
+++ b/tests/network/utils.test.ts
@@ -1,6 +1,6 @@
 import type { Host, Port } from '@/network/types';
 
-import * as networkUtils from '@/network/utils';
+import { utils as networkUtils, errors as networkErrors } from '@/network';
 
 describe('utils', () => {
   test('building addresses', async () => {
@@ -22,5 +22,15 @@ describe('utils', () => {
         '0000:0000:0000:0000:0000:0000:0000:0000' as Host,
       ),
     ).toBe('::1' as Host);
+  });
+  test('resolving hostnames', async () => {
+    await expect(
+      networkUtils.resolveHost('www.google.com' as Host),
+    ).resolves.toBeDefined();
+    const host = await networkUtils.resolveHost('www.google.com' as Host);
+    expect(networkUtils.isValidHost(host)).toBeTruthy();
+    await expect(
+      networkUtils.resolveHost('invalidHostname' as Host),
+    ).rejects.toThrow(networkErrors.ErrorHostnameResolutionFailed);
   });
 });

--- a/tests/nodes/NodeConnection.test.ts
+++ b/tests/nodes/NodeConnection.test.ts
@@ -340,6 +340,19 @@ describe('NodeConnection', () => {
     await conn.stop();
     await conn.destroy();
   });
+  test('fails to connect to target (times out)', async () => {
+    await expect(
+      NodeConnection.createNodeConnection({
+        targetNodeId: targetNodeId,
+        targetHost: '128.0.0.1' as Host,
+        targetPort: 12345 as Port,
+        connTimeout: 300,
+        forwardProxy: clientFwdProxy,
+        keyManager: clientKeyManager,
+        logger: logger,
+      }),
+    ).rejects.toThrow(nodesErrors.ErrorNodeConnectionTimeout);
+  });
   test('receives 20 closest local nodes from connected target', async () => {
     const conn = await NodeConnection.createNodeConnection({
       targetNodeId: targetNodeId,
@@ -359,7 +372,7 @@ describe('NodeConnection', () => {
         i,
       );
       const nodeAddress = {
-        ip: (i + '.' + i + '.' + i + '.' + i) as Host,
+        host: (i + '.' + i + '.' + i + '.' + i) as Host,
         port: i as Port,
       };
       await serverNodeManager.setNode(closeNodeId, nodeAddress);
@@ -373,7 +386,7 @@ describe('NodeConnection', () => {
     for (let i = 1; i <= 10; i++) {
       const farNodeId = nodeIdGenerator(i);
       const nodeAddress = {
-        ip: (i + '.' + i + '.' + i + '.' + i) as Host,
+        host: (i + '.' + i + '.' + i + '.' + i) as Host,
         port: i as Port,
       };
       await serverNodeManager.setNode(farNodeId, nodeAddress);

--- a/tests/nodes/NodeGraph.test.ts
+++ b/tests/nodes/NodeGraph.test.ts
@@ -200,17 +200,17 @@ describe('NodeGraph', () => {
   test('finds correct node address', async () => {
     // New node added
     const newNode2Id = nodeId1;
-    const newNode2Address = { ip: '227.1.1.1', port: 4567 } as NodeAddress;
+    const newNode2Address = { host: '227.1.1.1', port: 4567 } as NodeAddress;
     await nodeGraph.setNode(newNode2Id, newNode2Address);
 
     // Get node address
     const foundAddress = await nodeGraph.getNode(newNode2Id);
-    expect(foundAddress).toEqual({ ip: '227.1.1.1', port: 4567 });
+    expect(foundAddress).toEqual({ host: '227.1.1.1', port: 4567 });
   });
   test('unable to find node address', async () => {
     // New node added
     const newNode2Id = nodeId1;
-    const newNode2Address = { ip: '227.1.1.1', port: 4567 } as NodeAddress;
+    const newNode2Address = { host: '227.1.1.1', port: 4567 } as NodeAddress;
     await nodeGraph.setNode(newNode2Id, newNode2Address);
 
     // Get node address (of non-existent node)
@@ -220,7 +220,7 @@ describe('NodeGraph', () => {
   test('adds a single node into a bucket', async () => {
     // New node added
     const newNode2Id = nodesTestUtils.generateNodeIdForBucket(nodeId, 1);
-    const newNode2Address = { ip: '227.1.1.1', port: 4567 } as NodeAddress;
+    const newNode2Address = { host: '227.1.1.1', port: 4567 } as NodeAddress;
     await nodeGraph.setNode(newNode2Id, newNode2Address);
 
     // Check new node is in retrieved bucket from database
@@ -228,36 +228,36 @@ describe('NodeGraph', () => {
     const bucket = await nodeGraph.getBucket(1);
     expect(bucket).toBeDefined();
     expect(bucket![newNode2Id]).toEqual({
-      address: { ip: '227.1.1.1', port: 4567 },
+      address: { host: '227.1.1.1', port: 4567 },
       lastUpdated: expect.any(Date),
     });
   });
   test('adds multiple nodes into the same bucket', async () => {
     // Add 3 new nodes into bucket 4
     const newNode1Id = nodesTestUtils.generateNodeIdForBucket(nodeId, 4);
-    const newNode1Address = { ip: '4.4.4.4', port: 4444 } as NodeAddress;
+    const newNode1Address = { host: '4.4.4.4', port: 4444 } as NodeAddress;
     await nodeGraph.setNode(newNode1Id, newNode1Address);
 
     const newNode2Id = nodesTestUtils.incrementNodeId(newNode1Id);
-    const newNode2Address = { ip: '5.5.5.5', port: 5555 } as NodeAddress;
+    const newNode2Address = { host: '5.5.5.5', port: 5555 } as NodeAddress;
     await nodeGraph.setNode(newNode2Id, newNode2Address);
 
     const newNode3Id = nodesTestUtils.incrementNodeId(newNode2Id);
-    const newNode3Address = { ip: '6.6.6.6', port: 6666 } as NodeAddress;
+    const newNode3Address = { host: '6.6.6.6', port: 6666 } as NodeAddress;
     await nodeGraph.setNode(newNode3Id, newNode3Address);
     // Based on XOR values, all 3 nodes should appear in bucket 4.
     const bucket = await nodeGraph.getBucket(4);
     if (bucket) {
       expect(bucket[newNode1Id]).toEqual({
-        address: { ip: '4.4.4.4', port: 4444 },
+        address: { host: '4.4.4.4', port: 4444 },
         lastUpdated: expect.any(Date),
       });
       expect(bucket[newNode2Id]).toEqual({
-        address: { ip: '5.5.5.5', port: 5555 },
+        address: { host: '5.5.5.5', port: 5555 },
         lastUpdated: expect.any(Date),
       });
       expect(bucket[newNode3Id]).toEqual({
-        address: { ip: '6.6.6.6', port: 6666 },
+        address: { host: '6.6.6.6', port: 6666 },
         lastUpdated: expect.any(Date),
       });
     } else {
@@ -268,22 +268,22 @@ describe('NodeGraph', () => {
   test('adds a single node into different buckets', async () => {
     // New node for bucket 3
     const newNode1Id = nodesTestUtils.generateNodeIdForBucket(nodeId, 3);
-    const newNode1Address = { ip: '1.1.1.1', port: 1111 } as NodeAddress;
+    const newNode1Address = { host: '1.1.1.1', port: 1111 } as NodeAddress;
     await nodeGraph.setNode(newNode1Id, newNode1Address);
     // New node for bucket 255 (the highest possible bucket)
     const newNode2Id = nodesTestUtils.generateNodeIdForBucket(nodeId, 255);
-    const newNode2Address = { ip: '2.2.2.2', port: 2222 } as NodeAddress;
+    const newNode2Address = { host: '2.2.2.2', port: 2222 } as NodeAddress;
     await nodeGraph.setNode(newNode2Id, newNode2Address);
 
     const bucket3 = await nodeGraph.getBucket(3);
     const bucket351 = await nodeGraph.getBucket(255);
     if (bucket3 && bucket351) {
       expect(bucket3[newNode1Id]).toEqual({
-        address: { ip: '1.1.1.1', port: 1111 },
+        address: { host: '1.1.1.1', port: 1111 },
         lastUpdated: expect.any(Date),
       });
       expect(bucket351[newNode2Id]).toEqual({
-        address: { ip: '2.2.2.2', port: 2222 },
+        address: { host: '2.2.2.2', port: 2222 },
         lastUpdated: expect.any(Date),
       });
     } else {
@@ -294,14 +294,14 @@ describe('NodeGraph', () => {
   test('deletes a single node (and removes bucket)', async () => {
     // New node for bucket 2
     const newNode1Id = nodesTestUtils.generateNodeIdForBucket(nodeId, 2);
-    const newNode1Address = { ip: '4.4.4.4', port: 4444 } as NodeAddress;
+    const newNode1Address = { host: '4.4.4.4', port: 4444 } as NodeAddress;
     await nodeGraph.setNode(newNode1Id, newNode1Address);
 
     // Check the bucket is there first.
     const bucket = await nodeGraph.getBucket(2);
     if (bucket) {
       expect(bucket[newNode1Id]).toEqual({
-        address: { ip: '4.4.4.4', port: 4444 },
+        address: { host: '4.4.4.4', port: 4444 },
         lastUpdated: expect.any(Date),
       });
     } else {
@@ -318,29 +318,29 @@ describe('NodeGraph', () => {
   test('deletes a single node (and retains remainder of bucket)', async () => {
     // Add 3 new nodes into bucket 4
     const newNode1Id = nodesTestUtils.generateNodeIdForBucket(nodeId, 4);
-    const newNode1Address = { ip: '4.4.4.4', port: 4444 } as NodeAddress;
+    const newNode1Address = { host: '4.4.4.4', port: 4444 } as NodeAddress;
     await nodeGraph.setNode(newNode1Id, newNode1Address);
 
     const newNode2Id = nodesTestUtils.incrementNodeId(newNode1Id);
-    const newNode2Address = { ip: '5.5.5.5', port: 5555 } as NodeAddress;
+    const newNode2Address = { host: '5.5.5.5', port: 5555 } as NodeAddress;
     await nodeGraph.setNode(newNode2Id, newNode2Address);
 
     const newNode3Id = nodesTestUtils.incrementNodeId(newNode2Id);
-    const newNode3Address = { ip: '6.6.6.6', port: 6666 } as NodeAddress;
+    const newNode3Address = { host: '6.6.6.6', port: 6666 } as NodeAddress;
     await nodeGraph.setNode(newNode3Id, newNode3Address);
     // Based on XOR values, all 3 nodes should appear in bucket 4.
     const bucket = await nodeGraph.getBucket(4);
     if (bucket) {
       expect(bucket[newNode1Id]).toEqual({
-        address: { ip: '4.4.4.4', port: 4444 },
+        address: { host: '4.4.4.4', port: 4444 },
         lastUpdated: expect.any(Date),
       });
       expect(bucket[newNode2Id]).toEqual({
-        address: { ip: '5.5.5.5', port: 5555 },
+        address: { host: '5.5.5.5', port: 5555 },
         lastUpdated: expect.any(Date),
       });
       expect(bucket[newNode3Id]).toEqual({
-        address: { ip: '6.6.6.6', port: 6666 },
+        address: { host: '6.6.6.6', port: 6666 },
         lastUpdated: expect.any(Date),
       });
     } else {
@@ -355,11 +355,11 @@ describe('NodeGraph', () => {
     if (newBucket) {
       expect(newBucket[newNode1Id]).toBeUndefined();
       expect(bucket[newNode2Id]).toEqual({
-        address: { ip: '5.5.5.5', port: 5555 },
+        address: { host: '5.5.5.5', port: 5555 },
         lastUpdated: expect.any(Date),
       });
       expect(bucket[newNode3Id]).toEqual({
-        address: { ip: '6.6.6.6', port: 6666 },
+        address: { host: '6.6.6.6', port: 6666 },
         lastUpdated: expect.any(Date),
       });
     } else {
@@ -375,7 +375,7 @@ describe('NodeGraph', () => {
     for (let i = 1; i <= nodeGraph.maxNodesPerBucket; i++) {
       // Add the current node ID
       const nodeAddress = {
-        ip: (i + '.' + i + '.' + i + '.' + i) as Host,
+        host: (i + '.' + i + '.' + i + '.' + i) as Host,
         port: i as Port,
       };
       await nodeGraph.setNode(currNodeId, nodeAddress);
@@ -397,7 +397,7 @@ describe('NodeGraph', () => {
     // Attempt to add a new node into this full bucket (increment the last node
     // ID that was added)
     const newNodeId = nodesTestUtils.incrementNodeId(currNodeId);
-    const newNodeAddress = { ip: '0.0.0.1' as Host, port: 1234 as Port };
+    const newNodeAddress = { host: '0.0.0.1' as Host, port: 1234 as Port };
     await nodeGraph.setNode(newNodeId, newNodeAddress);
 
     const finalBucket = await nodeGraph.getBucket(59);
@@ -420,29 +420,89 @@ describe('NodeGraph', () => {
       fail('Bucket undefined');
     }
   });
+  test('enforces k-bucket size, retaining all nodes if adding a pre-existing node', async () => {
+    // Add k nodes to the database (importantly, they all go into the same bucket)
+    let currNodeId = nodesTestUtils.generateNodeIdForBucket(nodeId, 59);
+    // Keep a record of the first node ID that we added
+    // const firstNodeId = currNodeId;
+    for (let i = 1; i <= nodeGraph.maxNodesPerBucket; i++) {
+      // Add the current node ID
+      const nodeAddress = {
+        host: (i + '.' + i + '.' + i + '.' + i) as Host,
+        port: i as Port,
+      };
+      await nodeGraph.setNode(currNodeId, nodeAddress);
+      // Increment the current node ID - skip for the last one to keep currNodeId
+      // as the last added node ID
+      if (i !== nodeGraph.maxNodesPerBucket) {
+        const incrementedNodeId = nodesTestUtils.incrementNodeId(currNodeId);
+        currNodeId = incrementedNodeId;
+      }
+    }
+    // All of these nodes are in bucket 59
+    const originalBucket = await nodeGraph.getBucket(59);
+    if (originalBucket) {
+      expect(Object.keys(originalBucket).length).toBe(
+        nodeGraph.maxNodesPerBucket,
+      );
+    } else {
+      // Should be unreachable
+      fail('Bucket undefined');
+    }
+
+    // If we tried to re-add the first node, it would simply remove the original
+    // first node, as this is the "least active".
+    // We instead want to check that we don't mistakenly delete a node if we're
+    // updating an existing one.
+    // So, re-add the last node
+    const newLastAddress: NodeAddress = {
+      host: '30.30.30.30' as Host,
+      port: 30 as Port,
+    };
+    await nodeGraph.setNode(currNodeId, newLastAddress);
+
+    const finalBucket = await nodeGraph.getBucket(59);
+    if (finalBucket) {
+      // We should still have a full bucket
+      expect(Object.keys(finalBucket).length).toEqual(
+        nodeGraph.maxNodesPerBucket,
+      );
+      // Ensure that this new node is in the bucket
+      expect(finalBucket[currNodeId]).toEqual({
+        address: newLastAddress,
+        lastUpdated: expect.any(Date),
+      });
+    } else {
+      // Should be unreachable
+      fail('Bucket undefined');
+    }
+  });
   test('retrieves all buckets (in expected lexicographic order)', async () => {
     // Bucket 0 is expected to never have any nodes (as nodeId XOR 0 = nodeId)
     // Bucket 1 (minimum):
     const node1Id = nodesTestUtils.generateNodeIdForBucket(nodeId, 1);
-    const node1Address = { ip: '1.1.1.1', port: 1111 } as NodeAddress;
+    const node1Address = { host: '1.1.1.1', port: 1111 } as NodeAddress;
     await nodeGraph.setNode(node1Id, node1Address);
 
     // Bucket 4 (multiple nodes in 1 bucket):
     const node41Id = nodesTestUtils.generateNodeIdForBucket(nodeId, 4);
-    const node41Address = { ip: '41.41.41.41', port: 4141 } as NodeAddress;
+    const node41Address = { host: '41.41.41.41', port: 4141 } as NodeAddress;
     await nodeGraph.setNode(node41Id, node41Address);
     const node42Id = nodesTestUtils.incrementNodeId(node41Id);
-    const node42Address = { ip: '42.42.42.42', port: 4242 } as NodeAddress;
+    const node42Address = { host: '42.42.42.42', port: 4242 } as NodeAddress;
     await nodeGraph.setNode(node42Id, node42Address);
 
     // Bucket 10 (lexicographic ordering - should appear after 2):
     const node10Id = nodesTestUtils.generateNodeIdForBucket(nodeId, 10);
-    const node10Address = { ip: '10.10.10.10', port: 1010 } as NodeAddress;
+    const node10Address = { host: '10.10.10.10', port: 1010 } as NodeAddress;
     await nodeGraph.setNode(node10Id, node10Address);
 
     // Bucket 255 (maximum):
     const node255Id = nodesTestUtils.generateNodeIdForBucket(nodeId, 255);
-    const node255Address = { ip: '255.255.255.255', port: 255 } as NodeAddress;
+    const node255Address = {
+      host: '255.255.255.255',
+      port: 255,
+    } as NodeAddress;
     await nodeGraph.setNode(node255Id, node255Address);
 
     const buckets = await nodeGraph.getAllBuckets();
@@ -452,29 +512,29 @@ describe('NodeGraph', () => {
     expect(buckets).toEqual([
       {
         [node1Id]: {
-          address: { ip: '1.1.1.1', port: 1111 },
+          address: { host: '1.1.1.1', port: 1111 },
           lastUpdated: expect.any(String),
         },
       },
       {
         [node41Id]: {
-          address: { ip: '41.41.41.41', port: 4141 },
+          address: { host: '41.41.41.41', port: 4141 },
           lastUpdated: expect.any(String),
         },
         [node42Id]: {
-          address: { ip: '42.42.42.42', port: 4242 },
+          address: { host: '42.42.42.42', port: 4242 },
           lastUpdated: expect.any(String),
         },
       },
       {
         [node10Id]: {
-          address: { ip: '10.10.10.10', port: 1010 },
+          address: { host: '10.10.10.10', port: 1010 },
           lastUpdated: expect.any(String),
         },
       },
       {
         [node255Id]: {
-          address: { ip: '255.255.255.255', port: 255 },
+          address: { host: '255.255.255.255', port: 255 },
           lastUpdated: expect.any(String),
         },
       },
@@ -491,7 +551,7 @@ describe('NodeGraph', () => {
           i,
         );
         const nodeAddress = {
-          ip: (i + '.' + i + '.' + i + '.' + i) as Host,
+          host: (i + '.' + i + '.' + i + '.' + i) as Host,
           port: i as Port,
         };
         await nodeGraph.setNode(newNodeId, nodeAddress);
@@ -544,7 +604,7 @@ describe('NodeGraph', () => {
   test('finds a single closest node', async () => {
     // New node added
     const newNode2Id = nodeId1;
-    const newNode2Address = { ip: '227.1.1.1', port: 4567 } as NodeAddress;
+    const newNode2Address = { host: '227.1.1.1', port: 4567 } as NodeAddress;
     await nodeGraph.setNode(newNode2Id, newNode2Address);
 
     // Find the closest nodes to some node, NODEID3
@@ -552,21 +612,21 @@ describe('NodeGraph', () => {
     expect(closest).toContainEqual({
       id: newNode2Id,
       distance: 121n,
-      address: { ip: '227.1.1.1', port: 4567 },
+      address: { host: '227.1.1.1', port: 4567 },
     });
   });
   test('finds 3 closest nodes', async () => {
     // Add 3 nodes
     await nodeGraph.setNode(nodeId1, {
-      ip: '2.2.2.2',
+      host: '2.2.2.2',
       port: 2222,
     } as NodeAddress);
     await nodeGraph.setNode(nodeId2, {
-      ip: '3.3.3.3',
+      host: '3.3.3.3',
       port: 3333,
     } as NodeAddress);
     await nodeGraph.setNode(nodeId3, {
-      ip: '4.4.4.4',
+      host: '4.4.4.4',
       port: 4444,
     } as NodeAddress);
 
@@ -576,17 +636,17 @@ describe('NodeGraph', () => {
     expect(closest).toContainEqual({
       id: nodeId3,
       distance: 0n,
-      address: { ip: '4.4.4.4', port: 4444 },
+      address: { host: '4.4.4.4', port: 4444 },
     });
     expect(closest).toContainEqual({
       id: nodeId2,
       distance: 116n,
-      address: { ip: '3.3.3.3', port: 3333 },
+      address: { host: '3.3.3.3', port: 3333 },
     });
     expect(closest).toContainEqual({
       id: nodeId1,
       distance: 121n,
-      address: { ip: '2.2.2.2', port: 2222 },
+      address: { host: '2.2.2.2', port: 2222 },
     });
   });
   test('finds the 20 closest nodes', async () => {
@@ -600,7 +660,7 @@ describe('NodeGraph', () => {
         i,
       );
       const nodeAddress = {
-        ip: (i + '.' + i + '.' + i + '.' + i) as Host,
+        host: (i + '.' + i + '.' + i + '.' + i) as Host,
         port: i as Port,
       };
       await nodeGraph.setNode(closeNodeId, nodeAddress);
@@ -614,7 +674,7 @@ describe('NodeGraph', () => {
     for (let i = 1; i <= 10; i++) {
       const farNodeId = nodeIdGenerator(i);
       const nodeAddress = {
-        ip: (i + '.' + i + '.' + i + '.' + i) as Host,
+        host: (i + '.' + i + '.' + i + '.' + i) as Host,
         port: i as Port,
       };
       await nodeGraph.setNode(farNodeId, nodeAddress);
@@ -630,7 +690,7 @@ describe('NodeGraph', () => {
   test('updates node', async () => {
     // New node added
     const node1Id = nodesTestUtils.generateNodeIdForBucket(nodeId, 2);
-    const node1Address = { ip: '1.1.1.1', port: 1 } as NodeAddress;
+    const node1Address = { host: '1.1.1.1', port: 1 } as NodeAddress;
     await nodeGraph.setNode(node1Id, node1Address);
 
     // Check new node is in retrieved bucket from database
@@ -638,7 +698,7 @@ describe('NodeGraph', () => {
     const time1 = bucket![node1Id].lastUpdated;
 
     // Update node and check that time is later
-    const newNode1Address = { ip: '2.2.2.2', port: 2 } as NodeAddress;
+    const newNode1Address = { host: '2.2.2.2', port: 2 } as NodeAddress;
     await nodeGraph.updateNode(node1Id, newNode1Address);
 
     const bucket2 = await nodeGraph.getBucket(2);

--- a/tests/nodes/NodeManager.test.ts
+++ b/tests/nodes/NodeManager.test.ts
@@ -158,7 +158,7 @@ describe('NodeManager', () => {
       await target.start({ password: 'password' });
       targetNodeId = target.keyManager.getNodeId();
       targetNodeAddress = {
-        ip: target.revProxy.ingressHost,
+        host: target.revProxy.ingressHost,
         port: target.revProxy.ingressPort,
       };
       await nodeManager.setNode(targetNodeId, targetNodeAddress);
@@ -224,7 +224,7 @@ describe('NodeManager', () => {
       async () => {
         // Add the dummy node
         await nodeManager.setNode(dummyNode, {
-          ip: '125.0.0.1' as Host,
+          host: '125.0.0.1' as Host,
           port: 55555 as Port,
         });
         // @ts-ignore accessing protected NodeConnectionMap
@@ -259,7 +259,7 @@ describe('NodeManager', () => {
       });
       const serverNodeId = server.nodeManager.getNodeId();
       let serverNodeAddress: NodeAddress = {
-        ip: server.revProxy.ingressHost,
+        host: server.revProxy.ingressHost,
         port: server.revProxy.ingressPort,
       };
       await nodeManager.setNode(serverNodeId, serverNodeAddress);
@@ -274,7 +274,7 @@ describe('NodeManager', () => {
       await server.start({ password: 'password' });
       // Update the node address (only changes because we start and stop)
       serverNodeAddress = {
-        ip: server.revProxy.ingressHost,
+        host: server.revProxy.ingressHost,
         port: server.revProxy.ingressPort,
       };
       await nodeManager.setNode(serverNodeId, serverNodeAddress);
@@ -301,7 +301,7 @@ describe('NodeManager', () => {
     // Case 1: node already exists in the local node graph (no contact required)
     const nodeId = nodeId1;
     const nodeAddress: NodeAddress = {
-      ip: '127.0.0.1' as Host,
+      host: '127.0.0.1' as Host,
       port: 11111 as Port,
     };
     await nodeManager.setNode(nodeId, nodeAddress);
@@ -316,12 +316,12 @@ describe('NodeManager', () => {
       // Case 2: node can be found on the remote node
       const nodeId = nodeId1;
       const nodeAddress: NodeAddress = {
-        ip: '127.0.0.1' as Host,
+        host: '127.0.0.1' as Host,
         port: 11111 as Port,
       };
       const server = await testUtils.setupRemoteKeynode({ logger: logger });
       await nodeManager.setNode(server.nodeManager.getNodeId(), {
-        ip: server.revProxy.ingressHost,
+        host: server.revProxy.ingressHost,
         port: server.revProxy.ingressPort,
       } as NodeAddress);
       await server.nodeManager.setNode(nodeId, nodeAddress);
@@ -339,14 +339,14 @@ describe('NodeManager', () => {
       const nodeId = nodeId1;
       const server = await testUtils.setupRemoteKeynode({ logger: logger });
       await nodeManager.setNode(server.nodeManager.getNodeId(), {
-        ip: server.revProxy.ingressHost,
+        host: server.revProxy.ingressHost,
         port: server.revProxy.ingressPort,
       } as NodeAddress);
       // Add a dummy node to the server node graph database
       // Server will not be able to connect to this node (the only node in its
       // database), and will therefore not be able to locate the node.
       await server.nodeManager.setNode(dummyNode, {
-        ip: '127.0.0.2' as Host,
+        host: '127.0.0.2' as Host,
         port: 22222 as Port,
       } as NodeAddress);
       // So unfindableNode cannot be found
@@ -361,7 +361,7 @@ describe('NodeManager', () => {
   test('knows node (true and false case)', async () => {
     // Known node
     const nodeAddress1: NodeAddress = {
-      ip: '127.0.0.1' as Host,
+      host: '127.0.0.1' as Host,
       port: 11111 as Port,
     };
     await nodeManager.setNode(nodeId1, nodeAddress1);
@@ -396,7 +396,7 @@ describe('NodeManager', () => {
       });
       xNodeId = x.nodeManager.getNodeId();
       xNodeAddress = {
-        ip: x.revProxy.ingressHost,
+        host: x.revProxy.ingressHost,
         port: x.revProxy.ingressPort,
       };
       xPublicKey = x.keyManager.getRootKeyPairPem().publicKey;
@@ -406,7 +406,7 @@ describe('NodeManager', () => {
       });
       yNodeId = y.nodeManager.getNodeId();
       yNodeAddress = {
-        ip: y.revProxy.ingressHost,
+        host: y.revProxy.ingressHost,
         port: y.revProxy.ingressPort,
       };
       yPublicKey = y.keyManager.getRootKeyPairPem().publicKey;

--- a/tests/notifications/NotificationsManager.test.ts
+++ b/tests/notifications/NotificationsManager.test.ts
@@ -249,7 +249,7 @@ describe('NotificationsManager', () => {
     });
     await senderNodeManager.start();
     await senderNodeManager.setNode(receiverNodeId, {
-      ip: receiverHost,
+      host: receiverHost,
       port: receiverIngressPort,
     } as NodeAddress);
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -67,7 +67,7 @@ async function addRemoteDetails(
 ) {
   // Add remote node's details to local node
   await localNode.nodeManager.setNode(remoteNode.nodeManager.getNodeId(), {
-    ip: remoteNode.revProxy.ingressHost,
+    host: remoteNode.revProxy.ingressHost,
     port: remoteNode.revProxy.ingressPort,
   } as NodeAddress);
 }

--- a/tests/vaults/VaultManager.test.ts
+++ b/tests/vaults/VaultManager.test.ts
@@ -818,7 +818,7 @@ describe('VaultManager', () => {
           await vaultOps.addSecret(vault, name, content);
         }
         await nodeManager.setNode(targetNodeId, {
-          ip: targetHost,
+          host: targetHost,
           port: targetPort,
         } as NodeAddress);
         await nodeManager.getConnectionToNode(targetNodeId);


### PR DESCRIPTION
### Description

Supporting trusted seed nodes configuration.

### Issues Fixed
* Fixes #269 
* Does not address #224 

### Tasks

1. Refactor `nodes` domain:
   - [x] - Refactor all notions of `broker` into `seed` nodes
   - [x] - Remove separation of `brokerNodeConnections` - the seed nodes should be treated as regular nodes, that get added to the `NodeGraph` (Kademlia system)
   - [x] - Change `NodeAddress.ip` to `NodeAddress.host`
2. DNS resolution
   - [x] - `resolveHost` function to resolve a hostname into an IP address (`Host` type)
   - [x] - figure out where `resolveHost` calls are required, and add them in
3. Support various seed node sources:
   - [x] - Resolve all 3 sources to a common object type (`NodeMapping`: `NodeId -> NodeAddress` - i.e. `NodeBucket` without the `lastUpdated` field)
   -  CLI arguments
      * [x] - Parser for `nodeId@host:port` structure
      * ~~resolve issue with variadic options and `argParser` https://github.com/tj/commander.js/issues/1641~~ no longer a problem - see https://github.com/MatrixAI/js-polykey/issues/269#issuecomment-972432918
   -  Environment variable `PK_SEED_NODES`
      * [x] - Parser for semicolon separated structure
      * [x] - Figure out if possible to use commander's `.env` with this parsing logic (instead of just a straight read from environment)
   - `src/config.ts`
      * [x] - Parser for `config.ts` POJO structure
   - verification:
      * [x] - single CLI argument
      * [x] - multiple CLI arguments
      * [x] - single in `PK_SEED_NODES` environment variable (and takes precedence over `src/config.ts`)
      * [x] - multiple in `PK_SEED_NODES` environment variable (and takes precedence over `src/config.ts`)
      * [x] - single in `src/config.ts`
      * [x] - multiple in `src/config.ts`
      * [x] - combination of CLI, environment, `src/config.ts` - should only take CLI arguments
      * [x] - combination of CLI, environment, `src/config.ts` with `<seed-nodes>` flag - should take CLI arguments as well as `src/config.ts`
   - tests:
      * [x] - combination of CLI, environment, `src/config.ts` - should only take CLI arguments
      * [x] - combination of environment, `src/config.ts` and `<seed-nodes>` flag - should take all

~~4. Resolve propagation of `NodeConnection` errors (from networking domain) - see #224~~ - will now be handled in #225

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [ ] Sanity check the final build
