### PR TITLE
Change `NodeId` from encoded string to an opaque alias of `Id` which is a typed array from js-id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1620,9 +1620,9 @@
       }
     },
     "@matrixai/id": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@matrixai/id/-/id-2.1.0.tgz",
-      "integrity": "sha512-yB8ew2Aj5THx/p+8MyNNxtbaqEhsT0nySV2HZ3vAS79NSHtwa89AWStdXjBg+EtzUiWP1cWrJnU2ScXPNLP3wA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/id/-/id-3.3.0.tgz",
+      "integrity": "sha512-o3iagu6hW6ya5p87Ptn74pXY9zxbIEH5f91YeaBwo7K/g0e3/OzgBbwHiwTbc9xpxqxBn/mNyZp0ovAWexA4Vw==",
       "requires": {
         "multiformats": "^9.4.8",
         "uuid": "^8.3.2"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@grpc/grpc-js": "1.3.7",
     "@matrixai/async-init": "^1.6.0",
     "@matrixai/db": "^1.1.2",
-    "@matrixai/id": "^2.1.0",
+    "@matrixai/id": "^3.3.0",
     "@matrixai/logger": "^2.1.0",
     "@matrixai/workers": "^1.2.5",
     "ajv": "^7.0.4",

--- a/src/agent/GRPCClientAgent.ts
+++ b/src/agent/GRPCClientAgent.ts
@@ -13,7 +13,8 @@ import type * as notificationsPB from '../proto/js/polykey/v1/notifications/noti
 import Logger from '@matrixai/logger';
 import { CreateDestroy, ready } from '@matrixai/async-init/dist/CreateDestroy';
 import * as agentErrors from './errors';
-import { GRPCClient, utils as grpcUtils } from '../grpc';
+import * as grpcUtils from '../grpc/utils';
+import GRPCClient from '../grpc/GRPCClient';
 import { AgentServiceClient } from '../proto/js/polykey/v1/agent_service_grpc_pb';
 
 interface GRPCClientAgent extends CreateDestroy {}

--- a/src/agent/service/nodesClosestLocalNodesGet.ts
+++ b/src/agent/service/nodesClosestLocalNodesGet.ts
@@ -19,7 +19,7 @@ function nodesClosestLocalNodesGet({
   ): Promise<void> => {
     const response = new nodesPB.NodeTable();
     try {
-      const targetNodeId = nodesUtils.makeNodeId(call.request.getNodeId());
+      const targetNodeId = nodesUtils.decodeNodeId(call.request.getNodeId());
       // Get all local nodes that are closest to the target node from the request
       const closestNodes = await nodeManager.getClosestLocalNodes(targetNodeId);
       for (const node of closestNodes) {
@@ -27,7 +27,9 @@ function nodesClosestLocalNodesGet({
         addressMessage.setHost(node.address.host);
         addressMessage.setPort(node.address.port);
         // Add the node to the response's map (mapping of node ID -> node address)
-        response.getNodeTableMap().set(node.id, addressMessage);
+        response
+          .getNodeTableMap()
+          .set(nodesUtils.encodeNodeId(node.id), addressMessage);
       }
     } catch (err) {
       callback(grpcUtils.fromError(err), response);

--- a/src/agent/service/nodesCrossSignClaim.ts
+++ b/src/agent/service/nodesCrossSignClaim.ts
@@ -6,6 +6,7 @@ import type { KeyManager } from '../../keys';
 import type * as nodesPB from '../../proto/js/polykey/v1/nodes/nodes_pb';
 import { utils as grpcUtils } from '../../grpc';
 import { utils as claimsUtils, errors as claimsErrors } from '../../claims';
+import { utils as nodesUtils } from '../../nodes';
 
 function nodesCrossSignClaim({
   keyManager,
@@ -66,7 +67,7 @@ function nodesCrossSignClaim({
         }
         // Verify the claim
         const senderPublicKey = await nodeManager.getPublicKey(
-          payloadData.node1,
+          nodesUtils.decodeNodeId(payloadData.node1),
         );
         const verified = await claimsUtils.verifyClaimSignature(
           constructedEncodedClaim,
@@ -79,12 +80,12 @@ function nodesCrossSignClaim({
         const doublySignedClaim = await claimsUtils.signIntermediaryClaim({
           claim: constructedIntermediaryClaim,
           privateKey: keyManager.getRootKeyPairPem().privateKey,
-          signeeNodeId: nodeManager.getNodeId(),
+          signeeNodeId: nodesUtils.encodeNodeId(nodeManager.getNodeId()),
         });
         // Then create your own intermediary node claim (from X -> Y)
         const singlySignedClaim = await sigchain.createIntermediaryClaim({
           type: 'node',
-          node1: nodeManager.getNodeId(),
+          node1: nodesUtils.encodeNodeId(nodeManager.getNodeId()),
           node2: payloadData.node1,
         });
         // Should never be reached, but just for type safety

--- a/src/agent/service/nodesHolePunchMessageSend.ts
+++ b/src/agent/service/nodesHolePunchMessageSend.ts
@@ -22,7 +22,7 @@ function nodesHolePunchMessageSend({
       // back to the source node.
       if (
         nodeManager.getNodeId() ===
-        nodesUtils.makeNodeId(call.request.getTargetId())
+        nodesUtils.decodeNodeId(call.request.getTargetId())
       ) {
         const [host, port] = networkUtils.parseAddress(
           call.request.getEgressAddress(),
@@ -32,7 +32,7 @@ function nodesHolePunchMessageSend({
         // If so, ask the nodeManager to relay to the node
       } else if (
         await nodeManager.knowsNode(
-          nodesUtils.makeNodeId(call.request.getSrcId()),
+          nodesUtils.decodeNodeId(call.request.getSrcId()),
         )
       ) {
         await nodeManager.relayHolePunchMessage(call.request);

--- a/src/bin/identities/CommandDiscover.ts
+++ b/src/bin/identities/CommandDiscover.ts
@@ -50,7 +50,7 @@ class CommandDiscover extends CommandPolykey {
           port: clientOptions.clientPort,
           logger: this.logger.getChild(PolykeyClient.name),
         });
-        if (gestaltId.nodeId) {
+        if (gestaltId.nodeId != null) {
           // Discovery by Node.
           const nodeMessage = new nodesPB.Node();
           nodeMessage.setNodeId(gestaltId.nodeId);

--- a/src/claims/types.ts
+++ b/src/claims/types.ts
@@ -1,5 +1,5 @@
 import type { Opaque } from '../types';
-import type { NodeId } from '../nodes/types';
+import type { NodeIdEncoded } from '../nodes/types';
 import type { ProviderId, IdentityId } from '../identities/types';
 import type { GeneralJWS, FlattenedJWSInput } from 'jose';
 import type { Id, IdString } from '../GenericIdTypes';
@@ -19,7 +19,7 @@ type Claim = {
     data: ClaimData; // Our custom payload data
     iat: number; // Timestamp (initialised at JWS field)
   };
-  signatures: Record<NodeId | string, SignatureData>; // Signee node ID -> claim signature // FIXME: the string union on VaultId is to prevent some false errors.
+  signatures: Record<NodeIdEncoded, SignatureData>; // Signee node ID -> claim signature
 };
 
 /**
@@ -38,7 +38,7 @@ type SignatureData = {
   signature: string;
   header: {
     alg: string; // Signing algorithm (e.g. RS256 for RSA keys)
-    kid: NodeId; // Node ID of the signing keynode
+    kid: NodeIdEncoded; // Node ID of the signing keynode
   };
 };
 
@@ -84,12 +84,12 @@ type ClaimData = ClaimLinkNode | ClaimLinkIdentity;
 // Cryptolink (to either a node or an identity)
 type ClaimLinkNode = {
   type: 'node';
-  node1: NodeId;
-  node2: NodeId;
+  node1: NodeIdEncoded;
+  node2: NodeIdEncoded;
 };
 type ClaimLinkIdentity = {
   type: 'identity';
-  node: NodeId;
+  node: NodeIdEncoded;
   provider: ProviderId;
   identity: IdentityId;
 };

--- a/src/client/service/agentStatus.ts
+++ b/src/client/service/agentStatus.ts
@@ -7,6 +7,7 @@ import type * as utilsPB from '../../proto/js/polykey/v1/utils/utils_pb';
 import process from 'process';
 import * as grpcUtils from '../../grpc/utils';
 import * as agentPB from '../../proto/js/polykey/v1/agent/agent_pb';
+import { utils as nodeUtils } from '../../nodes';
 
 function agentStatus({
   authenticate,
@@ -32,7 +33,7 @@ function agentStatus({
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
       response.setPid(process.pid);
-      response.setNodeId(keyManager.getNodeId());
+      response.setNodeId(nodeUtils.encodeNodeId(keyManager.getNodeId()));
       response.setClientHost(grpcServerClient.host);
       response.setClientPort(grpcServerClient.port);
       response.setIngressHost(revProxy.getIngressHost());

--- a/src/client/service/gestaltsActionsGetByNode.ts
+++ b/src/client/service/gestaltsActionsGetByNode.ts
@@ -22,9 +22,8 @@ function gestaltsActionsGetByNode({
     try {
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
-      const result = await gestaltGraph.getGestaltActionsByNode(
-        nodesUtils.makeNodeId(info.getNodeId()),
-      );
+      const nodeId = nodesUtils.decodeNodeId(info.getNodeId());
+      const result = await gestaltGraph.getGestaltActionsByNode(nodeId);
       if (result == null) {
         // Node doesn't exist, so no permissions. might throw error instead TBD.
         response.setActionList([]);

--- a/src/client/service/gestaltsActionsSetByNode.ts
+++ b/src/client/service/gestaltsActionsSetByNode.ts
@@ -25,7 +25,7 @@ function gestaltsActionsSetByNode({
       call.sendMetadata(metadata);
       // Setting the action.
       const action = gestaltsUtils.makeGestaltAction(info.getAction());
-      const nodeId = nodesUtils.makeNodeId(info.getNode()?.getNodeId());
+      const nodeId = nodesUtils.decodeNodeId(info.getNode()!.getNodeId());
       await gestaltGraph.setGestaltActionByNode(nodeId, action);
       callback(null, response);
       return;

--- a/src/client/service/gestaltsActionsUnsetByNode.ts
+++ b/src/client/service/gestaltsActionsUnsetByNode.ts
@@ -25,7 +25,7 @@ function gestaltsActionsUnsetByNode({
       call.sendMetadata(metadata);
       // Setting the action.
       const action = gestaltsUtils.makeGestaltAction(info.getAction());
-      const nodeId = nodesUtils.makeNodeId(info.getNode()?.getNodeId());
+      const nodeId = nodesUtils.decodeNodeId(info.getNode()!.getNodeId());
       await gestaltGraph.unsetGestaltActionByNode(nodeId, action);
       callback(null, response);
       return;

--- a/src/client/service/gestaltsDiscoveryByNode.ts
+++ b/src/client/service/gestaltsDiscoveryByNode.ts
@@ -23,9 +23,8 @@ function gestaltsDiscoveryByNode({
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
       // Constructing identity info.
-      const gen = discovery.discoverGestaltByNode(
-        nodesUtils.makeNodeId(info.getNodeId()),
-      );
+      const nodeId = nodesUtils.decodeNodeId(info.getNodeId()!);
+      const gen = discovery.discoverGestaltByNode(nodeId);
       for await (const _ of gen) {
         // Empty
       }

--- a/src/client/service/gestaltsGestaltGetByNode.ts
+++ b/src/client/service/gestaltsGestaltGetByNode.ts
@@ -21,9 +21,8 @@ function gestaltsGestaltGetByNode({
     try {
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
-      const gestalt = await gestaltGraph.getGestaltByNode(
-        nodesUtils.makeNodeId(call.request.getNodeId()),
-      );
+      const nodeId = nodesUtils.decodeNodeId(call.request.getNodeId()!);
+      const gestalt = await gestaltGraph.getGestaltByNode(nodeId);
       if (gestalt != null) {
         response.setGestaltGraph(JSON.stringify(gestalt));
       }

--- a/src/client/service/identitiesClaim.ts
+++ b/src/client/service/identitiesClaim.ts
@@ -9,6 +9,7 @@ import { utils as grpcUtils } from '../../grpc';
 import { utils as claimsUtils } from '../../claims';
 import { errors as identitiesErrors } from '../../identities';
 import * as identitiesPB from '../../proto/js/polykey/v1/identities/identities_pb';
+import { utils as nodeUtils } from '../../nodes';
 
 /**
  * Augments the keynode with a new identity.
@@ -44,7 +45,7 @@ function identitiesClaim({
       // Create identity claim on our node
       const [, claim] = await sigchain.addClaim({
         type: 'identity',
-        node: nodeManager.getNodeId(),
+        node: nodeUtils.encodeNodeId(nodeManager.getNodeId()),
         provider: providerId,
         identity: identityId,
       });

--- a/src/client/service/nodesAdd.ts
+++ b/src/client/service/nodesAdd.ts
@@ -29,23 +29,17 @@ function nodesAdd({
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
       // Validate the passed node ID and host
-      const validNodeId = nodesUtils.isNodeId(call.request.getNodeId());
-      if (!validNodeId) {
-        throw new nodesErrors.ErrorInvalidNodeId();
-      }
+      const nodeId = nodesUtils.decodeNodeId(call.request.getNodeId());
       const validHost = networkUtils.isValidHost(
         call.request.getAddress()!.getHost(),
       );
       if (!validHost) {
         throw new nodesErrors.ErrorInvalidHost();
       }
-      await nodeManager.setNode(
-        nodesUtils.makeNodeId(call.request.getNodeId()),
-        {
-          host: call.request.getAddress()!.getHost(),
-          port: call.request.getAddress()!.getPort(),
-        } as NodeAddress,
-      );
+      await nodeManager.setNode(nodeId, {
+        host: call.request.getAddress()!.getHost(),
+        port: call.request.getAddress()!.getPort(),
+      } as NodeAddress);
       callback(null, response);
       return;
     } catch (err) {

--- a/src/client/service/nodesClaim.ts
+++ b/src/client/service/nodesClaim.ts
@@ -30,7 +30,7 @@ function nodesClaim({
     try {
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
-      const remoteNodeId = nodesUtils.makeNodeId(call.request.getNodeId());
+      const remoteNodeId = nodesUtils.decodeNodeId(call.request.getNodeId());
       const gestaltInvite = await notificationsManager.findGestaltInvite(
         remoteNodeId,
       );

--- a/src/client/service/nodesFind.ts
+++ b/src/client/service/nodesFind.ts
@@ -25,10 +25,11 @@ function nodesFind({
     try {
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
-      const nodeId = nodesUtils.makeNodeId(call.request.getNodeId());
+      const nodeIdEncoded = call.request.getNodeId();
+      const nodeId = nodesUtils.decodeNodeId(nodeIdEncoded);
       const address = await nodeManager.findNode(nodeId);
       response
-        .setNodeId(nodeId)
+        .setNodeId(nodeIdEncoded)
         .setAddress(
           new nodesPB.Address().setHost(address.host).setPort(address.port),
         );

--- a/src/client/service/nodesPing.ts
+++ b/src/client/service/nodesPing.ts
@@ -24,9 +24,8 @@ function nodesPing({
     try {
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
-      const status = await nodeManager.pingNode(
-        nodesUtils.makeNodeId(call.request.getNodeId()),
-      );
+      const nodeId = nodesUtils.decodeNodeId(call.request.getNodeId());
+      const status = await nodeManager.pingNode(nodeId);
       response.setSuccess(status);
       callback(null, response);
       return;

--- a/src/client/service/notificationsSend.ts
+++ b/src/client/service/notificationsSend.ts
@@ -22,7 +22,7 @@ function notificationsSend({
     try {
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
-      const receivingId = nodesUtils.makeNodeId(call.request.getReceiverId());
+      const receivingId = nodesUtils.decodeNodeId(call.request.getReceiverId());
       const data = {
         type: 'General',
         message: call.request.getData()?.getMessage(),

--- a/src/client/service/vaultsScan.ts
+++ b/src/client/service/vaultsScan.ts
@@ -17,8 +17,8 @@ function vaultsScan({
     call: grpc.ServerWritableStream<nodesPB.Node, vaultsPB.List>,
   ): Promise<void> => {
     const genWritable = grpcUtils.generatorWritable(call);
-    // Const nodeId = makeNodeId(call.request.getNodeId());
-
+    // Const possibleNodeId = nodesUtils.decodeNodeId(call.request.getNodeId());
+    // const nodeId = nodesUtils.validateNodeId(possibleNodeId);
     try {
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);

--- a/src/gestalts/types.ts
+++ b/src/gestalts/types.ts
@@ -1,5 +1,5 @@
 import type { Opaque } from '../types';
-import type { NodeId, NodeInfo } from '../nodes/types';
+import type { NodeIdEncoded, NodeInfo } from '../nodes/types';
 import type { IdentityId, ProviderId, IdentityInfo } from '../identities/types';
 
 type GestaltAction = 'notify' | 'scan';
@@ -8,7 +8,7 @@ type GestaltActions = Partial<Record<GestaltAction, null>>;
 type GestaltId = GestaltNodeId | GestaltIdentityId;
 type GestaltNodeId = {
   type: 'node';
-  nodeId: NodeId;
+  nodeId: NodeIdEncoded;
 };
 type GestaltIdentityId = {
   type: 'identity';

--- a/src/gestalts/utils.ts
+++ b/src/gestalts/utils.ts
@@ -12,6 +12,7 @@ import type { IdentityId, ProviderId } from '../identities/types';
 
 import canonicalize from 'canonicalize';
 import { ErrorGestaltsInvalidAction } from './errors';
+import { utils as nodesUtils } from '../nodes';
 
 /**
  * Construct GestaltKey from GestaltId
@@ -37,7 +38,10 @@ function ungestaltKey(gestaltKey: GestaltKey): GestaltId {
  * Construct GestaltKey from NodeId
  */
 function keyFromNode(nodeId: NodeId): GestaltNodeKey {
-  return gestaltKey({ type: 'node', nodeId }) as GestaltNodeKey;
+  return gestaltKey({
+    type: 'node',
+    nodeId: nodesUtils.encodeNodeId(nodeId),
+  }) as GestaltNodeKey;
 }
 
 /**
@@ -60,7 +64,7 @@ function keyFromIdentity(
  */
 function nodeFromKey(nodeKey: GestaltNodeKey): NodeId {
   const node = ungestaltKey(nodeKey) as GestaltNodeId;
-  return node.nodeId;
+  return nodesUtils.decodeNodeId(node.nodeId);
 }
 
 /**

--- a/src/keys/KeyManager.ts
+++ b/src/keys/KeyManager.ts
@@ -23,7 +23,6 @@ import {
 import * as keysUtils from './utils';
 import * as keysErrors from './errors';
 import * as utils from '../utils';
-import * as networkUtils from '../network/utils';
 
 /**
  * Manage Root Keys and Root Certificates
@@ -277,7 +276,7 @@ class KeyManager {
    */
   @ready(new keysErrors.ErrorKeyManagerNotRunning())
   public getNodeId(): NodeId {
-    return networkUtils.certNodeId(this.getRootCert());
+    return keysUtils.publicKeyToNodeId(this.rootKeyPair.publicKey);
   }
 
   @ready(new keysErrors.ErrorKeyManagerNotRunning())

--- a/src/network/ForwardProxy.ts
+++ b/src/network/ForwardProxy.ts
@@ -13,6 +13,7 @@ import ConnectionForward from './ConnectionForward';
 import * as networkUtils from './utils';
 import * as networkErrors from './errors';
 import { promisify, timerStart, timerStop } from '../utils';
+import { utils as nodesUtils } from '../nodes';
 
 interface ForwardProxy extends StartStop {}
 @StartStop()
@@ -299,7 +300,11 @@ class ForwardProxy {
       return;
     }
     const url = new URL(`pk://${request.url}`);
-    const nodeId = url.searchParams.get('nodeId') as NodeId | null;
+    const nodeIdEncodedForURL = url.searchParams.get('nodeId');
+    const nodeId =
+      nodeIdEncodedForURL != null
+        ? nodesUtils.decodeNodeId(nodeIdEncodedForURL)
+        : undefined;
     if (nodeId == null) {
       await clientSocketEnd('HTTP/1.1 400 Bad Request\r\n' + '\r\n');
       clientSocket.destroy(new networkErrors.ErrorForwardProxyMissingNodeId());

--- a/src/nodes/NodeGraph.ts
+++ b/src/nodes/NodeGraph.ts
@@ -11,6 +11,7 @@ import {
   CreateDestroyStartStop,
   ready,
 } from '@matrixai/async-init/dist/CreateDestroyStartStop';
+import { IdInternal } from '@matrixai/id';
 import * as nodesUtils from './utils';
 import * as nodesErrors from './errors';
 
@@ -410,7 +411,7 @@ class NodeGraph {
       // 2. Re-add all the nodes from all buckets
       for (const b of buckets) {
         for (const n of Object.keys(b)) {
-          const nodeId = n as NodeId;
+          const nodeId: NodeId = IdInternal.fromString(n);
           const newIndex = this.getBucketIndex(nodeId);
           let expectedBucket = tempBuckets[newIndex];
           // The following is more or less copied from setNodeOps
@@ -472,7 +473,8 @@ class NodeGraph {
     // Iterate over all of the nodes in each bucket
     const distanceToNodes: Array<NodeData> = [];
     buckets.forEach(function (bucket) {
-      for (const nodeId of Object.keys(bucket) as Array<NodeId>) {
+      for (const nodeIdString of Object.keys(bucket)) {
+        const nodeId: NodeId = IdInternal.fromString(nodeIdString);
         // Compute the distance from the node, and add it to the array.
         distanceToNodes.push({
           id: nodeId,
@@ -559,7 +561,7 @@ class NodeGraph {
         if (contacted[nodeData.id]) {
           continue;
         }
-        if (nodeData.id === targetNodeId) {
+        if (nodeData.id.equals(targetNodeId)) {
           // FoundTarget = true;
           // Attempt to create a connection to the node. Will throw an error
           // (ErrorConnectionStart, from ConnectionForward) if the connection

--- a/src/nodes/types.ts
+++ b/src/nodes/types.ts
@@ -1,12 +1,11 @@
-import type NodeConnection from './NodeConnection';
-import type { MutexInterface } from 'async-mutex';
 import type { Opaque } from '../types';
 import type { Host, Hostname, Port } from '../network/types';
 import type { Claim, ClaimId } from '../claims/types';
 import type { ChainData } from '../sigchain/types';
-import type { IdString } from '../GenericIdTypes';
+import type { Id } from '@matrixai/id';
 
-type NodeId = Opaque<'NodeId', IdString>;
+type NodeId = Opaque<'NodeId', Id>;
+type NodeIdEncoded = Opaque<'NodeIdEncoded', string>;
 
 type NodeAddress = {
   host: Host | Hostname;
@@ -39,7 +38,7 @@ type NodeClaim = Claim & {
  * chain: maps ClaimId (lexicographic integer of sequence number) -> Claim
  */
 type NodeInfo = {
-  id: NodeId;
+  id: NodeIdEncoded;
   chain: ChainData;
 };
 
@@ -52,22 +51,6 @@ type NodeBucket = {
     lastUpdated: Date;
   };
 };
-
-/**
- * Data structure to store all NodeConnections. If a connection to a node n does
- * not exist, no entry for n will exist in the map. Alternatively, if a
- * connection is currently being instantiated by some thread, an entry will
- * exist in the map, but only with the lock (no connection object). Once a
- * connection is instantiated, the entry in the map is updated to include the
- * connection object.
- */
-type NodeConnectionMap = Map<
-  NodeId,
-  {
-    connection?: NodeConnection;
-    lock: MutexInterface;
-  }
->;
 
 // Only 1 domain, so don't need a 'domain' value (like /gestalts/types.ts)
 type NodeGraphOp_ = {
@@ -86,6 +69,7 @@ type NodeGraphOp =
 
 export type {
   NodeId,
+  NodeIdEncoded,
   NodeAddress,
   NodeMapping,
   NodeData,
@@ -93,6 +77,5 @@ export type {
   NodeInfo,
   NodeBucketIndex,
   NodeBucket,
-  NodeConnectionMap,
   NodeGraphOp,
 };

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -1,5 +1,5 @@
 import type { Opaque } from '../types';
-import type { NodeId } from '../nodes/types';
+import type { NodeIdEncoded } from '../nodes/types';
 import type { VaultName, VaultActions } from '../vaults/types';
 import type { Id, IdString } from '../GenericIdTypes';
 
@@ -25,7 +25,7 @@ type NotificationData = GestaltInvite | VaultShare | General;
 
 type Notification = {
   data: NotificationData;
-  senderId: NodeId;
+  senderId: NodeIdEncoded;
   isRead: boolean;
 };
 

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -11,6 +11,7 @@ import { Mutex } from 'async-mutex';
 import * as sessionsUtils from './utils';
 import * as sessionsErrors from './errors';
 import * as keysUtils from '../keys/utils';
+import { utils as nodesUtils } from '../nodes';
 
 interface SessionManager extends CreateDestroyStartStop {}
 @CreateDestroyStartStop(
@@ -154,8 +155,8 @@ class SessionManager {
     expiry: number | undefined = this.expiry,
   ): Promise<SessionToken> {
     const payload = {
-      iss: this.keyManager.getNodeId(),
-      sub: this.keyManager.getNodeId(),
+      iss: nodesUtils.encodeNodeId(this.keyManager.getNodeId()),
+      sub: nodesUtils.encodeNodeId(this.keyManager.getNodeId()),
     };
     const token = await sessionsUtils.createSessionToken(
       payload,

--- a/src/sigchain/Sigchain.ts
+++ b/src/sigchain/Sigchain.ts
@@ -7,9 +7,9 @@ import type {
   ClaimIntermediary,
   ClaimType,
 } from '../claims/types';
-import type { NodeId } from '../nodes/types';
 import type { KeyManager } from '../keys';
 import type { DB, DBLevel, DBOp } from '@matrixai/db';
+import type { NodeIdEncoded } from '../nodes/types';
 
 import Logger from '@matrixai/logger';
 import { Mutex } from 'async-mutex';
@@ -21,6 +21,7 @@ import { utils as idUtils } from '@matrixai/id';
 import * as sigchainErrors from './errors';
 import * as claimsUtils from '../claims/utils';
 import { createClaimIdGenerator, makeClaimIdString } from '../sigchain/utils';
+import { utils as nodesUtils } from '../nodes';
 
 interface Sigchain extends CreateDestroyStartStop {}
 @CreateDestroyStartStop(
@@ -139,7 +140,7 @@ class Sigchain {
     // Creating the ID generator
     const latestId = await this.getLatestClaimId();
     this.generateClaimId = createClaimIdGenerator(
-      this.keyManager.getNodeId(),
+      nodesUtils.encodeNodeId(this.keyManager.getNodeId()),
       latestId,
     );
     this.logger.info(`Started ${this.constructor.name}`);
@@ -200,7 +201,7 @@ class Sigchain {
     alg?: string;
   }): Promise<ClaimEncoded> {
     // Get kid from the claim data
-    let kid: NodeId;
+    let kid: NodeIdEncoded;
     if (data.type === 'node') {
       kid = data.node1;
     } else {

--- a/src/sigchain/utils.ts
+++ b/src/sigchain/utils.ts
@@ -1,9 +1,9 @@
 import type { PublicKeyPem } from '../keys/types';
 import type { ChainData, ChainDataEncoded } from './types';
 import type { ClaimId, ClaimIdString } from '../claims/types';
+import type { NodeIdEncoded } from '../nodes/types';
 
-import type { NodeId } from '../nodes/types';
-import { IdSortable } from '@matrixai/id';
+import { IdInternal, IdSortable } from '@matrixai/id';
 import * as claimsUtils from '../claims/utils';
 import { isIdString, isId, makeIdString, makeId } from '../GenericIdTypes';
 
@@ -45,10 +45,10 @@ function makeClaimIdString(arg) {
   return makeIdString<ClaimIdString>(arg);
 }
 
-function createClaimIdGenerator(nodeId: NodeId, lastClaimId?: ClaimId) {
+function createClaimIdGenerator(nodeId: NodeIdEncoded, lastClaimId?: ClaimId) {
   const generator = new IdSortable({
     lastId: lastClaimId,
-    nodeId: Buffer.from(nodeId),
+    nodeId: IdInternal.fromString(nodeId).toBuffer(),
   });
   return () => makeClaimId(Buffer.from(generator.get()));
 }

--- a/src/status/StatusSchema.json
+++ b/src/status/StatusSchema.json
@@ -28,7 +28,7 @@
           "type": "object",
           "properties": {
             "pid": { "type": "number" },
-            "nodeId": { "type": "string" },
+            "nodeId": { "type": "object" },
             "clientHost": { "type": "string" },
             "clientPort": { "type": "number" },
             "ingressHost": { "type": "string" },

--- a/src/vaults/VaultInternal.ts
+++ b/src/vaults/VaultInternal.ts
@@ -16,6 +16,7 @@ import { CreateDestroy, ready } from '@matrixai/async-init/dist/CreateDestroy';
 import * as vaultsUtils from './utils';
 import * as vaultsErrors from './errors';
 import { makeVaultIdPretty } from './utils';
+import { utils as nodesUtils } from '../nodes';
 
 const lastTag = 'last';
 
@@ -237,7 +238,7 @@ class VaultInternal {
           dir: this.baseDir,
           gitdir: this.gitDir,
           author: {
-            name: this.keyManager.getNodeId(),
+            name: nodesUtils.encodeNodeId(this.keyManager.getNodeId()),
           },
           message: message.toString(),
         });

--- a/src/vaults/VaultManager.ts
+++ b/src/vaults/VaultManager.ts
@@ -39,6 +39,7 @@ import * as utils from '../utils';
 import * as gitUtils from '../git/utils';
 import * as gitErrors from '../git/errors';
 import * as gestaltErrors from '../gestalts/errors';
+import { utils as nodesUtils } from '../nodes';
 
 interface VaultManager extends CreateDestroyStartStop {}
 @CreateDestroyStartStop(
@@ -354,8 +355,16 @@ class VaultManager {
         const nodes = gestalt.nodes;
         for (const node in nodes) {
           await this.acl.setNodeAction(nodeId, 'scan');
-          await this.acl.setVaultAction(vaultId, nodes[node].id, 'pull');
-          await this.acl.setVaultAction(vaultId, nodes[node].id, 'clone');
+          await this.acl.setVaultAction(
+            vaultId,
+            nodesUtils.decodeNodeId(nodes[node].id),
+            'pull',
+          );
+          await this.acl.setVaultAction(
+            vaultId,
+            nodesUtils.decodeNodeId(nodes[node].id),
+            'clone',
+          );
         }
         await this.notificationsManager.sendNotification(nodeId, {
           type: 'VaultShare',
@@ -642,7 +651,7 @@ class VaultManager {
           ref: 'HEAD',
           singleBranch: true,
           author: {
-            name: pullNodeId,
+            name: nodesUtils.encodeNodeId(pullNodeId!),
           },
         });
       } catch (err) {

--- a/src/vaults/utils.ts
+++ b/src/vaults/utils.ts
@@ -21,6 +21,7 @@ import * as vaultsPB from '../proto/js/polykey/v1/vaults/vaults_pb';
 import * as nodesPB from '../proto/js/polykey/v1/nodes/nodes_pb';
 import * as keysUtils from '../keys/utils';
 import { isIdString, isId, makeIdString, makeId } from '../GenericIdTypes';
+import { utils as nodesUtils } from '../nodes';
 
 async function generateVaultKey(bits: number = 256): Promise<VaultKey> {
   return (await keysUtils.generateKey(bits)) as VaultKey;
@@ -232,7 +233,7 @@ async function requestVaultNames(
   nodeId: NodeId,
 ): Promise<string[]> {
   const request = new nodesPB.Node();
-  request.setNodeId(nodeId);
+  request.setNodeId(nodesUtils.encodeNodeId(nodeId));
   const vaultList = client.vaultsScan(request);
   const data: string[] = [];
   for await (const vault of vaultList) {

--- a/tests/PolykeyClient.test.ts
+++ b/tests/PolykeyClient.test.ts
@@ -55,7 +55,9 @@ describe('PolykeyClient', () => {
       fs,
       logger,
     });
-    expect(pkClient.grpcClient.nodeId).toBe(pkAgent.keyManager.getNodeId());
+    expect(pkClient.grpcClient.nodeId).toStrictEqual(
+      pkAgent.keyManager.getNodeId(),
+    );
     expect(pkClient.grpcClient.host).toBe(pkAgent.grpcServerClient.host);
     expect(pkClient.grpcClient.port).toBe(pkAgent.grpcServerClient.port);
     expect(pkClient.grpcClient.secured).toBe(true);

--- a/tests/acl/ACL.test.ts
+++ b/tests/acl/ACL.test.ts
@@ -11,11 +11,23 @@ import { utils as idUtils } from '@matrixai/id';
 import { ACL, errors as aclErrors } from '@/acl';
 import { utils as keysUtils } from '@/keys';
 import { utils as vaultsUtils } from '@/vaults';
+import * as testUtils from '../utils';
 
 describe(ACL.name, () => {
   const logger = new Logger(`${ACL.name} test`, LogLevel.WARN, [
     new StreamHandler(),
   ]);
+
+  // Node Ids
+  const nodeIdX = testUtils.generateRandomNodeId();
+  const nodeIdY = testUtils.generateRandomNodeId();
+  const nodeIdG1First = testUtils.generateRandomNodeId();
+  const nodeIdG1Second = testUtils.generateRandomNodeId();
+  const nodeIdG1Third = testUtils.generateRandomNodeId();
+  const nodeIdG1Fourth = testUtils.generateRandomNodeId();
+  const nodeIdG2First = testUtils.generateRandomNodeId();
+  const nodeIdG2Second = testUtils.generateRandomNodeId();
+
   let dataDir: string;
   let db: DB;
   let vaultId1: VaultId;
@@ -66,32 +78,32 @@ describe(ACL.name, () => {
     await expect(async () => {
       await acl.start();
     }).rejects.toThrow(aclErrors.ErrorACLDestroyed);
-    await expect(
-      acl.sameNodePerm('x' as NodeId, 'y' as NodeId),
-    ).rejects.toThrow(aclErrors.ErrorACLNotRunning);
+    await expect(acl.sameNodePerm(nodeIdX, nodeIdY)).rejects.toThrow(
+      aclErrors.ErrorACLNotRunning,
+    );
     await expect(acl.getNodePerms()).rejects.toThrow(
       aclErrors.ErrorACLNotRunning,
     );
     await expect(acl.getVaultPerms()).rejects.toThrow(
       aclErrors.ErrorACLNotRunning,
     );
-    await expect(acl.getNodePerm('x' as NodeId)).rejects.toThrow(
+    await expect(acl.getNodePerm(nodeIdX)).rejects.toThrow(
       aclErrors.ErrorACLNotRunning,
     );
     await expect(acl.getVaultPerm(1 as VaultId)).rejects.toThrow(
       aclErrors.ErrorACLNotRunning,
     );
     await expect(
-      acl.setNodeAction('x' as NodeId, {} as GestaltAction),
+      acl.setNodeAction(nodeIdX, {} as GestaltAction),
     ).rejects.toThrow(aclErrors.ErrorACLNotRunning);
     await expect(
-      acl.unsetNodeAction('x' as NodeId, {} as GestaltAction),
+      acl.unsetNodeAction(nodeIdX, {} as GestaltAction),
     ).rejects.toThrow(aclErrors.ErrorACLNotRunning);
     await expect(
-      acl.setVaultAction(1 as VaultId, 'x' as NodeId, {} as VaultAction),
+      acl.setVaultAction(1 as VaultId, nodeIdX, {} as VaultAction),
     ).rejects.toThrow(aclErrors.ErrorACLNotRunning);
     await expect(
-      acl.unsetVaultAction(1 as VaultId, 'x' as NodeId, {} as VaultAction),
+      acl.unsetVaultAction(1 as VaultId, nodeIdX, {} as VaultAction),
     ).rejects.toThrow(aclErrors.ErrorACLNotRunning);
     await expect(acl.setNodesPerm([], {} as Permission)).rejects.toThrow(
       aclErrors.ErrorACLNotRunning,
@@ -99,25 +111,25 @@ describe(ACL.name, () => {
     await expect(acl.setNodesPermOps([], {} as Permission)).rejects.toThrow(
       aclErrors.ErrorACLNotRunning,
     );
-    await expect(
-      acl.setNodePerm('x' as NodeId, {} as Permission),
-    ).rejects.toThrow(aclErrors.ErrorACLNotRunning);
-    await expect(
-      acl.setNodePermOps('x' as NodeId, {} as Permission),
-    ).rejects.toThrow(aclErrors.ErrorACLNotRunning);
-    await expect(acl.unsetNodePerm('x' as NodeId)).rejects.toThrow(
+    await expect(acl.setNodePerm(nodeIdX, {} as Permission)).rejects.toThrow(
       aclErrors.ErrorACLNotRunning,
     );
-    await expect(acl.unsetNodePermOps('x' as NodeId)).rejects.toThrow(
+    await expect(acl.setNodePermOps(nodeIdX, {} as Permission)).rejects.toThrow(
+      aclErrors.ErrorACLNotRunning,
+    );
+    await expect(acl.unsetNodePerm(nodeIdX)).rejects.toThrow(
+      aclErrors.ErrorACLNotRunning,
+    );
+    await expect(acl.unsetNodePermOps(nodeIdX)).rejects.toThrow(
       aclErrors.ErrorACLNotRunning,
     );
     await expect(acl.unsetVaultPerms(1 as VaultId)).rejects.toThrow(
       aclErrors.ErrorACLNotRunning,
     );
-    await expect(acl.joinNodePerm('x' as NodeId, [])).rejects.toThrow(
+    await expect(acl.joinNodePerm(nodeIdX, [])).rejects.toThrow(
       aclErrors.ErrorACLNotRunning,
     );
-    await expect(acl.joinNodePermOps('x' as NodeId, [])).rejects.toThrow(
+    await expect(acl.joinNodePermOps(nodeIdX, [])).rejects.toThrow(
       aclErrors.ErrorACLNotRunning,
     );
     await expect(acl.joinVaultPerms(1 as VaultId, [])).rejects.toThrow(
@@ -127,7 +139,7 @@ describe(ACL.name, () => {
   test('trust and untrust gestalts', async () => {
     const acl = await ACL.createACL({ db, logger });
     // Gestalt 1
-    await acl.setNodesPerm(['g1-first', 'g1-second'] as Array<NodeId>, {
+    await acl.setNodesPerm([nodeIdG1First, nodeIdG1Second] as Array<NodeId>, {
       gestalt: {
         notify: null,
       },
@@ -136,7 +148,7 @@ describe(ACL.name, () => {
       },
     });
     // Gestalt2
-    await acl.setNodesPerm(['g2-first', 'g2-second'] as Array<NodeId>, {
+    await acl.setNodesPerm([nodeIdG2First, nodeIdG2Second] as Array<NodeId>, {
       gestalt: {
         notify: null,
       },
@@ -145,15 +157,15 @@ describe(ACL.name, () => {
       },
     });
     // Check g1 perm
-    const g1Perm1 = await acl.getNodePerm('g1-first' as NodeId);
-    const g1Perm2 = await acl.getNodePerm('g1-second' as NodeId);
+    const g1Perm1 = await acl.getNodePerm(nodeIdG1First);
+    const g1Perm2 = await acl.getNodePerm(nodeIdG1Second);
     expect(g1Perm1).toBeDefined();
     expect(g1Perm1).toEqual(g1Perm2);
     expect(g1Perm1!.gestalt).toHaveProperty('notify');
     expect(g1Perm1!.vaults[vaultId1]).toHaveProperty('pull');
     // Check g2 perm
-    const g2Perm = await acl.getNodePerm('g2-first' as NodeId);
-    const g2Perm_ = await acl.getNodePerm('g2-second' as NodeId);
+    const g2Perm = await acl.getNodePerm(nodeIdG2First);
+    const g2Perm_ = await acl.getNodePerm(nodeIdG2Second);
     expect(g2Perm).toBeDefined();
     expect(g2Perm).toEqual(g2Perm_);
     expect(g2Perm!.gestalt).toHaveProperty('notify');
@@ -163,44 +175,42 @@ describe(ACL.name, () => {
       ...g1Perm1!,
       gestalt: {},
     };
-    await acl.setNodePerm('g1-first' as NodeId, g1PermNew);
+    await acl.setNodePerm(nodeIdG1First, g1PermNew);
     // Check that g1-second also gets the same permission
-    const g1Perm3 = await acl.getNodePerm('g1-second' as NodeId);
+    const g1Perm3 = await acl.getNodePerm(nodeIdG1Second);
     expect(g1Perm3).toEqual(g1PermNew);
     const nodePerms = await acl.getNodePerms();
-    expect(nodePerms).toEqual([
-      {
-        'g1-first': g1PermNew,
-        'g1-second': g1PermNew,
-      },
-      {
-        'g2-first': g2Perm,
-        'g2-second': g2Perm,
-      },
-    ]);
+    expect(nodePerms).toContainEqual({
+      [nodeIdG1First]: g1PermNew,
+      [nodeIdG1Second]: g1PermNew,
+    });
+    expect(nodePerms).toContainEqual({
+      [nodeIdG2First]: g2Perm,
+      [nodeIdG2Second]: g2Perm,
+    });
     // Check that the permission object is identical
     // this should be a performance optimisation
-    expect(nodePerms[0]['g1-first']).toBe(nodePerms[0]['g1-second']);
+    expect(nodePerms[0][nodeIdG1First]).toBe(nodePerms[0][nodeIdG1Second]);
     await acl.stop();
   });
   test('setting and unsetting vault actions', async () => {
     const acl = await ACL.createACL({ db, logger });
     // The node id must exist as a gestalt first
     await expect(() =>
-      acl.setVaultAction(vaultId1, 'g1-1' as NodeId, 'pull'),
+      acl.setVaultAction(vaultId1, nodeIdG1First, 'pull'),
     ).rejects.toThrow(aclErrors.ErrorACLNodeIdMissing);
-    await acl.setNodesPerm(['g1-1'] as Array<NodeId>, {
+    await acl.setNodesPerm([nodeIdG1First] as Array<NodeId>, {
       gestalt: {
         notify: null,
       },
       vaults: {},
     });
     let vaultPerm: Record<NodeId, Permission>;
-    await acl.setVaultAction(vaultId1, 'g1-1' as NodeId, 'pull');
+    await acl.setVaultAction(vaultId1, nodeIdG1First, 'pull');
     // Idempotent
-    await acl.setVaultAction(vaultId1, 'g1-1' as NodeId, 'pull');
+    await acl.setVaultAction(vaultId1, nodeIdG1First, 'pull');
     vaultPerm = await acl.getVaultPerm(vaultId1);
-    expect(vaultPerm['g1-1']).toEqual({
+    expect(vaultPerm[nodeIdG1First]).toEqual({
       gestalt: {
         notify: null,
       },
@@ -208,11 +218,11 @@ describe(ACL.name, () => {
         vault1xxxxxxxxxx: { pull: null },
       },
     });
-    await acl.unsetVaultAction(vaultId1, 'g1-1' as NodeId, 'pull');
+    await acl.unsetVaultAction(vaultId1, nodeIdG1First, 'pull');
     // Idempotent
-    await acl.unsetVaultAction(vaultId1, 'g1-1' as NodeId, 'pull');
+    await acl.unsetVaultAction(vaultId1, nodeIdG1First, 'pull');
     vaultPerm = await acl.getVaultPerm(vaultId1);
-    expect(vaultPerm['g1-1']).toEqual({
+    expect(vaultPerm[nodeIdG1First]).toEqual({
       gestalt: {
         notify: null,
       },
@@ -220,15 +230,15 @@ describe(ACL.name, () => {
         vault1xxxxxxxxxx: {},
       },
     });
-    await acl.setVaultAction(vaultId1, 'g1-1' as NodeId, 'pull');
-    await acl.setVaultAction(vaultId1, 'g1-1' as NodeId, 'clone');
+    await acl.setVaultAction(vaultId1, nodeIdG1First, 'pull');
+    await acl.setVaultAction(vaultId1, nodeIdG1First, 'clone');
     vaultPerm = await acl.getVaultPerm(vaultId1);
-    expect(vaultPerm['g1-1'].vaults[vaultId1]).toHaveProperty('pull');
-    expect(vaultPerm['g1-1'].vaults[vaultId1]).toHaveProperty('clone');
+    expect(vaultPerm[nodeIdG1First].vaults[vaultId1]).toHaveProperty('pull');
+    expect(vaultPerm[nodeIdG1First].vaults[vaultId1]).toHaveProperty('clone');
     const vaultPerms = await acl.getVaultPerms();
     expect(vaultPerms).toEqual({
       vault1xxxxxxxxxx: {
-        'g1-1': {
+        [nodeIdG1First]: {
           gestalt: {
             notify: null,
           },
@@ -250,27 +260,30 @@ describe(ACL.name, () => {
         vault1xxxxxxxxxx: { pull: null },
       },
     };
-    await acl.setNodesPerm(['g1-first', 'g1-second'] as Array<NodeId>, g1Perm);
-    await acl.joinNodePerm(
-      'g1-second' as NodeId,
-      ['g1-third', 'g1-fourth'] as Array<NodeId>,
+    await acl.setNodesPerm(
+      [nodeIdG1First, nodeIdG1Second] as Array<NodeId>,
+      g1Perm,
     );
-    const nodePerm = await acl.getNodePerm('g1-fourth' as NodeId);
+    await acl.joinNodePerm(nodeIdG1Second, [
+      nodeIdG1Third,
+      nodeIdG1Fourth,
+    ] as Array<NodeId>);
+    const nodePerm = await acl.getNodePerm(nodeIdG1Fourth);
     expect(nodePerm).toEqual(g1Perm);
     const nodePerms = await acl.getNodePerms();
     expect(nodePerms).toEqual([
       {
-        'g1-first': g1Perm,
-        'g1-second': g1Perm,
-        'g1-third': g1Perm,
-        'g1-fourth': g1Perm,
+        [nodeIdG1First]: g1Perm,
+        [nodeIdG1Second]: g1Perm,
+        [nodeIdG1Third]: g1Perm,
+        [nodeIdG1Fourth]: g1Perm,
       },
     ]);
     await acl.stop();
   });
   test('joining existing vault permissions', async () => {
     const acl = await ACL.createACL({ db, logger });
-    await acl.setNodesPerm(['g1-1'] as Array<NodeId>, {
+    await acl.setNodesPerm([nodeIdG1First] as Array<NodeId>, {
       gestalt: {
         notify: null,
       },
@@ -278,19 +291,19 @@ describe(ACL.name, () => {
         vault1xxxxxxxxxx: { clone: null },
       },
     });
-    await acl.setVaultAction(vaultId1, 'g1-1' as NodeId, 'pull');
+    await acl.setVaultAction(vaultId1, nodeIdG1First, 'pull');
     await acl.joinVaultPerms(vaultId1, [vaultId2, vaultId3]);
     const vaultPerm1 = await acl.getVaultPerm(vaultId1);
     const vaultPerm2 = await acl.getVaultPerm(vaultId2);
     const vaultPerm3 = await acl.getVaultPerm(vaultId3);
     expect(vaultPerm1).toEqual(vaultPerm2);
     expect(vaultPerm2).toEqual(vaultPerm3);
-    expect(vaultPerm1['g1-1'].vaults[vaultId1]).toHaveProperty('clone');
-    expect(vaultPerm1['g1-1'].vaults[vaultId1]).toHaveProperty('pull');
+    expect(vaultPerm1[nodeIdG1First].vaults[vaultId1]).toHaveProperty('clone');
+    expect(vaultPerm1[nodeIdG1First].vaults[vaultId1]).toHaveProperty('pull');
     const vaultPerms = await acl.getVaultPerms();
     expect(vaultPerms).toMatchObject({
       vault1xxxxxxxxxx: {
-        'g1-1': {
+        [nodeIdG1First]: {
           gestalt: {
             notify: null,
           },
@@ -302,7 +315,7 @@ describe(ACL.name, () => {
         },
       },
       vault2xxxxxxxxxx: {
-        'g1-1': {
+        [nodeIdG1First]: {
           gestalt: {
             notify: null,
           },
@@ -314,7 +327,7 @@ describe(ACL.name, () => {
         },
       },
       vault3xxxxxxxxxx: {
-        'g1-1': {
+        [nodeIdG1First]: {
           gestalt: {
             notify: null,
           },
@@ -327,8 +340,12 @@ describe(ACL.name, () => {
       },
     });
     // Object identity for performance
-    expect(vaultPerms[vaultId1]['g1-1']).toEqual(vaultPerms[vaultId2]['g1-1']);
-    expect(vaultPerms[vaultId2]['g1-1']).toEqual(vaultPerms[vaultId3]['g1-1']);
+    expect(vaultPerms[vaultId1][nodeIdG1First]).toEqual(
+      vaultPerms[vaultId2][nodeIdG1First],
+    );
+    expect(vaultPerms[vaultId2][nodeIdG1First]).toEqual(
+      vaultPerms[vaultId3][nodeIdG1First],
+    );
     await acl.stop();
   });
   test('node removal', async () => {
@@ -341,13 +358,16 @@ describe(ACL.name, () => {
         vault1xxxxxxxxxx: { pull: null },
       },
     };
-    await acl.setNodesPerm(['g1-first', 'g1-second'] as Array<NodeId>, g1Perm);
-    await acl.unsetNodePerm('g1-first' as NodeId);
-    expect(await acl.getNodePerm('g1-first' as NodeId)).toBeUndefined();
-    const g1Perm_ = await acl.getNodePerm('g1-second' as NodeId);
+    await acl.setNodesPerm(
+      [nodeIdG1First, nodeIdG1Second] as Array<NodeId>,
+      g1Perm,
+    );
+    await acl.unsetNodePerm(nodeIdG1First);
+    expect(await acl.getNodePerm(nodeIdG1First)).toBeUndefined();
+    const g1Perm_ = await acl.getNodePerm(nodeIdG1Second);
     expect(g1Perm_).toEqual(g1Perm);
-    await acl.unsetNodePerm('g1-second' as NodeId);
-    expect(await acl.getNodePerm('g1-second' as NodeId)).toBeUndefined();
+    await acl.unsetNodePerm(nodeIdG1Second);
+    expect(await acl.getNodePerm(nodeIdG1Second)).toBeUndefined();
     expect(await acl.getNodePerms()).toHaveLength(0);
     await acl.stop();
   });
@@ -359,15 +379,18 @@ describe(ACL.name, () => {
       },
       vaults: {},
     };
-    await acl.setNodesPerm(['g1-first', 'g1-second'] as Array<NodeId>, g1Perm);
+    await acl.setNodesPerm(
+      [nodeIdG1First, nodeIdG1Second] as Array<NodeId>,
+      g1Perm,
+    );
     // V1 and v2 are pointing to the same gestalt
     // but using different node ids as the representative
-    await acl.setVaultAction(vaultId1, 'g1-first' as NodeId, 'clone');
-    await acl.setVaultAction(vaultId2, 'g1-second' as NodeId, 'pull');
+    await acl.setVaultAction(vaultId1, nodeIdG1First, 'clone');
+    await acl.setVaultAction(vaultId2, nodeIdG1Second, 'pull');
     let vaultPerm;
     vaultPerm = await acl.getVaultPerm(vaultId2);
     expect(vaultPerm).toEqual({
-      'g1-second': {
+      [nodeIdG1Second]: {
         gestalt: {
           notify: null,
         },
@@ -381,7 +404,7 @@ describe(ACL.name, () => {
     await acl.unsetVaultPerms(vaultId1);
     vaultPerm = await acl.getVaultPerm(vaultId2);
     expect(vaultPerm).toEqual({
-      'g1-second': {
+      [nodeIdG1Second]: {
         gestalt: {
           notify: null,
         },
@@ -396,89 +419,87 @@ describe(ACL.name, () => {
     const acl = await ACL.createACL({ db, logger });
     const p1 = acl.getNodePerms();
     const p2 = acl.transaction(async (acl) => {
-      await acl.setNodesPerm(['g1-first', 'g1-second'] as Array<NodeId>, {
+      await acl.setNodesPerm([nodeIdG1First, nodeIdG1Second] as Array<NodeId>, {
         gestalt: {
           notify: null,
         },
         vaults: {},
       });
-      await acl.setNodesPerm(['g2-first', 'g2-second'] as Array<NodeId>, {
+      await acl.setNodesPerm([nodeIdG2First, nodeIdG2Second] as Array<NodeId>, {
         gestalt: {
           notify: null,
         },
         vaults: {},
       });
-      await acl.setVaultAction(vaultId1, 'g1-first' as NodeId, 'pull');
-      await acl.setVaultAction(vaultId1, 'g2-first' as NodeId, 'clone');
-      await acl.joinNodePerm(
-        'g1-second' as NodeId,
-        ['g1-third', 'g1-fourth'] as Array<NodeId>,
-      );
+      await acl.setVaultAction(vaultId1, nodeIdG1First, 'pull');
+      await acl.setVaultAction(vaultId1, nodeIdG2First, 'clone');
+      await acl.joinNodePerm(nodeIdG1Second, [
+        nodeIdG1Third,
+        nodeIdG1Fourth,
+      ] as Array<NodeId>);
       // V3 and v4 joins v1
       // this means v3 and v4 now has g1 and g2 permissions
       await acl.joinVaultPerms(vaultId1, [vaultId3, vaultId4]);
       // Removing v3
       await acl.unsetVaultPerms(vaultId3);
       // Removing g1-second
-      await acl.unsetNodePerm('g1-second' as NodeId);
+      await acl.unsetNodePerm(nodeIdG1Second);
       // Unsetting pull just for v1 for g1
-      await acl.unsetVaultAction(vaultId1, 'g1-first' as NodeId, 'pull');
+      await acl.unsetVaultAction(vaultId1, nodeIdG1First, 'pull');
       return await acl.getNodePerms();
     });
     const p3 = acl.getNodePerms();
     const results = await Promise.all([p1, p2, p3]);
     expect(results[0]).toEqual([]);
-    expect(results[1]).toEqual([
-      {
-        'g1-first': {
-          gestalt: {
-            notify: null,
-          },
-          vaults: {
-            vault1xxxxxxxxxx: {},
-            vault4xxxxxxxxxx: { pull: null },
-          },
+    expect(results[1]).toContainEqual({
+      [nodeIdG1First]: {
+        gestalt: {
+          notify: null,
         },
-        'g1-fourth': {
-          gestalt: {
-            notify: null,
-          },
-          vaults: {
-            vault1xxxxxxxxxx: {},
-            vault4xxxxxxxxxx: { pull: null },
-          },
-        },
-        'g1-third': {
-          gestalt: {
-            notify: null,
-          },
-          vaults: {
-            vault1xxxxxxxxxx: {},
-            vault4xxxxxxxxxx: { pull: null },
-          },
+        vaults: {
+          vault1xxxxxxxxxx: {},
+          vault4xxxxxxxxxx: { pull: null },
         },
       },
-      {
-        'g2-first': {
-          gestalt: {
-            notify: null,
-          },
-          vaults: {
-            vault1xxxxxxxxxx: { clone: null },
-            vault4xxxxxxxxxx: { clone: null },
-          },
+      [nodeIdG1Fourth]: {
+        gestalt: {
+          notify: null,
         },
-        'g2-second': {
-          gestalt: {
-            notify: null,
-          },
-          vaults: {
-            vault1xxxxxxxxxx: { clone: null },
-            vault4xxxxxxxxxx: { clone: null },
-          },
+        vaults: {
+          vault1xxxxxxxxxx: {},
+          vault4xxxxxxxxxx: { pull: null },
         },
       },
-    ]);
+      [nodeIdG1Third]: {
+        gestalt: {
+          notify: null,
+        },
+        vaults: {
+          vault1xxxxxxxxxx: {},
+          vault4xxxxxxxxxx: { pull: null },
+        },
+      },
+    });
+    expect(results[1]).toContainEqual({
+      [nodeIdG2First]: {
+        gestalt: {
+          notify: null,
+        },
+        vaults: {
+          vault1xxxxxxxxxx: { clone: null },
+          vault4xxxxxxxxxx: { clone: null },
+        },
+      },
+      [nodeIdG2Second]: {
+        gestalt: {
+          notify: null,
+        },
+        vaults: {
+          vault1xxxxxxxxxx: { clone: null },
+          vault4xxxxxxxxxx: { clone: null },
+        },
+      },
+    });
     // If p2 was executed ahead of p3
     // then results[2] would equal results[1]
     // if p3 was executed ahead of p2

--- a/tests/agent/utils.ts
+++ b/tests/agent/utils.ts
@@ -1,5 +1,4 @@
 import type { Host, Port } from '@/network/types';
-import type { NodeId } from '@/nodes/types';
 
 import type { IAgentServiceServer } from '@/proto/js/polykey/v1/agent_service_grpc_pb';
 import type { KeyManager } from '@/keys';
@@ -15,6 +14,7 @@ import {
   GRPCClientAgent,
   AgentServiceService,
 } from '@/agent';
+import * as testUtils from '../utils';
 
 async function openTestAgentServer({
   keyManager,
@@ -58,7 +58,7 @@ async function openTestAgentClient(port: number): Promise<GRPCClientAgent> {
     new StreamHandler(),
   ]);
   const agentClient = await GRPCClientAgent.createGRPCClientAgent({
-    nodeId: 'NODEID' as NodeId,
+    nodeId: testUtils.generateRandomNodeId(),
     host: '127.0.0.1' as Host,
     port: port as Port,
     logger: logger,

--- a/tests/bin/agent/start.test.ts
+++ b/tests/bin/agent/start.test.ts
@@ -562,7 +562,7 @@ describe('start', () => {
       const statusInfo2 = await status.waitFor('LIVE');
       expect(statusInfo2.status).toBe('LIVE');
       // Node Id hasn't changed
-      expect(statusInfo1.data.nodeId).toBe(statusInfo2.data.nodeId);
+      expect(statusInfo1.data.nodeId).toStrictEqual(statusInfo2.data.nodeId);
       agentProcess2.kill('SIGTERM');
       await testBinUtils.processExit(agentProcess2);
       // Check that the password has changed
@@ -578,7 +578,7 @@ describe('start', () => {
       const statusInfo3 = await status.waitFor('LIVE');
       expect(statusInfo3.status).toBe('LIVE');
       // Node ID hasn't changed
-      expect(statusInfo1.data.nodeId).toBe(statusInfo3.data.nodeId);
+      expect(statusInfo1.data.nodeId).toStrictEqual(statusInfo3.data.nodeId);
       agentProcess3.kill('SIGTERM');
       await testBinUtils.processExit(agentProcess3);
       // Checks deterministic generation using the same recovery code
@@ -608,7 +608,7 @@ describe('start', () => {
       const statusInfo4 = await status.waitFor('LIVE');
       expect(statusInfo4.status).toBe('LIVE');
       // Same Node ID as before
-      expect(statusInfo1.data.nodeId).toBe(statusInfo4.data.nodeId);
+      expect(statusInfo1.data.nodeId).toStrictEqual(statusInfo4.data.nodeId);
       agentProcess4.kill('SIGTERM');
       await testBinUtils.processExit(agentProcess4);
     },

--- a/tests/bin/agent/status.test.ts
+++ b/tests/bin/agent/status.test.ts
@@ -5,6 +5,7 @@ import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import { Status } from '@/status';
 import * as binErrors from '@/bin/errors';
 import config from '@/config';
+import { utils as nodesUtils } from '@/nodes';
 import * as testBinUtils from '../utils';
 import * as testUtils from '../../utils';
 
@@ -154,7 +155,7 @@ describe('status', () => {
       expect(JSON.parse(stdout)).toMatchObject({
         status: 'LIVE',
         pid: expect.any(Number),
-        nodeId: statusInfo.data.nodeId,
+        nodeId: nodesUtils.encodeNodeId(statusInfo.data.nodeId),
         clientHost: statusInfo.data.clientHost,
         clientPort: statusInfo.data.clientPort,
         ingressHost: statusInfo.data.ingressHost,
@@ -192,7 +193,7 @@ describe('status', () => {
         '--password-file',
         passwordPath,
         '--node-id',
-        statusInfo.data.nodeId,
+        nodesUtils.encodeNodeId(statusInfo.data.nodeId),
         '--client-host',
         statusInfo.data.clientHost,
         '--client-port',
@@ -205,7 +206,7 @@ describe('status', () => {
       expect(JSON.parse(stdout)).toMatchObject({
         status: 'LIVE',
         pid: expect.any(Number),
-        nodeId: statusInfo.data.nodeId,
+        nodeId: nodesUtils.encodeNodeId(statusInfo.data.nodeId),
         clientHost: statusInfo.data.clientHost,
         clientPort: statusInfo.data.clientPort,
         ingressHost: statusInfo.data.ingressHost,

--- a/tests/bin/keys/renew.test.ts
+++ b/tests/bin/keys/renew.test.ts
@@ -71,7 +71,7 @@ describe('renew', () => {
     expect(fwdTLSConfig1).toEqual(expectedTLSConfig1);
     expect(revTLSConfig1).toEqual(expectedTLSConfig1);
     expect(serverTLSConfig1).toEqual(expectedTLSConfig1);
-    expect(nodeId1).toBe(nodeIdStatus1);
+    expect(nodeId1.equals(nodeIdStatus1)).toBe(true);
     // Renew keypair
     const passPath = path.join(dataDir, 'passwordNew');
     await fs.promises.writeFile(passPath, 'password-new');
@@ -104,7 +104,7 @@ describe('renew', () => {
     expect(rootKeyPair2.publicKey).not.toBe(rootKeyPair1.publicKey);
     expect(nodeId1).not.toBe(nodeId2);
     expect(nodeIdStatus1).not.toBe(nodeIdStatus2);
-    expect(nodeId2).toBe(nodeIdStatus2);
+    expect(nodeId2.equals(nodeIdStatus2)).toBe(true);
     // Revert side effects
     await fs.promises.writeFile(passPath, password);
     ({ exitCode } = await testBinUtils.pkStdio(

--- a/tests/bin/keys/reset.test.ts
+++ b/tests/bin/keys/reset.test.ts
@@ -71,7 +71,7 @@ describe('renew', () => {
     expect(fwdTLSConfig1).toEqual(expectedTLSConfig1);
     expect(revTLSConfig1).toEqual(expectedTLSConfig1);
     expect(serverTLSConfig1).toEqual(expectedTLSConfig1);
-    expect(nodeId1).toBe(nodeIdStatus1);
+    expect(nodeId1.equals(nodeIdStatus1)).toBe(true);
     // Renew keypair
     const passPath = path.join(dataDir, 'passwordNew');
     await fs.promises.writeFile(passPath, 'password-new');
@@ -104,7 +104,7 @@ describe('renew', () => {
     expect(rootKeyPair2.publicKey).not.toBe(rootKeyPair1.publicKey);
     expect(nodeId1).not.toBe(nodeId2);
     expect(nodeIdStatus1).not.toBe(nodeIdStatus2);
-    expect(nodeId2).toBe(nodeIdStatus2);
+    expect(nodeId2.equals(nodeIdStatus2)).toBe(true);
     // Revert side effects
     await fs.promises.writeFile(passPath, password);
     ({ exitCode } = await testBinUtils.pkStdio(

--- a/tests/bin/nodes/add.test.ts
+++ b/tests/bin/nodes/add.test.ts
@@ -3,9 +3,11 @@ import os from 'os';
 import path from 'path';
 import fs from 'fs';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
+import { IdInternal } from '@matrixai/id';
 import PolykeyAgent from '@/PolykeyAgent';
 import * as nodesUtils from '@/nodes/utils';
 import * as testBinUtils from '../utils';
+import * as testUtils from '../../utils';
 
 jest.mock('@/keys/utils', () => ({
   ...jest.requireActual('@/keys/utils'),
@@ -21,10 +23,8 @@ describe('add', () => {
   let passwordFile: string;
   let polykeyAgent: PolykeyAgent;
 
-  const validNodeId = nodesUtils.makeNodeId(
-    'vrsc24a1er424epq77dtoveo93meij0pc8ig4uvs9jbeld78n9nl0',
-  );
-  const invalidNodeId = 'INVALIDID' as NodeId;
+  const validNodeId = testUtils.generateRandomNodeId();
+  const invalidNodeId = IdInternal.fromString<NodeId>('INVALIDID');
   const validHost = '0.0.0.0';
   const invalidHost = 'INVALIDHOST';
   const port = 55555;
@@ -69,7 +69,7 @@ describe('add', () => {
   test('add a node', async () => {
     const commands = genCommands([
       'add',
-      validNodeId,
+      nodesUtils.encodeNodeId(validNodeId),
       validHost,
       port.toString(),
     ]);
@@ -87,7 +87,7 @@ describe('add', () => {
     async () => {
       const commands = genCommands([
         'add',
-        invalidNodeId,
+        nodesUtils.encodeNodeId(invalidNodeId),
         validHost,
         port.toString(),
       ]);
@@ -102,7 +102,7 @@ describe('add', () => {
     async () => {
       const commands = genCommands([
         'add',
-        validNodeId,
+        nodesUtils.encodeNodeId(validNodeId),
         invalidHost,
         port.toString(),
       ]);

--- a/tests/bin/nodes/find.test.ts
+++ b/tests/bin/nodes/find.test.ts
@@ -107,7 +107,10 @@ describe('find', () => {
   });
 
   test('find an online node', async () => {
-    const commands = genCommands(['find', remoteOnlineNodeId]);
+    const commands = genCommands([
+      'find',
+      nodesUtils.encodeNodeId(remoteOnlineNodeId),
+    ]);
     const result = await testBinUtils.pkStdio(commands, {}, dataDir);
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('Found node at');
@@ -117,7 +120,7 @@ describe('find', () => {
     // Checking json format.
     const commands2 = genCommands([
       'find',
-      remoteOnlineNodeId,
+      nodesUtils.encodeNodeId(remoteOnlineNodeId),
       '--format',
       'json',
     ]);
@@ -132,10 +135,15 @@ describe('find', () => {
     expect(result2.stdout).toContain('host');
     expect(result2.stdout).toContain('port');
     expect(result2.stdout).toContain('id');
-    expect(result2.stdout).toContain(remoteOnlineNodeId);
+    expect(result2.stdout).toContain(
+      nodesUtils.encodeNodeId(remoteOnlineNodeId),
+    );
   });
   test('find an offline node', async () => {
-    const commands = genCommands(['find', remoteOfflineNodeId]);
+    const commands = genCommands([
+      'find',
+      nodesUtils.encodeNodeId(remoteOfflineNodeId),
+    ]);
     const result = await testBinUtils.pkStdio(commands, {}, dataDir);
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('Found node at');
@@ -145,7 +153,7 @@ describe('find', () => {
     // Checking json format.
     const commands2 = genCommands([
       'find',
-      remoteOfflineNodeId,
+      nodesUtils.encodeNodeId(remoteOfflineNodeId),
       '--format',
       'json',
     ]);
@@ -160,23 +168,30 @@ describe('find', () => {
     expect(result2.stdout).toContain('host');
     expect(result2.stdout).toContain('port');
     expect(result2.stdout).toContain('id');
-    expect(result2.stdout).toContain(remoteOfflineNodeId);
+    expect(result2.stdout).toContain(
+      nodesUtils.encodeNodeId(remoteOfflineNodeId),
+    );
   });
   test(
     'fail to find an unknown node',
     async () => {
-      const unknownNodeId = nodesUtils.makeNodeId(
+      const unknownNodeId = nodesUtils.decodeNodeId(
         'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
       );
-      const commands = genCommands(['find', unknownNodeId]);
+      const commands = genCommands([
+        'find',
+        nodesUtils.encodeNodeId(unknownNodeId),
+      ]);
       const result = await testBinUtils.pkStdio(commands, {}, dataDir);
       expect(result.exitCode).toBe(1);
-      expect(result.stdout).toContain(`Failed to find node ${unknownNodeId}`);
+      expect(result.stdout).toContain(
+        `Failed to find node ${nodesUtils.encodeNodeId(unknownNodeId)}`,
+      );
 
       // Checking json format.
       const commands2 = genCommands([
         'find',
-        unknownNodeId,
+        nodesUtils.encodeNodeId(unknownNodeId),
         '--format',
         'json',
       ]);

--- a/tests/bin/nodes/ping.test.ts
+++ b/tests/bin/nodes/ping.test.ts
@@ -37,6 +37,9 @@ describe('ping', () => {
     dataDir = await fs.promises.mkdtemp(
       path.join(os.tmpdir(), 'polykey-test-'),
     );
+    rootDataDir = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'polykey-test-'),
+    );
     nodePath = path.join(dataDir, 'keynode');
     passwordFile = path.join(dataDir, 'passwordFile');
     await fs.promises.writeFile(passwordFile, 'password');
@@ -95,7 +98,10 @@ describe('ping', () => {
   test(
     'fail when pinging an offline node',
     async () => {
-      const commands = genCommands(['ping', remoteOfflineNodeId]);
+      const commands = genCommands([
+        'ping',
+        nodesUtils.encodeNodeId(remoteOfflineNodeId),
+      ]);
       const result = await testBinUtils.pkStdio(commands, {}, dataDir);
       expect(result.exitCode).toBe(1); // Should fail with no response. for automation purposes.
       expect(result.stdout).toContain('No response received');
@@ -103,7 +109,7 @@ describe('ping', () => {
       // Checking for json output
       const commands2 = genCommands([
         'ping',
-        remoteOfflineNodeId,
+        nodesUtils.encodeNodeId(remoteOfflineNodeId),
         '--format',
         'json',
       ]);
@@ -116,16 +122,24 @@ describe('ping', () => {
   test(
     'fail if node cannot be found',
     async () => {
-      const fakeNodeId = nodesUtils.makeNodeId(
+      const fakeNodeId = nodesUtils.decodeNodeId(
         'vrsc24a1er424epq77dtoveo93meij0pc8ig4uvs9jbeld78n9nl0',
       );
-      const commands = genCommands(['ping', fakeNodeId]);
-      const result = await testBinUtils.pkStdio(commands, {}, dataDir);
+      const commands = genCommands([
+        'ping',
+        nodesUtils.encodeNodeId(fakeNodeId),
+      ]);
+      const result = await testBinUtils.pk(commands);
       expect(result.exitCode).not.toBe(0); // Should fail if node doesn't exist.
       expect(result.stdout).toContain('Failed to resolve node ID');
 
       // Json format.
-      const commands2 = genCommands(['ping', fakeNodeId, '--format', 'json']);
+      const commands2 = genCommands([
+        'ping',
+        nodesUtils.encodeNodeId(fakeNodeId),
+        '--format',
+        'json',
+      ]);
       const result2 = await testBinUtils.pkStdio(commands2, {}, dataDir);
       expect(result2.exitCode).not.toBe(0); // Should fail if node doesn't exist.
       expect(result2.stdout).toContain('success');
@@ -136,7 +150,10 @@ describe('ping', () => {
     global.failedConnectionTimeout * 2,
   );
   test('succeed when pinging a live node', async () => {
-    const commands = genCommands(['ping', remoteOnlineNodeId]);
+    const commands = genCommands([
+      'ping',
+      nodesUtils.encodeNodeId(remoteOnlineNodeId),
+    ]);
     const result = await testBinUtils.pkStdio(commands, {}, dataDir);
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('Node is Active.');
@@ -144,7 +161,7 @@ describe('ping', () => {
     // Checking for Json output.
     const commands2 = genCommands([
       'ping',
-      remoteOnlineNodeId,
+      nodesUtils.encodeNodeId(remoteOnlineNodeId),
       '--format',
       'json',
     ]);

--- a/tests/bin/notifications/notifications.test.ts
+++ b/tests/bin/notifications/notifications.test.ts
@@ -8,6 +8,7 @@ import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import { utils as idUtils } from '@matrixai/id';
 import PolykeyAgent from '@/PolykeyAgent';
 import { makeVaultId } from '@/vaults/utils';
+import { utils as nodesUtils } from '@/nodes';
 import * as testBinUtils from '../utils';
 
 jest.mock('@/keys/utils', () => ({
@@ -106,7 +107,11 @@ describe('CLI Notifications', () => {
         },
         vaults: {},
       });
-      const commands = genCommandsSender(['send', receiverNodeId, 'msg']);
+      const commands = genCommandsSender([
+        'send',
+        nodesUtils.encodeNodeId(receiverNodeId),
+        'msg',
+      ]);
       const result = await testBinUtils.pkStdio(commands, {}, senderDataDir);
       expect(result.exitCode).toBe(0); // Succeeds
       const notifications =
@@ -121,7 +126,11 @@ describe('CLI Notifications', () => {
         gestalt: {},
         vaults: {},
       });
-      const commands = genCommandsSender(['send', receiverNodeId, 'msg']);
+      const commands = genCommandsSender([
+        'send',
+        nodesUtils.encodeNodeId(receiverNodeId),
+        'msg',
+      ]);
       const result = await testBinUtils.pkStdio(commands, {}, senderDataDir);
       expect(result.exitCode).toBe(0); // Succeeds
       const notifications =
@@ -139,17 +148,17 @@ describe('CLI Notifications', () => {
       });
       const senderCommands1 = genCommandsSender([
         'send',
-        receiverNodeId,
+        nodesUtils.encodeNodeId(receiverNodeId),
         'msg1',
       ]);
       const senderCommands2 = genCommandsSender([
         'send',
-        receiverNodeId,
+        nodesUtils.encodeNodeId(receiverNodeId),
         'msg2',
       ]);
       const senderCommands3 = genCommandsSender([
         'send',
-        receiverNodeId,
+        nodesUtils.encodeNodeId(receiverNodeId),
         'msg3',
       ]);
       await testBinUtils.pkStdio(senderCommands1, {}, senderDataDir);
@@ -167,7 +176,7 @@ describe('CLI Notifications', () => {
       expect(result1.stdout).toContain('msg3');
       const senderCommands4 = genCommandsSender([
         'send',
-        receiverNodeId,
+        nodesUtils.encodeNodeId(receiverNodeId),
         'msg4',
       ]);
       await testBinUtils.pkStdio(senderCommands4, {}, senderDataDir);
@@ -191,17 +200,17 @@ describe('CLI Notifications', () => {
       });
       const senderCommands1 = genCommandsSender([
         'send',
-        receiverNodeId,
+        nodesUtils.encodeNodeId(receiverNodeId),
         'msg1',
       ]);
       const senderCommands2 = genCommandsSender([
         'send',
-        receiverNodeId,
+        nodesUtils.encodeNodeId(receiverNodeId),
         'msg2',
       ]);
       const senderCommands3 = genCommandsSender([
         'send',
-        receiverNodeId,
+        nodesUtils.encodeNodeId(receiverNodeId),
         'msg3',
       ]);
       await testBinUtils.pkStdio(senderCommands1, {}, senderDataDir);
@@ -211,7 +220,7 @@ describe('CLI Notifications', () => {
       await testBinUtils.pkStdio(receiverCommands1, {}, receiverDataDir);
       const senderCommands4 = genCommandsSender([
         'send',
-        receiverNodeId,
+        nodesUtils.encodeNodeId(receiverNodeId),
         'msg4',
       ]);
       await testBinUtils.pkStdio(senderCommands4, {}, senderDataDir);
@@ -236,17 +245,17 @@ describe('CLI Notifications', () => {
       });
       const senderCommands1 = genCommandsSender([
         'send',
-        receiverNodeId,
+        nodesUtils.encodeNodeId(receiverNodeId),
         'msg1',
       ]);
       const senderCommands2 = genCommandsSender([
         'send',
-        receiverNodeId,
+        nodesUtils.encodeNodeId(receiverNodeId),
         'msg2',
       ]);
       const senderCommands3 = genCommandsSender([
         'send',
-        receiverNodeId,
+        nodesUtils.encodeNodeId(receiverNodeId),
         'msg3',
       ]);
       await testBinUtils.pkStdio(senderCommands1, {}, senderDataDir);
@@ -272,17 +281,17 @@ describe('CLI Notifications', () => {
       });
       const senderCommands1 = genCommandsSender([
         'send',
-        receiverNodeId,
+        nodesUtils.encodeNodeId(receiverNodeId),
         'msg1',
       ]);
       const senderCommands2 = genCommandsSender([
         'send',
-        receiverNodeId,
+        nodesUtils.encodeNodeId(receiverNodeId),
         'msg2',
       ]);
       const senderCommands3 = genCommandsSender([
         'send',
-        receiverNodeId,
+        nodesUtils.encodeNodeId(receiverNodeId),
         'msg3',
       ]);
       await testBinUtils.pkStdio(senderCommands1, {}, senderDataDir);
@@ -344,7 +353,7 @@ describe('CLI Notifications', () => {
       };
       const notificationData3: NotificationData = {
         type: 'VaultShare',
-        vaultId: makeVaultId(idUtils.fromString('vaultId')).toString(),
+        vaultId: makeVaultId(idUtils.fromString('vaultIdxxxxxxxxx')).toString(),
         vaultName: 'vaultName' as VaultName,
         actions: {
           clone: null,
@@ -381,17 +390,17 @@ describe('CLI Notifications', () => {
       });
       const senderCommands1 = genCommandsSender([
         'send',
-        receiverNodeId,
+        nodesUtils.encodeNodeId(receiverNodeId),
         'msg1',
       ]);
       const senderCommands2 = genCommandsSender([
         'send',
-        receiverNodeId,
+        nodesUtils.encodeNodeId(receiverNodeId),
         'msg2',
       ]);
       const senderCommands3 = genCommandsSender([
         'send',
-        receiverNodeId,
+        nodesUtils.encodeNodeId(receiverNodeId),
         'msg3',
       ]);
       await testBinUtils.pkStdio(senderCommands1, {}, senderDataDir);

--- a/tests/bin/vaults/vaults.test.ts
+++ b/tests/bin/vaults/vaults.test.ts
@@ -1,12 +1,12 @@
-import type { NodeInfo } from '@/nodes/types';
+import type { NodeIdEncoded, NodeInfo } from '@/nodes/types';
 import type { Vault, VaultName } from '@/vaults/types';
 import os from 'os';
 import path from 'path';
 import fs from 'fs';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import PolykeyAgent from '@/PolykeyAgent';
-import { makeNodeId } from '@/nodes/utils';
 import { makeVaultIdPretty } from '@/vaults/utils';
+import { utils as nodesUtils } from '@/nodes';
 import * as testBinUtils from '../utils';
 
 jest.mock('@/keys/utils', () => ({
@@ -39,26 +39,26 @@ describe('CLI vaults', () => {
   let vaultName: VaultName;
 
   // Constants
-  const nodeId1 = makeNodeId(
-    'vrsc24a1er424epq77dtoveo93meij0pc8ig4uvs9jbeld78n9nl0',
-  );
-  const nodeId2 = makeNodeId(
-    'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
-  );
-  const nodeId3 = makeNodeId(
-    'v359vgrgmqf1r5g4fvisiddjknjko6bmm4qv7646jr7fi9enbfuug',
-  );
+  const nodeId1Encoded =
+    'vrsc24a1er424epq77dtoveo93meij0pc8ig4uvs9jbeld78n9nl0' as NodeIdEncoded;
+  const nodeId1 = nodesUtils.decodeNodeId(nodeId1Encoded);
+  const nodeId2Encoded =
+    'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg' as NodeIdEncoded;
+  // Const nodeId2 = nodesUtils.decodeNodeId(nodeId2Encoded);
+  const nodeId3Encoded =
+    'v359vgrgmqf1r5g4fvisiddjknjko6bmm4qv7646jr7fi9enbfuug' as NodeIdEncoded;
+  // Const nodeId3 = nodesUtils.decodeNodeId(nodeId3Encoded);
 
   const node1: NodeInfo = {
-    id: nodeId1,
+    id: nodeId1Encoded,
     chain: {},
   };
   const node2: NodeInfo = {
-    id: nodeId2,
+    id: nodeId2Encoded,
     chain: {},
   };
   const node3: NodeInfo = {
-    id: nodeId3,
+    id: nodeId3Encoded,
     chain: {},
   };
 
@@ -212,7 +212,14 @@ describe('CLI vaults', () => {
   });
   describe.skip('commandSetPermsVault', () => {
     test('should share a vault', async () => {
-      command = ['vaults', 'share', '-np', dataDir, vaultName, node1.id];
+      command = [
+        'vaults',
+        'share',
+        '-np',
+        dataDir,
+        vaultName,
+        nodesUtils.encodeNodeId(nodeId1),
+      ];
       await polykeyAgent.vaultManager.createVault(vaultName);
       const id = await polykeyAgent.vaultManager.getVaultId(vaultName);
       expect(id).toBeTruthy();
@@ -232,7 +239,14 @@ describe('CLI vaults', () => {
   });
   describe.skip('commandUnsetPermsVault', () => {
     test('should un-share a vault', async () => {
-      command = ['vaults', 'unshare', '-np', dataDir, vaultName, node1.id];
+      command = [
+        'vaults',
+        'unshare',
+        '-np',
+        dataDir,
+        vaultName,
+        nodesUtils.encodeNodeId(nodeId1),
+      ];
       // Creating vault.
       await polykeyAgent.vaultManager.createVault(vaultName);
       const id = await polykeyAgent.vaultManager.getVaultId(vaultName);
@@ -295,7 +309,7 @@ describe('CLI vaults', () => {
         expect(id).toBeTruthy();
 
         await targetPolykeyAgent.gestaltGraph.setNode({
-          id: polykeyAgent.nodeManager.getNodeId(),
+          id: nodesUtils.encodeNodeId(polykeyAgent.nodeManager.getNodeId()),
           chain: {},
         });
         fail();
@@ -329,7 +343,7 @@ describe('CLI vaults', () => {
           '-np',
           dataDir,
           '-ni',
-          targetNodeId as string,
+          nodesUtils.encodeNodeId(targetNodeId),
           '-vi',
           makeVaultIdPretty(vault.vaultId),
         ];
@@ -371,7 +385,7 @@ describe('CLI vaults', () => {
         expect(id).toBeTruthy();
 
         await targetPolykeyAgent.gestaltGraph.setNode({
-          id: polykeyAgent.nodeManager.getNodeId(),
+          id: nodesUtils.encodeNodeId(polykeyAgent.nodeManager.getNodeId()),
           chain: {},
         });
         fail();
@@ -422,7 +436,7 @@ describe('CLI vaults', () => {
           '-vn',
           vaultName,
           '-ni',
-          targetNodeId,
+          nodesUtils.encodeNodeId(targetNodeId),
         ];
 
         const result = await testBinUtils.pkStdio([...command]);
@@ -496,7 +510,7 @@ describe('CLI vaults', () => {
         '-np',
         dataDir,
         '-ni',
-        targetNodeId as string,
+        nodesUtils.encodeNodeId(targetNodeId),
       ];
       const result = await testBinUtils.pkStdio([...command]);
       expect(result.exitCode).toBe(0);

--- a/tests/client/GRPCClientClient.test.ts
+++ b/tests/client/GRPCClientClient.test.ts
@@ -14,6 +14,7 @@ import { errors as clientErrors } from '@/client';
 import config from '@/config';
 import * as binProcessors from '@/bin/utils/processors';
 import * as utilsPB from '@/proto/js/polykey/v1/utils/utils_pb';
+import { utils as nodesUtils } from '@/nodes';
 import * as testClientUtils from './utils';
 import * as testUtils from '../utils';
 
@@ -112,7 +113,9 @@ describe(GRPCClientClient.name, () => {
     const emptyMessage = new utilsPB.EmptyMessage();
     const response = await client.agentStatus(emptyMessage, meta);
     expect(typeof response.getPid()).toBe('number');
-    expect(response.getNodeId()).toBe(statusInfo.data.nodeId);
+    expect(response.getNodeId()).toBe(
+      nodesUtils.encodeNodeId(statusInfo.data.nodeId),
+    );
     expect(response.getClientHost()).toBe(statusInfo.data.clientHost);
     expect(response.getClientPort()).toBe(statusInfo.data.clientPort);
     expect(response.getIngressHost()).toBe(statusInfo.data.ingressHost);

--- a/tests/client/service/agentUnlock.test.ts
+++ b/tests/client/service/agentUnlock.test.ts
@@ -1,5 +1,4 @@
 import type { Host, Port } from '@/network/types';
-import type { NodeId } from '@/nodes/types';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import { Metadata } from '@grpc/grpc-js';
 import { GRPCServer } from '@/grpc';
@@ -10,6 +9,7 @@ import {
 } from '@/client';
 import agentUnlock from '@/client/service/agentUnlock';
 import * as utilsPB from '@/proto/js/polykey/v1/utils/utils_pb';
+import { utils as nodesUtils } from '@/nodes';
 
 describe('agentUnlock', () => {
   const logger = new Logger('agentUnlock test', LogLevel.WARN, [
@@ -33,7 +33,9 @@ describe('agentUnlock', () => {
       port: 0 as Port,
     });
     grpcClient = await GRPCClientClient.createGRPCClientClient({
-      nodeId: 'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg' as NodeId,
+      nodeId: nodesUtils.decodeNodeId(
+        'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
+      ),
       host: '127.0.0.1' as Host,
       port: grpcServer.port,
       logger,

--- a/tests/client/service/identitiesAuthenticate.test.ts
+++ b/tests/client/service/identitiesAuthenticate.test.ts
@@ -1,6 +1,5 @@
 import type { IdentityId, ProviderId } from '@/identities/types';
 import type { Host, Port } from '@/network/types';
-import type { NodeId } from '@/nodes/types';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -16,6 +15,7 @@ import {
 } from '@/client';
 import identitiesAuthenticate from '@/client/service/identitiesAuthenticate';
 import * as identitiesPB from '@/proto/js/polykey/v1/identities/identities_pb';
+import { utils as nodesUtils } from '@/nodes';
 import TestProvider from '../../identities/TestProvider';
 
 describe('identitiesAuthenticate', () => {
@@ -66,7 +66,9 @@ describe('identitiesAuthenticate', () => {
       port: 0 as Port,
     });
     grpcClient = await GRPCClientClient.createGRPCClientClient({
-      nodeId: 'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg' as NodeId,
+      nodeId: nodesUtils.decodeNodeId(
+        'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
+      ),
       host: '127.0.0.1' as Host,
       port: grpcServer.port,
       logger,

--- a/tests/client/service/identitiesClaim.test.ts
+++ b/tests/client/service/identitiesClaim.test.ts
@@ -1,7 +1,7 @@
 import type { Host, Port } from '@/network/types';
-import type { NodeId } from '@/nodes/types';
 import type { IdentityId, ProviderId } from '@/identities/types';
 import type { ClaimLinkIdentity } from '@/claims/types';
+import type { NodeIdEncoded } from '@/nodes/types';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -42,7 +42,7 @@ describe('identitiesClaim', () => {
   };
   const claimData: ClaimLinkIdentity = {
     type: 'identity',
-    node: 'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg' as NodeId,
+    node: 'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg' as NodeIdEncoded,
     provider: testToken.providerId,
     identity: testToken.identityId,
   };

--- a/tests/client/service/identitiesInfoGet.test.ts
+++ b/tests/client/service/identitiesInfoGet.test.ts
@@ -1,6 +1,5 @@
 import type { IdentityId, ProviderId } from '@/identities/types';
 import type { Host, Port } from '@/network/types';
-import type { NodeId } from '@/nodes/types';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -16,6 +15,7 @@ import {
 } from '@/client';
 import identitiesInfoGet from '@/client/service/identitiesInfoGet';
 import * as identitiesPB from '@/proto/js/polykey/v1/identities/identities_pb';
+import { utils as nodesUtils } from '@/nodes';
 import TestProvider from '../../identities/TestProvider';
 
 describe('identitiesInfoGet', () => {
@@ -75,7 +75,9 @@ describe('identitiesInfoGet', () => {
       port: 0 as Port,
     });
     grpcClient = await GRPCClientClient.createGRPCClientClient({
-      nodeId: 'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg' as NodeId,
+      nodeId: nodesUtils.decodeNodeId(
+        'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
+      ),
       host: '127.0.0.1' as Host,
       port: grpcServer.port,
       logger,

--- a/tests/client/service/identitiesInfoGetConnected.test.ts
+++ b/tests/client/service/identitiesInfoGetConnected.test.ts
@@ -1,6 +1,5 @@
 import type { IdentityData, IdentityId, ProviderId } from '@/identities/types';
 import type { Host, Port } from '@/network/types';
-import type { NodeId } from '@/nodes/types';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -16,6 +15,7 @@ import {
 } from '@/client';
 import identitiesInfoGetConnected from '@/client/service/identitiesInfoGetConnected';
 import * as identitiesPB from '@/proto/js/polykey/v1/identities/identities_pb';
+import { utils as nodesUtils } from '@/nodes';
 import TestProvider from '../../identities/TestProvider';
 
 describe('identitiesInfoGetConnected', () => {
@@ -93,7 +93,9 @@ describe('identitiesInfoGetConnected', () => {
       port: 0 as Port,
     });
     grpcClient = await GRPCClientClient.createGRPCClientClient({
-      nodeId: 'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg' as NodeId,
+      nodeId: nodesUtils.decodeNodeId(
+        'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
+      ),
       host: '127.0.0.1' as Host,
       port: grpcServer.port,
       logger,

--- a/tests/client/service/identitiesProvidersList.test.ts
+++ b/tests/client/service/identitiesProvidersList.test.ts
@@ -1,5 +1,4 @@
 import type { Host, Port } from '@/network/types';
-import type { NodeId } from '@/nodes/types';
 import type { ProviderId } from '@/identities/types';
 import fs from 'fs';
 import path from 'path';
@@ -17,6 +16,7 @@ import {
 import identitiesProvidersList from '@/client/service/identitiesProvidersList';
 import * as identitiesPB from '@/proto/js/polykey/v1/identities/identities_pb';
 import * as utilsPB from '@/proto/js/polykey/v1/utils/utils_pb';
+import { utils as nodesUtils } from '@/nodes';
 import TestProvider from '../../identities/TestProvider';
 
 describe('identitiesProvidersList', () => {
@@ -71,7 +71,9 @@ describe('identitiesProvidersList', () => {
       port: 0 as Port,
     });
     grpcClient = await GRPCClientClient.createGRPCClientClient({
-      nodeId: 'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg' as NodeId,
+      nodeId: nodesUtils.decodeNodeId(
+        'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
+      ),
       host: '127.0.0.1' as Host,
       port: grpcServer.port,
       logger,

--- a/tests/client/service/identitiesTokenDelete.test.ts
+++ b/tests/client/service/identitiesTokenDelete.test.ts
@@ -1,5 +1,4 @@
 import type { Host, Port } from '@/network/types';
-import type { NodeId } from '@/nodes/types';
 import type { IdentityId, ProviderId } from '@/identities/types';
 import fs from 'fs';
 import path from 'path';
@@ -17,6 +16,7 @@ import {
 import identitiesTokenDelete from '@/client/service/identitiesTokenDelete';
 import * as identitiesPB from '@/proto/js/polykey/v1/identities/identities_pb';
 import * as utilsPB from '@/proto/js/polykey/v1/utils/utils_pb';
+import { utils as nodesUtils } from '@/nodes';
 import TestProvider from '../../identities/TestProvider';
 
 describe('identitiesTokenDelete', () => {
@@ -65,7 +65,9 @@ describe('identitiesTokenDelete', () => {
       port: 0 as Port,
     });
     grpcClient = await GRPCClientClient.createGRPCClientClient({
-      nodeId: 'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg' as NodeId,
+      nodeId: nodesUtils.decodeNodeId(
+        'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
+      ),
       host: '127.0.0.1' as Host,
       port: grpcServer.port,
       logger,

--- a/tests/client/service/identitiesTokenGet.test.ts
+++ b/tests/client/service/identitiesTokenGet.test.ts
@@ -1,5 +1,4 @@
 import type { Host, Port } from '@/network/types';
-import type { NodeId } from '@/nodes/types';
 import type { IdentityId, ProviderId } from '@/identities/types';
 import fs from 'fs';
 import path from 'path';
@@ -16,6 +15,7 @@ import {
 } from '@/client';
 import identitiesTokenGet from '@/client/service/identitiesTokenGet';
 import * as identitiesPB from '@/proto/js/polykey/v1/identities/identities_pb';
+import { utils as nodesUtils } from '@/nodes';
 import TestProvider from '../../identities/TestProvider';
 
 describe('identitiesTokenGet', () => {
@@ -64,7 +64,9 @@ describe('identitiesTokenGet', () => {
       port: 0 as Port,
     });
     grpcClient = await GRPCClientClient.createGRPCClientClient({
-      nodeId: 'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg' as NodeId,
+      nodeId: nodesUtils.decodeNodeId(
+        'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
+      ),
       host: '127.0.0.1' as Host,
       port: grpcServer.port,
       logger,

--- a/tests/client/service/identitiesTokenPut.test.ts
+++ b/tests/client/service/identitiesTokenPut.test.ts
@@ -1,5 +1,4 @@
 import type { Host, Port } from '@/network/types';
-import type { NodeId } from '@/nodes/types';
 import type { IdentityId, ProviderId } from '@/identities/types';
 import fs from 'fs';
 import path from 'path';
@@ -17,6 +16,7 @@ import {
 import identitiesTokenPut from '@/client/service/identitiesTokenPut';
 import * as identitiesPB from '@/proto/js/polykey/v1/identities/identities_pb';
 import * as utilsPB from '@/proto/js/polykey/v1/utils/utils_pb';
+import { utils as nodesUtils } from '@/nodes';
 import TestProvider from '../../identities/TestProvider';
 
 describe('identitiesTokenPut', () => {
@@ -65,7 +65,9 @@ describe('identitiesTokenPut', () => {
       port: 0 as Port,
     });
     grpcClient = await GRPCClientClient.createGRPCClientClient({
-      nodeId: 'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg' as NodeId,
+      nodeId: nodesUtils.decodeNodeId(
+        'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
+      ),
       host: '127.0.0.1' as Host,
       port: grpcServer.port,
       logger,

--- a/tests/client/service/keysKeyPairRenew.test.ts
+++ b/tests/client/service/keysKeyPairRenew.test.ts
@@ -120,7 +120,7 @@ describe('keysKeyPairRenew', () => {
     expect(fwdTLSConfig1).toEqual(expectedTLSConfig1);
     expect(revTLSConfig1).toEqual(expectedTLSConfig1);
     expect(serverTLSConfig1).toEqual(expectedTLSConfig1);
-    expect(nodeId1).toBe(nodeIdStatus1);
+    expect(nodeId1.equals(nodeIdStatus1)).toBe(true);
     // Run command
     const request = new keysPB.Key();
     request.setName('somepassphrase');
@@ -150,6 +150,6 @@ describe('keysKeyPairRenew', () => {
     expect(rootKeyPair2.publicKey).not.toBe(rootKeyPair1.publicKey);
     expect(nodeId1).not.toBe(nodeId2);
     expect(nodeIdStatus1).not.toBe(nodeIdStatus2);
-    expect(nodeId2).toBe(nodeIdStatus2);
+    expect(nodeId2.equals(nodeIdStatus2)).toBe(true);
   });
 });

--- a/tests/client/service/keysKeyPairReset.test.ts
+++ b/tests/client/service/keysKeyPairReset.test.ts
@@ -120,7 +120,7 @@ describe('keysKeyPairReset', () => {
     expect(fwdTLSConfig1).toEqual(expectedTLSConfig1);
     expect(revTLSConfig1).toEqual(expectedTLSConfig1);
     expect(serverTLSConfig1).toEqual(expectedTLSConfig1);
-    expect(nodeId1).toBe(nodeIdStatus1);
+    expect(nodeId1.equals(nodeIdStatus1)).toBe(true);
     // Run command
     const request = new keysPB.Key();
     request.setName('somepassphrase');
@@ -150,6 +150,6 @@ describe('keysKeyPairReset', () => {
     expect(rootKeyPair2.publicKey).not.toBe(rootKeyPair1.publicKey);
     expect(nodeId1).not.toBe(nodeId2);
     expect(nodeIdStatus1).not.toBe(nodeIdStatus2);
-    expect(nodeId2).toBe(nodeIdStatus2);
+    expect(nodeId2.equals(nodeIdStatus2)).toBe(true);
   });
 });

--- a/tests/client/service/nodesAdd.test.ts
+++ b/tests/client/service/nodesAdd.test.ts
@@ -1,5 +1,4 @@
 import type { Host, Port } from '@/network/types';
-import type { NodeId } from '@/nodes/types';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -19,6 +18,7 @@ import {
 import nodesAdd from '@/client/service/nodesAdd';
 import * as nodesPB from '@/proto/js/polykey/v1/nodes/nodes_pb';
 import * as utilsPB from '@/proto/js/polykey/v1/utils/utils_pb';
+import { utils as nodesUtils } from '@/nodes';
 import * as testUtils from '../../utils';
 
 describe('nodesAdd', () => {
@@ -147,7 +147,9 @@ describe('nodesAdd', () => {
     );
     expect(response).toBeInstanceOf(utilsPB.EmptyMessage);
     const result = await nodeManager.getNode(
-      'vrsc24a1er424epq77dtoveo93meij0pc8ig4uvs9jbeld78n9nl0' as NodeId,
+      nodesUtils.decodeNodeId(
+        'vrsc24a1er424epq77dtoveo93meij0pc8ig4uvs9jbeld78n9nl0',
+      ),
     );
     expect(result).toBeDefined();
     expect(result!.host).toBe('127.0.0.1');

--- a/tests/client/service/nodesClaim.test.ts
+++ b/tests/client/service/nodesClaim.test.ts
@@ -1,6 +1,6 @@
 import type { Host, Port } from '@/network/types';
-import type { NodeId } from '@/nodes/types';
 import type { Notification } from '@/notifications/types';
+import type { NodeIdEncoded } from '@/nodes/types';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -35,7 +35,8 @@ describe('nodesClaim', () => {
     data: {
       type: 'GestaltInvite',
     },
-    senderId: 'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg' as NodeId,
+    senderId:
+      'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg' as NodeIdEncoded,
     isRead: false,
   };
   let mockedGenerateKeyPair: jest.SpyInstance;

--- a/tests/client/service/notificationsRead.test.ts
+++ b/tests/client/service/notificationsRead.test.ts
@@ -1,5 +1,4 @@
 import type { Host, Port } from '@/network/types';
-import type { NodeId } from '@/nodes/types';
 import type { VaultName } from '@/vaults/types';
 import fs from 'fs';
 import path from 'path';
@@ -9,7 +8,7 @@ import { Metadata } from '@grpc/grpc-js';
 import { DB } from '@matrixai/db';
 import { KeyManager, utils as keysUtils } from '@/keys';
 import { GRPCServer } from '@/grpc';
-import { NodeManager } from '@/nodes';
+import { NodeManager, utils as nodesUtils } from '@/nodes';
 import { Sigchain } from '@/sigchain';
 import { ForwardProxy, ReverseProxy } from '@/network';
 import { NotificationsManager } from '@/notifications';
@@ -27,6 +26,8 @@ describe('notificationsRead', () => {
   const logger = new Logger('notificationsRead test', LogLevel.WARN, [
     new StreamHandler(),
   ]);
+  const nodeIdSender = testUtils.generateRandomNodeId();
+  const nodeIdSenderEncoded = nodesUtils.encodeNodeId(nodeIdSender);
   const password = 'helloworld';
   const authenticate = async (metaClient, metaServer = new Metadata()) =>
     metaServer;
@@ -49,7 +50,7 @@ describe('notificationsRead', () => {
             type: 'General',
             message: 'test',
           },
-          senderId: 'sender' as NodeId,
+          senderId: nodeIdSenderEncoded,
           isRead: true,
         },
       ])
@@ -59,7 +60,7 @@ describe('notificationsRead', () => {
             type: 'General',
             message: 'test1',
           },
-          senderId: 'sender' as NodeId,
+          senderId: nodeIdSenderEncoded,
           isRead: true,
         },
         {
@@ -67,7 +68,7 @@ describe('notificationsRead', () => {
             type: 'General',
             message: 'test2',
           },
-          senderId: 'sender' as NodeId,
+          senderId: nodeIdSenderEncoded,
           isRead: true,
         },
       ])
@@ -77,7 +78,7 @@ describe('notificationsRead', () => {
             type: 'General',
             message: 'test2',
           },
-          senderId: 'sender' as NodeId,
+          senderId: nodeIdSenderEncoded,
           isRead: true,
         },
         {
@@ -85,7 +86,7 @@ describe('notificationsRead', () => {
             type: 'General',
             message: 'test1',
           },
-          senderId: 'sender' as NodeId,
+          senderId: nodeIdSenderEncoded,
           isRead: true,
         },
       ])
@@ -94,7 +95,7 @@ describe('notificationsRead', () => {
           data: {
             type: 'GestaltInvite',
           },
-          senderId: 'sender' as NodeId,
+          senderId: nodeIdSenderEncoded,
           isRead: true,
         },
       ])
@@ -109,7 +110,7 @@ describe('notificationsRead', () => {
               pull: null,
             },
           },
-          senderId: 'sender' as NodeId,
+          senderId: nodeIdSenderEncoded,
           isRead: true,
         },
       ])
@@ -240,7 +241,7 @@ describe('notificationsRead', () => {
     expect(output).toHaveLength(1);
     expect(output[0].hasGeneral()).toBeTruthy();
     expect(output[0].getGeneral()!.getMessage()).toBe('test');
-    expect(output[0].getSenderId()).toBe('sender');
+    expect(output[0].getSenderId()).toBe(nodeIdSenderEncoded);
     expect(output[0].getIsRead()).toBeTruthy();
     // Check request was parsed correctly
     expect(mockedReadNotifications.mock.calls[0][0].unread).toBeFalsy();
@@ -261,11 +262,11 @@ describe('notificationsRead', () => {
     expect(output).toHaveLength(2);
     expect(output[0].hasGeneral()).toBeTruthy();
     expect(output[0].getGeneral()!.getMessage()).toBe('test1');
-    expect(output[0].getSenderId()).toBe('sender');
+    expect(output[0].getSenderId()).toBe(nodeIdSenderEncoded);
     expect(output[0].getIsRead()).toBeTruthy();
     expect(output[1].hasGeneral()).toBeTruthy();
     expect(output[1].getGeneral()!.getMessage()).toBe('test2');
-    expect(output[1].getSenderId()).toBe('sender');
+    expect(output[1].getSenderId()).toBe(nodeIdSenderEncoded);
     expect(output[1].getIsRead()).toBeTruthy();
     // Check request was parsed correctly
     expect(mockedReadNotifications.mock.calls[1][0].unread).toBeTruthy();
@@ -286,11 +287,11 @@ describe('notificationsRead', () => {
     expect(output).toHaveLength(2);
     expect(output[0].hasGeneral()).toBeTruthy();
     expect(output[0].getGeneral()!.getMessage()).toBe('test2');
-    expect(output[0].getSenderId()).toBe('sender');
+    expect(output[0].getSenderId()).toBe(nodeIdSenderEncoded);
     expect(output[0].getIsRead()).toBeTruthy();
     expect(output[1].hasGeneral()).toBeTruthy();
     expect(output[1].getGeneral()!.getMessage()).toBe('test1');
-    expect(output[1].getSenderId()).toBe('sender');
+    expect(output[1].getSenderId()).toBe(nodeIdSenderEncoded);
     expect(output[1].getIsRead()).toBeTruthy();
     // Check request was parsed correctly
     expect(mockedReadNotifications.mock.calls[2][0].unread).toBeFalsy();
@@ -311,7 +312,7 @@ describe('notificationsRead', () => {
     expect(output).toHaveLength(1);
     expect(output[0].hasGestaltInvite()).toBeTruthy();
     expect(output[0].getGestaltInvite()).toBe('GestaltInvite');
-    expect(output[0].getSenderId()).toBe('sender');
+    expect(output[0].getSenderId()).toBe(nodeIdSenderEncoded);
     expect(output[0].getIsRead()).toBeTruthy();
     // Check request was parsed correctly
     expect(mockedReadNotifications.mock.calls[3][0].unread).toBeFalsy();
@@ -335,7 +336,7 @@ describe('notificationsRead', () => {
     expect(output[0].getVaultShare()!.getVaultName()).toBe('vault');
     expect(output[0].getVaultShare()!.getActionsList()).toContain('clone');
     expect(output[0].getVaultShare()!.getActionsList()).toContain('pull');
-    expect(output[0].getSenderId()).toBe('sender');
+    expect(output[0].getSenderId()).toBe(nodeIdSenderEncoded);
     expect(output[0].getIsRead()).toBeTruthy();
     // Check request was parsed correctly
     expect(mockedReadNotifications.mock.calls[4][0].unread).toBeFalsy();

--- a/tests/client/service/notificationsSend.test.ts
+++ b/tests/client/service/notificationsSend.test.ts
@@ -8,7 +8,7 @@ import { Metadata } from '@grpc/grpc-js';
 import { DB } from '@matrixai/db';
 import { KeyManager, utils as keysUtils } from '@/keys';
 import { GRPCServer } from '@/grpc';
-import { NodeManager } from '@/nodes';
+import { NodeManager, utils as nodesUtils } from '@/nodes';
 import { Sigchain } from '@/sigchain';
 import { ForwardProxy, ReverseProxy } from '@/network';
 import {
@@ -182,9 +182,9 @@ describe('notificationsSend', () => {
     // Check we signed and sent the notification
     expect(mockedSignNotification.mock.calls.length).toBe(1);
     expect(mockedSendNotification.mock.calls.length).toBe(1);
-    expect(mockedSendNotification.mock.calls[0][0]).toBe(
-      'vrsc24a1er424epq77dtoveo93meij0pc8ig4uvs9jbeld78n9nl0',
-    );
+    expect(
+      nodesUtils.encodeNodeId(mockedSendNotification.mock.calls[0][0]),
+    ).toBe('vrsc24a1er424epq77dtoveo93meij0pc8ig4uvs9jbeld78n9nl0');
     expect(mockedSendNotification.mock.calls[0][1]).toBe('signedNotification');
     // Check notification content
     expect(mockedSignNotification.mock.calls[0][0]).toEqual({
@@ -192,7 +192,7 @@ describe('notificationsSend', () => {
         type: 'General',
         message: 'test',
       },
-      senderId: keyManager.getNodeId(),
+      senderId: nodesUtils.encodeNodeId(keyManager.getNodeId()),
       isRead: false,
     });
   });

--- a/tests/gestalts/GestaltGraph.test.ts
+++ b/tests/gestalts/GestaltGraph.test.ts
@@ -22,11 +22,22 @@ import {
 } from '@/gestalts';
 import { ACL } from '@/acl';
 import * as keysUtils from '@/keys/utils';
+import { utils as nodesUtils } from '@/nodes';
+import * as testUtils from '../utils';
 
 describe('GestaltGraph', () => {
   const logger = new Logger('GestaltGraph Test', LogLevel.WARN, [
     new StreamHandler(),
   ]);
+  const nodeIdABC = testUtils.generateRandomNodeId();
+  const nodeIdABCEncoded = nodesUtils.encodeNodeId(nodeIdABC);
+  const nodeIdDEE = testUtils.generateRandomNodeId();
+  const nodeIdDEEEncoded = nodesUtils.encodeNodeId(nodeIdDEE);
+  const nodeIdDEF = testUtils.generateRandomNodeId();
+  const nodeIdDEFEncoded = nodesUtils.encodeNodeId(nodeIdDEF);
+  const nodeIdZZZ = testUtils.generateRandomNodeId();
+  const nodeIdZZZEncoded = nodesUtils.encodeNodeId(nodeIdZZZ);
+
   let dataDir: string;
   let db: DB;
   let acl: ACL;
@@ -68,8 +79,8 @@ describe('GestaltGraph', () => {
         seq: 1,
         data: {
           type: 'node',
-          node1: 'abc' as NodeId,
-          node2: 'dee' as NodeId,
+          node1: nodeIdABCEncoded,
+          node2: nodeIdDEEEncoded,
         },
         iat: 1618203162,
       },
@@ -82,8 +93,8 @@ describe('GestaltGraph', () => {
         seq: 1,
         data: {
           type: 'node',
-          node1: 'dee' as NodeId, // TODO: use type guards for all `as NodeID` usages here.
-          node2: 'abc' as NodeId,
+          node1: nodeIdDEEEncoded, // TODO: use type guards for all `as NodeID` usages here.
+          node2: nodeIdABCEncoded,
         },
         iat: 1618203162,
       },
@@ -98,7 +109,7 @@ describe('GestaltGraph', () => {
         seq: 1,
         data: {
           type: 'identity',
-          node: 'abc' as NodeId,
+          node: nodeIdABCEncoded,
           provider: 'github.com' as ProviderId,
           identity: 'abc' as IdentityId,
         },
@@ -114,7 +125,7 @@ describe('GestaltGraph', () => {
         seq: 1,
         data: {
           type: 'identity',
-          node: 'abc' as NodeId,
+          node: nodeIdABCEncoded,
           provider: 'github.com' as ProviderId,
           identity: 'abc' as IdentityId,
         },
@@ -161,21 +172,26 @@ describe('GestaltGraph', () => {
       logger,
     });
     const nodeInfo: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: {},
     };
     await gestaltGraph.setNode(nodeInfo);
-    const gestalt = await gestaltGraph.getGestaltByNode(nodeInfo.id);
-    const gk = gestaltsUtils.keyFromNode(nodeInfo.id);
+    const gestalt = await gestaltGraph.getGestaltByNode(nodeIdABC);
+    const gk = gestaltsUtils.keyFromNode(nodeIdABC);
     expect(gestalt).toStrictEqual({
       matrix: { [gk]: {} },
-      nodes: { [gk]: nodeInfo },
+      nodes: {
+        [gk]: {
+          id: nodesUtils.encodeNodeId(nodeIdABC),
+          chain: nodeInfo.chain,
+        },
+      },
       identities: {},
     });
-    await gestaltGraph.unsetNode(nodeInfo.id);
-    await gestaltGraph.unsetNode(nodeInfo.id);
+    await gestaltGraph.unsetNode(nodeIdABC);
+    await gestaltGraph.unsetNode(nodeIdABC);
     await expect(
-      gestaltGraph.getGestaltByNode(nodeInfo.id),
+      gestaltGraph.getGestaltByNode(nodeIdABC),
     ).resolves.toBeUndefined();
     await gestaltGraph.stop();
     await gestaltGraph.destroy();
@@ -229,7 +245,7 @@ describe('GestaltGraph', () => {
       logger,
     });
     const nodeInfo: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: {},
     };
     const identityInfo: IdentityInfo = {
@@ -239,19 +255,24 @@ describe('GestaltGraph', () => {
     };
     await gestaltGraph.setNode(nodeInfo);
     await gestaltGraph.setIdentity(identityInfo);
-    const gestaltNode = await gestaltGraph.getGestaltByNode(nodeInfo.id);
+    const gestaltNode = await gestaltGraph.getGestaltByNode(nodeIdABC);
     const gestaltIdentity = await gestaltGraph.getGestaltByIdentity(
       identityInfo.providerId,
       identityInfo.identityId,
     );
-    const gkNode = gestaltsUtils.keyFromNode(nodeInfo.id);
+    const gkNode = gestaltsUtils.keyFromNode(nodeIdABC);
     const gkIdentity = gestaltsUtils.keyFromIdentity(
       identityInfo.providerId,
       identityInfo.identityId,
     );
     expect(gestaltNode).toStrictEqual({
       matrix: { [gkNode]: {} },
-      nodes: { [gkNode]: nodeInfo },
+      nodes: {
+        [gkNode]: {
+          id: nodesUtils.encodeNodeId(nodeIdABC),
+          chain: nodeInfo.chain,
+        },
+      },
       identities: {},
     });
     expect(gestaltIdentity).toStrictEqual({
@@ -269,7 +290,7 @@ describe('GestaltGraph', () => {
       logger,
     });
     const nodeInfo: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: {},
     };
     const identityInfo: IdentityInfo = {
@@ -286,19 +307,24 @@ describe('GestaltGraph', () => {
       acl,
       logger,
     });
-    const gestaltNode = await gestaltGraph.getGestaltByNode(nodeInfo.id);
+    const gestaltNode = await gestaltGraph.getGestaltByNode(nodeIdABC);
     const gestaltIdentity = await gestaltGraph.getGestaltByIdentity(
       identityInfo.providerId,
       identityInfo.identityId,
     );
-    const gkNode = gestaltsUtils.keyFromNode(nodeInfo.id);
+    const gkNode = gestaltsUtils.keyFromNode(nodeIdABC);
     const gkIdentity = gestaltsUtils.keyFromIdentity(
       identityInfo.providerId,
       identityInfo.identityId,
     );
     expect(gestaltNode).toStrictEqual({
       matrix: { [gkNode]: {} },
-      nodes: { [gkNode]: nodeInfo },
+      nodes: {
+        [gkNode]: {
+          id: nodesUtils.encodeNodeId(nodeIdABC),
+          chain: nodeInfo.chain,
+        },
+      },
       identities: {},
     });
     expect(gestaltIdentity).toStrictEqual({
@@ -320,7 +346,7 @@ describe('GestaltGraph', () => {
     const nodeInfo1Chain: ChainData = {};
     nodeInfo1Chain['A'] = nodeClaimAbcToDee;
     const nodeInfo1: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: nodeInfo1Chain,
     };
     // NodeInfo on node 'dee'. Contains claims:
@@ -328,17 +354,17 @@ describe('GestaltGraph', () => {
     const nodeInfo2Chain: ChainData = {};
     nodeInfo2Chain['A'] = nodeClaimDeeToAbc;
     const nodeInfo2: NodeInfo = {
-      id: 'dee' as NodeId,
+      id: nodeIdDEEEncoded,
       chain: nodeInfo2Chain,
     };
     await gestaltGraph.linkNodeAndNode(nodeInfo1, nodeInfo2);
-    const gestaltNode1 = await gestaltGraph.getGestaltByNode(nodeInfo1.id);
-    const gestaltNode2 = await gestaltGraph.getGestaltByNode(nodeInfo2.id);
+    const gestaltNode1 = await gestaltGraph.getGestaltByNode(nodeIdABC);
+    const gestaltNode2 = await gestaltGraph.getGestaltByNode(nodeIdDEE);
     expect(gestaltNode1).not.toBeUndefined();
     expect(gestaltNode2).not.toBeUndefined();
     expect(gestaltNode1).toStrictEqual(gestaltNode2);
-    const gkNode1 = gestaltsUtils.keyFromNode(nodeInfo1.id);
-    const gkNode2 = gestaltsUtils.keyFromNode(nodeInfo2.id);
+    const gkNode1 = gestaltsUtils.keyFromNode(nodeIdABC);
+    const gkNode2 = gestaltsUtils.keyFromNode(nodeIdDEE);
     expect(gestaltNode1).toStrictEqual({
       matrix: {
         [gkNode1]: {
@@ -349,8 +375,14 @@ describe('GestaltGraph', () => {
         },
       },
       nodes: {
-        [gkNode1]: nodeInfo1,
-        [gkNode2]: nodeInfo2,
+        [gkNode1]: {
+          id: nodesUtils.encodeNodeId(nodeIdABC),
+          chain: nodeInfo1.chain,
+        },
+        [gkNode2]: {
+          id: nodesUtils.encodeNodeId(nodeIdDEE),
+          chain: nodeInfo2.chain,
+        },
       },
       identities: {},
     });
@@ -368,7 +400,7 @@ describe('GestaltGraph', () => {
     const nodeInfo1Chain: ChainData = {};
     nodeInfo1Chain['A'] = identityClaimAbcToGH;
     const nodeInfo: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: nodeInfo1Chain,
     };
     // IdentityInfo on identity from GitHub. Contains claims:
@@ -381,14 +413,14 @@ describe('GestaltGraph', () => {
       claims: identityInfoClaims,
     };
     await gestaltGraph.linkNodeAndIdentity(nodeInfo, identityInfo);
-    const gestaltNode = await gestaltGraph.getGestaltByNode(nodeInfo.id);
+    const gestaltNode = await gestaltGraph.getGestaltByNode(nodeIdABC);
     const gestaltIdentity = await gestaltGraph.getGestaltByIdentity(
       identityInfo.providerId,
       identityInfo.identityId,
     );
     expect(gestaltNode).not.toBeUndefined();
     expect(gestaltNode).toStrictEqual(gestaltIdentity);
-    const gkNode = gestaltsUtils.keyFromNode(nodeInfo.id);
+    const gkNode = gestaltsUtils.keyFromNode(nodeIdABC);
     const gkIdentity = gestaltsUtils.keyFromIdentity(
       identityInfo.providerId,
       identityInfo.identityId,
@@ -403,7 +435,10 @@ describe('GestaltGraph', () => {
         },
       },
       nodes: {
-        [gkNode]: nodeInfo,
+        [gkNode]: {
+          id: nodesUtils.encodeNodeId(nodeIdABC),
+          chain: nodeInfo.chain,
+        },
       },
       identities: {
         [gkIdentity]: identityInfo,
@@ -426,7 +461,7 @@ describe('GestaltGraph', () => {
     identityClaimAbcToGH.payload.seq = 2;
     nodeInfo1Chain['B'] = identityClaimAbcToGH;
     const nodeInfo1: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: nodeInfo1Chain,
     };
     // NodeInfo on node 'dee'. Contains claims:
@@ -434,7 +469,7 @@ describe('GestaltGraph', () => {
     const nodeInfo2Chain: ChainData = {};
     nodeInfo2Chain['A'] = nodeClaimDeeToAbc;
     const nodeInfo2: NodeInfo = {
-      id: 'dee' as NodeId,
+      id: nodeIdDEEEncoded,
       chain: nodeInfo2Chain,
     };
     // IdentityInfo on identity from GitHub. Contains claims:
@@ -448,8 +483,8 @@ describe('GestaltGraph', () => {
     };
     await gestaltGraph.linkNodeAndIdentity(nodeInfo1, identityInfo);
     await gestaltGraph.linkNodeAndNode(nodeInfo1, nodeInfo2);
-    const gestaltNode1 = await gestaltGraph.getGestaltByNode(nodeInfo1.id);
-    const gestaltNode2 = await gestaltGraph.getGestaltByNode(nodeInfo2.id);
+    const gestaltNode1 = await gestaltGraph.getGestaltByNode(nodeIdABC);
+    const gestaltNode2 = await gestaltGraph.getGestaltByNode(nodeIdDEE);
     const gestaltIdentity = await gestaltGraph.getGestaltByIdentity(
       identityInfo.providerId,
       identityInfo.identityId,
@@ -459,8 +494,8 @@ describe('GestaltGraph', () => {
     expect(gestaltIdentity).not.toBeUndefined();
     expect(gestaltNode1).toStrictEqual(gestaltNode2);
     expect(gestaltNode2).toStrictEqual(gestaltIdentity);
-    const gkNode1 = gestaltsUtils.keyFromNode(nodeInfo1.id);
-    const gkNode2 = gestaltsUtils.keyFromNode(nodeInfo2.id);
+    const gkNode1 = gestaltsUtils.keyFromNode(nodeIdABC);
+    const gkNode2 = gestaltsUtils.keyFromNode(nodeIdDEE);
     const gkIdentity = gestaltsUtils.keyFromIdentity(
       identityInfo.providerId,
       identityInfo.identityId,
@@ -479,8 +514,14 @@ describe('GestaltGraph', () => {
         },
       },
       nodes: {
-        [gkNode1]: nodeInfo1,
-        [gkNode2]: nodeInfo2,
+        [gkNode1]: {
+          id: nodesUtils.encodeNodeId(nodeIdABC),
+          chain: nodeInfo1.chain,
+        },
+        [gkNode2]: {
+          id: nodesUtils.encodeNodeId(nodeIdDEE),
+          chain: nodeInfo2.chain,
+        },
       },
       identities: {
         [gkIdentity]: identityInfo,
@@ -496,7 +537,7 @@ describe('GestaltGraph', () => {
       logger,
     });
     const nodeInfo: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: {},
     };
     await gestaltGraph.setNode(nodeInfo);
@@ -511,7 +552,7 @@ describe('GestaltGraph', () => {
       identityInfo.providerId,
       identityInfo.identityId,
     );
-    const nodeGestalt = await gestaltGraph.getGestaltByNode(nodeInfo.id);
+    const nodeGestalt = await gestaltGraph.getGestaltByNode(nodeIdABC);
     expect(gestalts).toContainEqual(identityGestalt);
     expect(gestalts).toContainEqual(nodeGestalt);
     expect(gestalts).toHaveLength(2);
@@ -535,18 +576,18 @@ describe('GestaltGraph', () => {
       logger,
     });
     const nodeInfo: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: {},
     };
-    expect(await acl.getNodePerm(nodeInfo.id)).toBeUndefined();
+    expect(await acl.getNodePerm(nodeIdABC)).toBeUndefined();
     await gestaltGraph.setNode(nodeInfo);
-    const perm = await acl.getNodePerm(nodeInfo.id);
+    const perm = await acl.getNodePerm(nodeIdABC);
     expect(perm).toBeDefined();
     expect(perm).toMatchObject({
       gestalt: {},
       vaults: {},
     });
-    const actions = await gestaltGraph.getGestaltActionsByNode(nodeInfo.id);
+    const actions = await gestaltGraph.getGestaltActionsByNode(nodeIdABC);
     expect(actions).toBeDefined();
     expect(actions).toMatchObject({});
     await gestaltGraph.stop();
@@ -579,15 +620,15 @@ describe('GestaltGraph', () => {
       logger,
     });
     const nodeInfo: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: {},
     };
     await gestaltGraph.setNode(nodeInfo);
-    await gestaltGraph.setGestaltActionByNode(nodeInfo.id, 'notify');
+    await gestaltGraph.setGestaltActionByNode(nodeIdABC, 'notify');
     let actions;
-    actions = await gestaltGraph.getGestaltActionsByNode(nodeInfo.id);
+    actions = await gestaltGraph.getGestaltActionsByNode(nodeIdABC);
     expect(actions).toHaveProperty('notify');
-    const perm = await acl.getNodePerm(nodeInfo.id);
+    const perm = await acl.getNodePerm(nodeIdABC);
     expect(perm).toBeDefined();
     expect(perm).toMatchObject({
       gestalt: {
@@ -595,8 +636,8 @@ describe('GestaltGraph', () => {
       },
       vaults: {},
     });
-    await gestaltGraph.unsetGestaltActionByNode(nodeInfo.id, 'notify');
-    actions = await gestaltGraph.getGestaltActionsByNode(nodeInfo.id);
+    await gestaltGraph.unsetGestaltActionByNode(nodeIdABC, 'notify');
+    actions = await gestaltGraph.getGestaltActionsByNode(nodeIdABC);
     expect(actions).not.toHaveProperty('notify');
     await gestaltGraph.stop();
     await gestaltGraph.destroy();
@@ -613,7 +654,7 @@ describe('GestaltGraph', () => {
     const nodeInfo1Chain: ChainData = {};
     nodeInfo1Chain['A'] = nodeClaimAbcToDee;
     const nodeInfo1: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: nodeInfo1Chain,
     };
     // NodeInfo on node 'dee'. Contains claims:
@@ -621,19 +662,19 @@ describe('GestaltGraph', () => {
     const nodeInfo2Chain: ChainData = {};
     nodeInfo2Chain['A'] = nodeClaimDeeToAbc;
     const nodeInfo2: NodeInfo = {
-      id: 'dee' as NodeId,
+      id: nodeIdDEEEncoded,
       chain: nodeInfo2Chain,
     };
     await gestaltGraph.linkNodeAndNode(nodeInfo1, nodeInfo2);
     let actions1, actions2;
-    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeInfo1.id);
-    actions2 = await gestaltGraph.getGestaltActionsByNode(nodeInfo2.id);
+    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeIdABC);
+    actions2 = await gestaltGraph.getGestaltActionsByNode(nodeIdDEE);
     expect(actions1).not.toBeUndefined();
     expect(actions2).not.toBeUndefined();
     expect(actions1).toEqual(actions2);
-    await gestaltGraph.setGestaltActionByNode(nodeInfo1.id, 'notify');
-    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeInfo1.id);
-    actions2 = await gestaltGraph.getGestaltActionsByNode(nodeInfo2.id);
+    await gestaltGraph.setGestaltActionByNode(nodeIdABC, 'notify');
+    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeIdABC);
+    actions2 = await gestaltGraph.getGestaltActionsByNode(nodeIdDEE);
     expect(actions1).toEqual({ notify: null });
     expect(actions1).toEqual(actions2);
     await gestaltGraph.stop();
@@ -647,23 +688,23 @@ describe('GestaltGraph', () => {
     });
     // 2 existing nodes will have a joined permission
     const nodeInfo1: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: {},
     };
     const nodeInfo2: NodeInfo = {
-      id: 'dee' as NodeId,
+      id: nodeIdDEEEncoded,
       chain: {},
     };
     await gestaltGraph.setNode(nodeInfo1);
     await gestaltGraph.setNode(nodeInfo2);
-    await gestaltGraph.setGestaltActionByNode(nodeInfo1.id, 'notify');
-    await gestaltGraph.setGestaltActionByNode(nodeInfo2.id, 'scan');
+    await gestaltGraph.setGestaltActionByNode(nodeIdABC, 'notify');
+    await gestaltGraph.setGestaltActionByNode(nodeIdDEE, 'scan');
     // NodeInfo on node 'abc'. Contains claims:
     // abc -> dee
     const nodeInfo1Chain: ChainData = {};
     nodeInfo1Chain['A'] = nodeClaimAbcToDee;
     const nodeInfo1Linked: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: nodeInfo1Chain,
     };
     // NodeInfo on node 'dee'. Contains claims:
@@ -671,16 +712,12 @@ describe('GestaltGraph', () => {
     const nodeInfo2Chain: ChainData = {};
     nodeInfo2Chain['A'] = nodeClaimDeeToAbc;
     const nodeInfo2Linked: NodeInfo = {
-      id: 'dee' as NodeId,
+      id: nodeIdDEEEncoded,
       chain: nodeInfo2Chain,
     };
     await gestaltGraph.linkNodeAndNode(nodeInfo1Linked, nodeInfo2Linked);
-    const actions1 = await gestaltGraph.getGestaltActionsByNode(
-      nodeInfo1Linked.id,
-    );
-    const actions2 = await gestaltGraph.getGestaltActionsByNode(
-      nodeInfo2Linked.id,
-    );
+    const actions1 = await gestaltGraph.getGestaltActionsByNode(nodeIdABC);
+    const actions2 = await gestaltGraph.getGestaltActionsByNode(nodeIdDEE);
     expect(actions1).not.toBeUndefined();
     expect(actions2).not.toBeUndefined();
     expect(actions1).toEqual({ notify: null, scan: null });
@@ -696,17 +733,17 @@ describe('GestaltGraph', () => {
     });
     // Node 1 exists, but node 2 is new
     const nodeInfo1: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: {},
     };
     await gestaltGraph.setNode(nodeInfo1);
-    await gestaltGraph.setGestaltActionByNode(nodeInfo1.id, 'notify');
+    await gestaltGraph.setGestaltActionByNode(nodeIdABC, 'notify');
     // NodeInfo on node 'abc'. Contains claims:
     // abc -> dee
     const nodeInfo1Chain: ChainData = {};
     nodeInfo1Chain['A'] = nodeClaimAbcToDee;
     const nodeInfo1Linked: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: nodeInfo1Chain,
     };
     // NodeInfo on node 'dee'. Contains claims:
@@ -714,13 +751,13 @@ describe('GestaltGraph', () => {
     const nodeInfo2Chain: ChainData = {};
     nodeInfo2Chain['A'] = nodeClaimDeeToAbc;
     const nodeInfo2Linked: NodeInfo = {
-      id: 'dee' as NodeId,
+      id: nodeIdDEEEncoded,
       chain: nodeInfo2Chain,
     };
     await gestaltGraph.linkNodeAndNode(nodeInfo1Linked, nodeInfo2Linked);
     let actions1, actions2;
-    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeInfo1Linked.id);
-    actions2 = await gestaltGraph.getGestaltActionsByNode(nodeInfo2Linked.id);
+    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeIdABC);
+    actions2 = await gestaltGraph.getGestaltActionsByNode(nodeIdDEE);
     expect(actions1).not.toBeUndefined();
     expect(actions2).not.toBeUndefined();
     expect(actions1).toEqual({ notify: null });
@@ -736,8 +773,8 @@ describe('GestaltGraph', () => {
         seq: 1,
         data: {
           type: 'node',
-          node1: 'zzz' as NodeId,
-          node2: 'dee' as NodeId,
+          node1: nodeIdZZZEncoded,
+          node2: nodeIdDEEEncoded,
         },
         iat: 1618203162,
       },
@@ -748,15 +785,13 @@ describe('GestaltGraph', () => {
     const nodeInfo3Chain: ChainData = {};
     nodeInfo3Chain['A'] = nodeClaimZzzToDee;
     const nodeInfo3Linked: NodeInfo = {
-      id: 'zzz' as NodeId,
+      id: nodeIdZZZEncoded,
       chain: nodeInfo3Chain,
     };
     await gestaltGraph.linkNodeAndNode(nodeInfo3Linked, nodeInfo2Linked);
-    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeInfo1Linked.id);
-    actions2 = await gestaltGraph.getGestaltActionsByNode(nodeInfo2Linked.id);
-    const actions3 = await gestaltGraph.getGestaltActionsByNode(
-      nodeInfo3Linked.id,
-    );
+    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeIdABC);
+    actions2 = await gestaltGraph.getGestaltActionsByNode(nodeIdDEE);
+    const actions3 = await gestaltGraph.getGestaltActionsByNode(nodeIdZZZ);
     expect(actions1).not.toBeUndefined();
     expect(actions2).not.toBeUndefined();
     expect(actions3).not.toBeUndefined();
@@ -776,7 +811,7 @@ describe('GestaltGraph', () => {
     const nodeInfo1Chain: ChainData = {};
     nodeInfo1Chain['A'] = identityClaimAbcToGH;
     const nodeInfo: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: nodeInfo1Chain,
     };
     // IdentityInfo on identity from GitHub. Contains claims:
@@ -790,7 +825,7 @@ describe('GestaltGraph', () => {
     };
     await gestaltGraph.linkNodeAndIdentity(nodeInfo, identityInfo);
     let actions1, actions2;
-    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeInfo.id);
+    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeIdABC);
     actions2 = await gestaltGraph.getGestaltActionsByIdentity(
       identityInfo.providerId,
       identityInfo.identityId,
@@ -804,7 +839,7 @@ describe('GestaltGraph', () => {
       identityInfo.identityId,
       'notify',
     );
-    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeInfo.id);
+    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeIdABC);
     actions2 = await gestaltGraph.getGestaltActionsByIdentity(
       identityInfo.providerId,
       identityInfo.identityId,
@@ -821,7 +856,7 @@ describe('GestaltGraph', () => {
       logger,
     });
     const nodeInfo: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: {},
     };
     const identityInfo: IdentityInfo = {
@@ -831,13 +866,13 @@ describe('GestaltGraph', () => {
     };
     await gestaltGraph.setNode(nodeInfo);
     await gestaltGraph.setIdentity(identityInfo);
-    await gestaltGraph.setGestaltActionByNode(nodeInfo.id, 'notify');
+    await gestaltGraph.setGestaltActionByNode(nodeIdABC, 'notify');
     // NodeInfo on node 'abc'. Contains claims:
     // abc -> GitHub
     const nodeInfo1Chain: ChainData = {};
     nodeInfo1Chain['A'] = identityClaimAbcToGH;
     const nodeInfoLinked: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: nodeInfo1Chain,
     };
     // IdentityInfo on identity from GitHub. Contains claims:
@@ -851,7 +886,7 @@ describe('GestaltGraph', () => {
     };
     await gestaltGraph.linkNodeAndIdentity(nodeInfoLinked, identityInfoLinked);
     let actions1, actions2;
-    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeInfo.id);
+    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeIdABC);
     actions2 = await gestaltGraph.getGestaltActionsByIdentity(
       identityInfo.providerId,
       identityInfo.identityId,
@@ -861,7 +896,7 @@ describe('GestaltGraph', () => {
     expect(actions1).toEqual({ notify: null });
     expect(actions1).toEqual(actions2);
     const nodeInfo2: NodeInfo = {
-      id: 'def' as NodeId,
+      id: nodeIdDEFEncoded,
       chain: {},
     };
     await gestaltGraph.setNode(nodeInfo2);
@@ -875,7 +910,7 @@ describe('GestaltGraph', () => {
       identityInfo.identityId,
       'scan',
     );
-    await gestaltGraph.setGestaltActionByNode(nodeInfo2.id, 'notify');
+    await gestaltGraph.setGestaltActionByNode(nodeIdDEF, 'notify');
 
     const defSignature: Record<NodeId, SignatureData> = {};
     defSignature['def'] = 'defSignature';
@@ -886,7 +921,7 @@ describe('GestaltGraph', () => {
         seq: 1,
         data: {
           type: 'identity',
-          node: 'def' as NodeId,
+          node: nodeIdDEFEncoded,
           provider: 'github.com' as ProviderId,
           identity: 'abc' as IdentityId,
         },
@@ -899,7 +934,7 @@ describe('GestaltGraph', () => {
     const nodeInfo2Chain: ChainData = {};
     nodeInfo1Chain['A'] = identityClaimDefToGH;
     const nodeInfo2Linked: NodeInfo = {
-      id: 'def' as NodeId,
+      id: nodeIdDEFEncoded,
       chain: nodeInfo2Chain,
     };
 
@@ -911,7 +946,7 @@ describe('GestaltGraph', () => {
         seq: 2,
         data: {
           type: 'identity',
-          node: 'def' as NodeId,
+          node: nodeIdDEF,
           provider: 'github.com' as ProviderId,
           identity: 'abc' as IdentityId,
         },
@@ -934,12 +969,12 @@ describe('GestaltGraph', () => {
       nodeInfo2Linked,
       identityInfoLinkedAgain,
     );
-    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeInfo.id);
+    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeIdABC);
     actions2 = await gestaltGraph.getGestaltActionsByIdentity(
       identityInfo.providerId,
       identityInfo.identityId,
     );
-    const actions3 = await gestaltGraph.getGestaltActionsByNode(nodeInfo2.id);
+    const actions3 = await gestaltGraph.getGestaltActionsByNode(nodeIdDEF);
     expect(actions1).not.toBeUndefined();
     expect(actions2).not.toBeUndefined();
     expect(actions3).not.toBeUndefined();
@@ -956,7 +991,7 @@ describe('GestaltGraph', () => {
       logger,
     });
     const nodeInfo: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: {},
     };
     await gestaltGraph.setNode(nodeInfo);
@@ -965,7 +1000,7 @@ describe('GestaltGraph', () => {
     const nodeInfo1Chain: ChainData = {};
     nodeInfo1Chain['A'] = identityClaimAbcToGH;
     const nodeInfoLinked: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: nodeInfo1Chain,
     };
     // IdentityInfo on identity from GitHub. Contains claims:
@@ -979,7 +1014,7 @@ describe('GestaltGraph', () => {
     };
     await gestaltGraph.linkNodeAndIdentity(nodeInfoLinked, identityInfoLinked);
     let actions1, actions2;
-    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeInfo.id);
+    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeIdABC);
     actions2 = await gestaltGraph.getGestaltActionsByIdentity(
       identityInfoLinked.providerId,
       identityInfoLinked.identityId,
@@ -998,7 +1033,7 @@ describe('GestaltGraph', () => {
       identityInfoLinked.identityId,
       'notify',
     );
-    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeInfo.id);
+    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeIdABC);
     actions2 = await gestaltGraph.getGestaltActionsByIdentity(
       identityInfoLinked.providerId,
       identityInfoLinked.identityId,
@@ -1030,7 +1065,7 @@ describe('GestaltGraph', () => {
     const nodeInfo1Chain: ChainData = {};
     nodeInfo1Chain['A'] = identityClaimAbcToGH;
     const nodeInfoLinked: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: nodeInfo1Chain,
     };
     // IdentityInfo on identity from GitHub. Contains claims:
@@ -1044,7 +1079,7 @@ describe('GestaltGraph', () => {
     };
     await gestaltGraph.linkNodeAndIdentity(nodeInfoLinked, identityInfoLinked);
     let actions1, actions2;
-    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeInfoLinked.id);
+    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeIdABC);
     actions2 = await gestaltGraph.getGestaltActionsByIdentity(
       identityInfo.providerId,
       identityInfo.identityId,
@@ -1053,9 +1088,9 @@ describe('GestaltGraph', () => {
     expect(actions2).not.toBeUndefined();
     expect(actions1).toEqual(actions2);
     expect(actions1).toEqual({});
-    await gestaltGraph.setGestaltActionByNode(nodeInfoLinked.id, 'scan');
-    await gestaltGraph.setGestaltActionByNode(nodeInfoLinked.id, 'notify');
-    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeInfoLinked.id);
+    await gestaltGraph.setGestaltActionByNode(nodeIdABC, 'scan');
+    await gestaltGraph.setGestaltActionByNode(nodeIdABC, 'notify');
+    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeIdABC);
     actions2 = await gestaltGraph.getGestaltActionsByIdentity(
       identityInfo.providerId,
       identityInfo.identityId,
@@ -1081,7 +1116,7 @@ describe('GestaltGraph', () => {
     const nodeInfo1Chain: ChainData = {};
     nodeInfo1Chain['A'] = nodeClaimAbcToDee;
     const nodeInfo1: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: nodeInfo1Chain,
     };
     // NodeInfo on node 'dee'. Contains claims:
@@ -1089,33 +1124,33 @@ describe('GestaltGraph', () => {
     const nodeInfo2Chain: ChainData = {};
     nodeInfo2Chain['A'] = nodeClaimDeeToAbc;
     const nodeInfo2: NodeInfo = {
-      id: 'dee' as NodeId,
+      id: nodeIdDEEEncoded,
       chain: nodeInfo2Chain,
     };
     await gestaltGraph.linkNodeAndNode(nodeInfo1, nodeInfo2);
-    await gestaltGraph.setGestaltActionByNode(nodeInfo1.id, 'scan');
-    await gestaltGraph.setGestaltActionByNode(nodeInfo1.id, 'notify');
+    await gestaltGraph.setGestaltActionByNode(nodeIdABC, 'scan');
+    await gestaltGraph.setGestaltActionByNode(nodeIdABC, 'notify');
     let nodePerms;
     nodePerms = await acl.getNodePerms();
     expect(Object.keys(nodePerms)).toHaveLength(1);
-    await gestaltGraph.unlinkNodeAndNode(nodeInfo1.id, nodeInfo2.id);
+    await gestaltGraph.unlinkNodeAndNode(nodeIdABC, nodeIdDEE);
     let actions1, actions2;
     let perm1, perm2;
-    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeInfo1.id);
-    actions2 = await gestaltGraph.getGestaltActionsByNode(nodeInfo2.id);
+    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeIdABC);
+    actions2 = await gestaltGraph.getGestaltActionsByNode(nodeIdDEE);
     expect(actions1).toEqual({ scan: null, notify: null });
     expect(actions2).toEqual({ scan: null, notify: null });
-    perm1 = await acl.getNodePerm(nodeInfo1.id);
-    perm2 = await acl.getNodePerm(nodeInfo2.id);
+    perm1 = await acl.getNodePerm(nodeIdABC);
+    perm2 = await acl.getNodePerm(nodeIdDEE);
     expect(perm1).toEqual(perm2);
-    await gestaltGraph.unsetGestaltActionByNode(nodeInfo1.id, 'notify');
-    await gestaltGraph.unsetGestaltActionByNode(nodeInfo2.id, 'scan');
-    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeInfo1.id);
-    actions2 = await gestaltGraph.getGestaltActionsByNode(nodeInfo2.id);
+    await gestaltGraph.unsetGestaltActionByNode(nodeIdABC, 'notify');
+    await gestaltGraph.unsetGestaltActionByNode(nodeIdDEE, 'scan');
+    actions1 = await gestaltGraph.getGestaltActionsByNode(nodeIdABC);
+    actions2 = await gestaltGraph.getGestaltActionsByNode(nodeIdDEE);
     expect(actions1).toEqual({ scan: null });
     expect(actions2).toEqual({ notify: null });
-    perm1 = await acl.getNodePerm(nodeInfo1.id);
-    perm2 = await acl.getNodePerm(nodeInfo2.id);
+    perm1 = await acl.getNodePerm(nodeIdABC);
+    perm2 = await acl.getNodePerm(nodeIdDEE);
     expect(perm1).not.toEqual(perm2);
     nodePerms = await acl.getNodePerms();
     expect(Object.keys(nodePerms)).toHaveLength(2);
@@ -1133,7 +1168,7 @@ describe('GestaltGraph', () => {
     const nodeInfo1Chain: ChainData = {};
     nodeInfo1Chain['A'] = identityClaimAbcToGH;
     const nodeInfo: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: nodeInfo1Chain,
     };
     // IdentityInfo on identity from GitHub. Contains claims:
@@ -1160,11 +1195,11 @@ describe('GestaltGraph', () => {
     nodePerms = await acl.getNodePerms();
     expect(Object.keys(nodePerms)).toHaveLength(1);
     await gestaltGraph.unlinkNodeAndIdentity(
-      nodeInfo.id,
+      nodeIdABC,
       identityInfo.providerId,
       identityInfo.identityId,
     );
-    const actions1 = await gestaltGraph.getGestaltActionsByNode(nodeInfo.id);
+    const actions1 = await gestaltGraph.getGestaltActionsByNode(nodeIdABC);
     const actions2 = await gestaltGraph.getGestaltActionsByIdentity(
       identityInfo.providerId,
       identityInfo.identityId,
@@ -1188,7 +1223,7 @@ describe('GestaltGraph', () => {
     const nodeInfo1Chain: ChainData = {};
     nodeInfo1Chain['A'] = nodeClaimAbcToDee;
     const nodeInfo1: NodeInfo = {
-      id: 'abc' as NodeId,
+      id: nodeIdABCEncoded,
       chain: nodeInfo1Chain,
     };
     // NodeInfo on node 'dee'. Contains claims:
@@ -1196,23 +1231,22 @@ describe('GestaltGraph', () => {
     const nodeInfo2Chain: ChainData = {};
     nodeInfo2Chain['A'] = nodeClaimDeeToAbc;
     const nodeInfo2: NodeInfo = {
-      id: 'dee' as NodeId,
+      id: nodeIdDEEEncoded,
       chain: nodeInfo2Chain,
     };
     await gestaltGraph.linkNodeAndNode(nodeInfo1, nodeInfo2);
-    await gestaltGraph.setGestaltActionByNode(nodeInfo1.id, 'scan');
-    await gestaltGraph.setGestaltActionByNode(nodeInfo1.id, 'notify');
-    let nodePerms;
-    nodePerms = await acl.getNodePerms();
+    await gestaltGraph.setGestaltActionByNode(nodeIdABC, 'scan');
+    await gestaltGraph.setGestaltActionByNode(nodeIdABC, 'notify');
+    let nodePerms = await acl.getNodePerms();
     expect(Object.keys(nodePerms)).toHaveLength(1);
-    await gestaltGraph.unsetNode(nodeInfo1.id);
+    await gestaltGraph.unsetNode(nodeIdABC);
     // It's still 1 node perm
     // its just that node 1 is eliminated
     nodePerms = await acl.getNodePerms();
     expect(Object.keys(nodePerms)).toHaveLength(1);
-    expect(nodePerms[0]).not.toHaveProperty(nodeInfo1.id);
-    expect(nodePerms[0]).toHaveProperty(nodeInfo2.id);
-    await gestaltGraph.unsetNode(nodeInfo2.id);
+    expect(nodePerms[0]).not.toHaveProperty(nodeIdABC.toString());
+    expect(nodePerms[0]).toHaveProperty(nodeIdDEE.toString());
+    await gestaltGraph.unsetNode(nodeIdDEE);
     nodePerms = await acl.getNodePerms();
     expect(Object.keys(nodePerms)).toHaveLength(0);
     await gestaltGraph.stop();

--- a/tests/grpc/GRPCClient.test.ts
+++ b/tests/grpc/GRPCClient.test.ts
@@ -17,6 +17,7 @@ import { errors as grpcErrors } from '@/grpc';
 import * as clientUtils from '@/client/utils';
 import * as utilsPB from '@/proto/js/polykey/v1/utils/utils_pb';
 import * as utils from './utils';
+import * as testUtils from '../utils';
 
 describe('GRPCClient', () => {
   const logger = new Logger('GRPCClient Test', LogLevel.WARN, [
@@ -59,7 +60,9 @@ describe('GRPCClient', () => {
         },
       },
     });
-    const keyManager = { getNodeId: () => 'nodeID' as NodeId } as KeyManager; // Cheeky mocking.
+    const keyManager = {
+      getNodeId: () => testUtils.generateRandomNodeId(),
+    } as KeyManager; // Cheeky mocking.
     sessionManager = await SessionManager.createSessionManager({
       db,
       keyManager,

--- a/tests/grpc/utils/utils.ts
+++ b/tests/grpc/utils/utils.ts
@@ -8,6 +8,7 @@ import {
   TestServiceService,
   TestServiceClient,
 } from '@/proto/js/polykey/v1/test_service_grpc_pb';
+import { utils as nodesUtils } from '@/nodes';
 import createTestService from './testService';
 
 async function openTestServer(
@@ -57,7 +58,7 @@ async function openTestClientSecure(
 ): Promise<TestServiceClient> {
   const clientOptions = {
     // Prevents complaints with having an ip address as the server name
-    'grpc.ssl_target_name_override': nodeId,
+    'grpc.ssl_target_name_override': nodesUtils.encodeNodeId(nodeId),
   };
   const clientCredentials = grpcUtils.clientSecureCredentials(
     keyPrivatePem,

--- a/tests/identities/IdentitiesManager.test.ts
+++ b/tests/identities/IdentitiesManager.test.ts
@@ -16,7 +16,9 @@ import { DB } from '@matrixai/db';
 import { IdentitiesManager, providers } from '@/identities';
 import * as identitiesErrors from '@/identities/errors';
 import * as keysUtils from '@/keys/utils';
+import { utils as nodesUtils } from '@/nodes';
 import TestProvider from './TestProvider';
+import * as testUtils from '../utils';
 
 describe('IdentitiesManager', () => {
   const logger = new Logger('IdentitiesManager Test', LogLevel.WARN, [
@@ -215,12 +217,14 @@ describe('IdentitiesManager', () => {
     expect(identityDatas).toHaveLength(1);
     expect(identityDatas).not.toContainEqual(identityData);
     // Now publish a claim
+    const nodeIdSome = testUtils.generateRandomNodeId();
+    const nodeIdSomeEncoded = nodesUtils.encodeNodeId(nodeIdSome);
     const signatures: Record<NodeId, SignatureData> = {};
-    signatures['somenode' as NodeId] = {
+    signatures[nodeIdSome] = {
       signature: 'examplesignature',
       header: {
         alg: 'RS256',
-        kid: 'somenode' as NodeId,
+        kid: nodeIdSomeEncoded,
       },
     };
     const rawClaim: Claim = {
@@ -230,7 +234,7 @@ describe('IdentitiesManager', () => {
         iat: Math.floor(Date.now() / 1000),
         data: {
           type: 'identity',
-          node: 'somenode' as NodeId,
+          node: nodesUtils.encodeNodeId(nodeIdSome),
           provider: testProvider.id,
           identity: identityId,
         } as ClaimData,

--- a/tests/keys/KeyManager.test.ts
+++ b/tests/keys/KeyManager.test.ts
@@ -124,7 +124,7 @@ describe('KeyManager', () => {
         recoveryCode,
       });
       expect(await keyManager.checkPassword('newpassword')).toBe(true);
-      expect(keyManager.getNodeId()).toBe(nodeId);
+      expect(keyManager.getNodeId()).toStrictEqual(nodeId);
       await keyManager.stop();
     },
     global.defaultTimeout * 2,
@@ -157,7 +157,7 @@ describe('KeyManager', () => {
       expect(keyManager2.getRecoveryCode()).toBe(recoveryCode);
       const nodeId2 = keyManager2.getNodeId();
       await keyManager2.stop();
-      expect(nodeId1).toBe(nodeId2);
+      expect(nodeId1).toStrictEqual(nodeId2);
     },
     global.defaultTimeout * 2,
   );

--- a/tests/keys/utils.test.ts
+++ b/tests/keys/utils.test.ts
@@ -91,9 +91,9 @@ describe('utils', () => {
         256,
         recoveryCode,
       );
-      const nodeId1 = keysUtils.publicKeyToFingerprint(keyPair1.publicKey);
-      const nodeId2 = keysUtils.publicKeyToFingerprint(keyPair2.publicKey);
-      expect(nodeId1).toBe(nodeId2);
+      const nodeId1 = keysUtils.publicKeyToNodeId(keyPair1.publicKey);
+      const nodeId2 = keysUtils.publicKeyToNodeId(keyPair2.publicKey);
+      expect(nodeId1).toStrictEqual(nodeId2);
     },
     global.defaultTimeout * 2,
   );

--- a/tests/nodes/NodeGraph.test.ts
+++ b/tests/nodes/NodeGraph.test.ts
@@ -6,12 +6,12 @@ import path from 'path';
 import fs from 'fs';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import { DB } from '@matrixai/db';
+import { IdInternal } from '@matrixai/id';
 import { NodeManager, errors as nodesErrors } from '@/nodes';
 import { KeyManager, utils as keysUtils } from '@/keys';
 import { ForwardProxy, ReverseProxy } from '@/network';
 import * as nodesUtils from '@/nodes/utils';
 import { Sigchain } from '@/sigchain';
-import { makeNodeId } from '@/nodes/utils';
 import * as nodesTestUtils from './utils';
 
 // Mocks.
@@ -27,27 +27,21 @@ describe('NodeGraph', () => {
   let nodeGraph: NodeGraph;
   let nodeId: NodeId;
 
-  const nodeId1 = makeNodeId(
-    new Uint8Array([
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 5,
-    ]),
-  );
-  const nodeId2 = makeNodeId(
-    new Uint8Array([
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 8,
-    ]),
-  );
-  const nodeId3 = makeNodeId(
-    new Uint8Array([
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 124,
-    ]),
-  );
+  const nodeId1 = IdInternal.create<NodeId>([
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 5,
+  ]);
+  const nodeId2 = IdInternal.create<NodeId>([
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 8,
+  ]);
+  const nodeId3 = IdInternal.create<NodeId>([
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 124,
+  ]);
   // Const nodeId2 = makeNodeId('vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg');
   // const nodeId3 = makeNodeId('v359vgrgmqf1r5g4fvisiddjknjko6bmm4qv7646jr7fi9enbfuug');
-  const dummyNode = makeNodeId(
+  const dummyNode = nodesUtils.decodeNodeId(
     'vi3et1hrpv2m2lrplcm7cu913kr45v51cak54vm68anlbvuf83ra0',
   );
 
@@ -63,7 +57,7 @@ describe('NodeGraph', () => {
   let sigchain: Sigchain;
 
   const nodeIdGenerator = (number: number) => {
-    const idArray = new Uint8Array([
+    const idArray = [
       223,
       24,
       34,
@@ -96,8 +90,8 @@ describe('NodeGraph', () => {
       23,
       77,
       number,
-    ]);
-    return makeNodeId(idArray);
+    ];
+    return IdInternal.create<NodeId>(idArray);
   };
 
   beforeAll(async () => {
@@ -582,7 +576,7 @@ describe('NodeGraph', () => {
       let nodeCount = 0;
       for (const b of newBuckets) {
         for (const n of Object.keys(b)) {
-          const nodeId = makeNodeId(n);
+          const nodeId = IdInternal.fromString<NodeId>(n);
           // Check that it was a node in the original DB
           expect(initialNodes[nodeId]).toBeDefined();
           // Check it's in the correct bucket

--- a/tests/nodes/utils.test.ts
+++ b/tests/nodes/utils.test.ts
@@ -1,84 +1,57 @@
 import type { NodeId } from '@/nodes/types';
-import * as nodesUtils from '@/nodes/utils';
-import { isNodeId, makeNodeId } from '@/nodes/utils';
+import { IdInternal } from '@matrixai/id';
+import { utils as nodesUtils } from '@/nodes';
 
 describe('Nodes utils', () => {
   test('basic distance calculation', async () => {
-    const nodeId1 = makeNodeId(
-      new Uint8Array([
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 5,
-      ]),
-    );
-    const nodeId2 = makeNodeId(
-      new Uint8Array([
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 23, 0,
-        0, 0, 0, 0, 0, 0, 0, 1,
-      ]),
-    );
+    const nodeId1 = IdInternal.create<NodeId>([
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 5,
+    ]);
+    const nodeId2 = IdInternal.create<NodeId>([
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 23, 0,
+      0, 0, 0, 0, 0, 0, 0, 1,
+    ]);
+
     const distance = nodesUtils.calculateDistance(nodeId1, nodeId2);
     expect(distance).toEqual(316912758671486456376015716356n);
   });
   test('calculates correct first bucket (bucket 0)', async () => {
     // "1" XOR "0" = distance of 1
     // Therefore, bucket 0
-    const nodeId1 = makeNodeId(
-      new Uint8Array([
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 1,
-      ]),
-    );
-    const nodeId2 = makeNodeId(
-      new Uint8Array([
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-      ]),
-    );
+    const nodeId1 = IdInternal.create<NodeId>([
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 1,
+    ]);
+    const nodeId2 = IdInternal.create<NodeId>([
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0,
+    ]);
     const bucketIndex = nodesUtils.calculateBucketIndex(nodeId1, nodeId2, 256);
     expect(bucketIndex).toBe(0);
   });
   test('calculates correct arbitrary bucket (bucket 63)', async () => {
-    const nodeId1 = makeNodeId(
-      new Uint8Array([
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        255, 0, 0, 0, 0, 0, 0, 0,
-      ]),
-    );
-    const nodeId2 = makeNodeId(
-      new Uint8Array([
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-      ]),
-    );
+    const nodeId1 = IdInternal.create<NodeId>([
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      255, 0, 0, 0, 0, 0, 0, 0,
+    ]);
+    const nodeId2 = IdInternal.create<NodeId>([
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0,
+    ]);
     const bucketIndex = nodesUtils.calculateBucketIndex(nodeId1, nodeId2, 256);
     expect(bucketIndex).toBe(63);
   });
   test('calculates correct last bucket (bucket 255)', async () => {
-    const nodeId1 = makeNodeId(
-      new Uint8Array([
-        255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      ]),
-    );
-    const nodeId2 = makeNodeId(
-      new Uint8Array([
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-      ]),
-    );
+    const nodeId1 = IdInternal.create<NodeId>([
+      255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]);
+    const nodeId2 = IdInternal.create<NodeId>([
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0,
+    ]);
     const bucketIndex = nodesUtils.calculateBucketIndex(nodeId1, nodeId2, 256);
     expect(bucketIndex).toBe(255);
-  });
-  test('testing type guard.', async () => {
-    const invalidNodeId = 'invalid!!';
-    const validNodeIdString =
-      'vh3jik6l5ntqj9er9t3n1330e46pmh27btroh3b8hsc5i9qt71di0';
-    const validNodeId = validNodeIdString as NodeId;
-    expect(isNodeId(validNodeIdString)).toBeTruthy();
-    expect(isNodeId(makeNodeId(validNodeIdString))).toBeTruthy();
-    expect(isNodeId(validNodeId)).toBeTruthy();
-    expect(isNodeId(invalidNodeId)).toBeFalsy();
-    expect(isNodeId(invalidNodeId as NodeId)).toBeFalsy();
-    // Expect(makeNodeId(invalidNodeId)).toThrow();
   });
 });

--- a/tests/nodes/utils.ts
+++ b/tests/nodes/utils.ts
@@ -1,9 +1,7 @@
 import type { NodeId, NodeAddress } from '@/nodes/types';
 
 import type { PolykeyAgent } from '@';
-import * as nodesUtils from '@/nodes/utils';
-import { makeNodeId } from '@/nodes/utils';
-import { fromMultibase } from '@/GenericIdTypes';
+import { IdInternal } from '@matrixai/id';
 
 /**
  * Generates a node ID that, according to Kademlia, will be placed into 'nodeId's
@@ -14,7 +12,7 @@ import { fromMultibase } from '@/GenericIdTypes';
  */
 function generateNodeIdForBucket(nodeId: NodeId, bucketIndex: number): NodeId {
   const lowerBoundDistance = BigInt(2) ** BigInt(bucketIndex);
-  const bufferId = nodesUtils.nodeIdToU8(nodeId);
+  const bufferId = Buffer.from(nodeId.toBuffer());
   // Console.log(bufferId);
   const bufferDistance = bigIntToBuffer(lowerBoundDistance);
   // Console.log(bufferDistance);
@@ -25,7 +23,7 @@ function generateNodeIdForBucket(nodeId: NodeId, bucketIndex: number): NodeId {
   // Reverse the buffers such that we XOR from right to left
   bufferId.reverse();
   bufferDistance.reverse();
-  const newIdArray = new Uint8Array(max);
+  const newIdArray = Buffer.alloc(max);
 
   // XOR the 'rightmost' bytes first
   for (let i = 0; i < bufferId.length && i < bufferDistance.length; i++) {
@@ -43,8 +41,7 @@ function generateNodeIdForBucket(nodeId: NodeId, bucketIndex: number): NodeId {
   // Reverse the XORed array back to normal
   newIdArray.reverse();
   // Convert to an ASCII string
-  // console.log(newIdArray);
-  return makeNodeId(newIdArray);
+  return IdInternal.fromBuffer<NodeId>(newIdArray);
 }
 
 /**
@@ -57,10 +54,10 @@ function generateNodeIdForBucket(nodeId: NodeId, bucketIndex: number): NodeId {
  * nodes appearing in larger-indexed buckets.
  */
 function incrementNodeId(nodeId: NodeId): NodeId {
-  const nodeIdArray = fromMultibase(nodeId)!;
+  const nodeIdArray = Buffer.from(nodeId.toBuffer());
   const lastCharIndex = nodeIdArray.length - 1;
   nodeIdArray[lastCharIndex] = nodeIdArray[lastCharIndex] + 1;
-  return makeNodeId(nodeIdArray);
+  return IdInternal.fromBuffer<NodeId>(nodeIdArray);
 }
 
 /**

--- a/tests/notifications/NotificationsManager.test.ts
+++ b/tests/notifications/NotificationsManager.test.ts
@@ -22,6 +22,8 @@ import { AgentServiceService, createAgentService } from '@/agent';
 
 import * as networkUtils from '@/network/utils';
 import { generateVaultId } from '@/vaults/utils';
+import { utils as nodesUtils } from '@/nodes';
+import * as testUtils from '../utils';
 
 // Mocks.
 jest.mock('@/keys/utils', () => ({
@@ -33,7 +35,7 @@ jest.mock('@/keys/utils', () => ({
 describe('NotificationsManager', () => {
   const password = 'password';
   const node: NodeInfo = {
-    id: 'NodeId' as NodeId,
+    id: nodesUtils.encodeNodeId(testUtils.generateRandomNodeId()),
     chain: {},
   };
   const logger = new Logger('NotificationsManager Test', LogLevel.WARN, [
@@ -359,7 +361,7 @@ describe('NotificationsManager', () => {
     );
     const notifs = await receiverNotificationsManager.readNotifications();
     expect(notifs[0].data).toEqual(notificationData);
-    expect(notifs[0].senderId).toEqual(senderNodeId);
+    expect(notifs[0].senderId).toEqual(nodesUtils.encodeNodeId(senderNodeId));
     expect(notifs[0].isRead).toBeTruthy();
 
     await senderNotificationsManager.stop();

--- a/tests/notifications/utils.test.ts
+++ b/tests/notifications/utils.test.ts
@@ -1,4 +1,3 @@
-import type { NodeId } from '@/nodes/types';
 import type { Notification, NotificationData } from '@/notifications/types';
 import type { VaultActions, VaultName } from '@/vaults/types';
 import { createPublicKey } from 'crypto';
@@ -11,9 +10,12 @@ import * as notificationsErrors from '@/notifications/errors';
 import { createNotificationIdGenerator } from '@/notifications/utils';
 import { sleep } from '@/utils';
 import { makeVaultId } from '@/vaults/utils';
+import { utils as nodesUtils } from '@/nodes';
+import * as testUtils from '../utils';
 
 describe('Notifications utils', () => {
-  const nodeId = 'SomeRandomNodeId' as NodeId;
+  const nodeId = testUtils.generateRandomNodeId();
+  const nodeIdEncoded = nodesUtils.encodeNodeId(nodeId);
   const vaultId = makeVaultId(
     idUtils.fromString('vaultIdxxxxxxxxx'),
   ).toString();
@@ -49,14 +51,14 @@ describe('Notifications utils', () => {
         type: 'General',
         message: 'msg',
       } as NotificationData,
-      senderId: nodeId,
+      senderId: nodeIdEncoded,
       isRead: false,
     };
     const gestaltInviteNotification: Notification = {
       data: {
         type: 'GestaltInvite',
       } as NotificationData,
-      senderId: nodeId,
+      senderId: nodeIdEncoded,
       isRead: false,
     };
     const vaultShareNotification: Notification = {
@@ -69,7 +71,7 @@ describe('Notifications utils', () => {
           pull: null,
         } as VaultActions,
       } as NotificationData,
-      senderId: nodeId,
+      senderId: nodeIdEncoded,
       isRead: false,
     };
 
@@ -97,7 +99,7 @@ describe('Notifications utils', () => {
       type: 'General',
       message: 'msg',
     });
-    expect(result.payload.senderId).toEqual(nodeId);
+    expect(result.payload.senderId).toEqual(nodeIdEncoded);
     expect(result.payload.isRead).toBeFalsy();
     expect(result.protectedHeader.jwk).toEqual(jwkPublicKey);
 
@@ -105,7 +107,7 @@ describe('Notifications utils', () => {
     expect(result.payload.data).toEqual({
       type: 'GestaltInvite',
     });
-    expect(result.payload.senderId).toEqual(nodeId);
+    expect(result.payload.senderId).toEqual(nodeIdEncoded);
     expect(result.payload.isRead).toBeFalsy();
     expect(result.protectedHeader.jwk).toEqual(jwkPublicKey);
 
@@ -119,7 +121,7 @@ describe('Notifications utils', () => {
         pull: null,
       },
     });
-    expect(result.payload.senderId).toEqual(nodeId);
+    expect(result.payload.senderId).toEqual(nodeIdEncoded);
     expect(result.payload.isRead).toBeFalsy();
     expect(result.protectedHeader.jwk).toEqual(jwkPublicKey);
   });
@@ -130,14 +132,14 @@ describe('Notifications utils', () => {
         type: 'General',
         message: 'msg',
       } as NotificationData,
-      senderId: nodeId,
+      senderId: nodeIdEncoded,
       isRead: false,
     };
     const gestaltInviteNotification: Notification = {
       data: {
         type: 'GestaltInvite',
       } as NotificationData,
-      senderId: nodeId,
+      senderId: nodeIdEncoded,
       isRead: false,
     };
     const vaultShareNotification: Notification = {
@@ -150,7 +152,7 @@ describe('Notifications utils', () => {
           pull: null,
         } as VaultActions,
       } as NotificationData,
-      senderId: nodeId,
+      senderId: nodeIdEncoded,
       isRead: false,
     };
 
@@ -178,7 +180,7 @@ describe('Notifications utils', () => {
       type: 'General',
       message: 'msg',
     });
-    expect(decodedGeneralNotification.senderId).toEqual(nodeId);
+    expect(decodedGeneralNotification.senderId).toEqual(nodeIdEncoded);
     expect(decodedGeneralNotification.isRead).toBeFalsy();
 
     const decodedGestaltInviteNotification =
@@ -188,7 +190,7 @@ describe('Notifications utils', () => {
     expect(decodedGestaltInviteNotification.data).toEqual({
       type: 'GestaltInvite',
     });
-    expect(decodedGestaltInviteNotification.senderId).toEqual(nodeId);
+    expect(decodedGestaltInviteNotification.senderId).toEqual(nodeIdEncoded);
     expect(decodedGestaltInviteNotification.isRead).toBeFalsy();
 
     const decodedVaultShareNotification =
@@ -204,17 +206,19 @@ describe('Notifications utils', () => {
         pull: null,
       },
     });
-    expect(decodedVaultShareNotification.senderId).toEqual(nodeId);
+    expect(decodedVaultShareNotification.senderId).toEqual(nodeIdEncoded);
     expect(decodedVaultShareNotification.isRead).toBeFalsy();
   });
 
   test('validates correct notifications', async () => {
+    const nodeIdOther = testUtils.generateRandomNodeId();
+    const nodeIdOtherEncoded = nodesUtils.encodeNodeId(nodeIdOther);
     const generalNotification: Notification = {
       data: {
         type: 'General',
         message: 'msg',
       } as NotificationData,
-      senderId: 'nodeId' as NodeId,
+      senderId: nodeIdOtherEncoded,
       isRead: false,
     };
     expect(
@@ -225,7 +229,7 @@ describe('Notifications utils', () => {
       data: {
         type: 'GestaltInvite',
       } as NotificationData,
-      senderId: nodeId,
+      senderId: nodeIdEncoded,
       isRead: false,
     };
     expect(
@@ -242,7 +246,7 @@ describe('Notifications utils', () => {
           pull: null,
         } as VaultActions,
       } as NotificationData,
-      senderId: nodeId,
+      senderId: nodeIdEncoded,
       isRead: false,
     };
     expect(
@@ -256,7 +260,7 @@ describe('Notifications utils', () => {
       data: {
         type: 'Invalid Type',
       },
-      senderId: nodeId,
+      senderId: nodeIdEncoded,
       isRead: false,
     };
     expect(() =>
@@ -268,7 +272,7 @@ describe('Notifications utils', () => {
       data: {
         type: 'General',
       },
-      senderId: nodeId,
+      senderId: nodeIdEncoded,
       isRead: false,
     };
     expect(() =>
@@ -281,7 +285,7 @@ describe('Notifications utils', () => {
         type: 'GestaltInvite',
         message: 'msg',
       },
-      senderId: nodeId,
+      senderId: nodeIdEncoded,
       isRead: false,
     };
     expect(() =>
@@ -296,7 +300,7 @@ describe('Notifications utils', () => {
         vaultName: 'vaultName' as VaultName,
         actions: 'clone + pull',
       },
-      senderId: nodeId,
+      senderId: nodeIdEncoded,
       isRead: false,
     };
     expect(() =>
@@ -309,7 +313,7 @@ describe('Notifications utils', () => {
         type: 'General',
         message: 'message',
       },
-      sendingId: nodeId,
+      sendingId: nodeIdEncoded,
       isRead: false,
     };
     expect(() =>

--- a/tests/sigchain/Sigchain.test.ts
+++ b/tests/sigchain/Sigchain.test.ts
@@ -1,5 +1,5 @@
 import type { ProviderId, IdentityId } from '@/identities/types';
-import type { NodeId } from '@/nodes/types';
+import type { NodeIdEncoded } from '@/nodes/types';
 import type { Claim, ClaimData } from '@/claims/types';
 import os from 'os';
 import path from 'path';
@@ -10,6 +10,7 @@ import { KeyManager, utils as keysUtils } from '@/keys';
 import { Sigchain } from '@/sigchain';
 import * as claimsUtils from '@/claims/utils';
 import * as sigchainErrors from '@/sigchain/errors';
+import { utils as nodesUtils } from '@/nodes';
 import * as testUtils from '../utils';
 
 describe('Sigchain', () => {
@@ -17,7 +18,28 @@ describe('Sigchain', () => {
     new StreamHandler(),
   ]);
   const password = 'password';
-  const srcNodeId = 'NodeId1' as NodeId;
+  const srcNodeIdEncoded = nodesUtils.encodeNodeId(
+    testUtils.generateRandomNodeId(),
+  );
+  const nodeId2Encoded = nodesUtils.encodeNodeId(
+    testUtils.generateRandomNodeId(),
+  );
+  const nodeId3Encoded = nodesUtils.encodeNodeId(
+    testUtils.generateRandomNodeId(),
+  );
+  const nodeIdAEncoded = nodesUtils.encodeNodeId(
+    testUtils.generateRandomNodeId(),
+  );
+  const nodeIdBEncoded = nodesUtils.encodeNodeId(
+    testUtils.generateRandomNodeId(),
+  );
+  const nodeIdCEncoded = nodesUtils.encodeNodeId(
+    testUtils.generateRandomNodeId(),
+  );
+  const nodeIdDEncoded = nodesUtils.encodeNodeId(
+    testUtils.generateRandomNodeId(),
+  );
+
   let mockedGenerateKeyPair: jest.SpyInstance;
   let mockedGenerateDeterministicKeyPair: jest.SpyInstance;
   beforeAll(async () => {
@@ -96,8 +118,8 @@ describe('Sigchain', () => {
     const sigchain = await Sigchain.createSigchain({ keyManager, db, logger });
     const cryptolink: ClaimData = {
       type: 'node',
-      node1: srcNodeId,
-      node2: 'NodeId2' as NodeId,
+      node1: srcNodeIdEncoded,
+      node2: nodeId2Encoded,
     };
     const [claimId] = await sigchain.addClaim(cryptolink);
 
@@ -112,8 +134,8 @@ describe('Sigchain', () => {
         seq: 1,
         data: {
           type: 'node',
-          node1: srcNodeId,
-          node2: 'NodeId2' as NodeId,
+          node1: srcNodeIdEncoded,
+          node2: nodeId2Encoded,
         },
         iat: expect.any(Number),
       },
@@ -123,10 +145,10 @@ describe('Sigchain', () => {
 
     // Check the signature is valid
     expect(Object.keys(decoded.signatures).length).toBe(1);
-    expect(decoded.signatures[srcNodeId]).toBeDefined;
-    expect(decoded.signatures[srcNodeId].header).toStrictEqual({
+    expect(decoded.signatures[srcNodeIdEncoded]).toBeDefined;
+    expect(decoded.signatures[srcNodeIdEncoded].header).toStrictEqual({
       alg: 'RS256',
-      kid: srcNodeId,
+      kid: srcNodeIdEncoded,
     });
     const verified = await claimsUtils.verifyClaimSignature(
       claim,
@@ -140,15 +162,15 @@ describe('Sigchain', () => {
     const sigchain = await Sigchain.createSigchain({ keyManager, db, logger });
     const cryptolink: ClaimData = {
       type: 'node',
-      node1: srcNodeId,
-      node2: 'NodeId2' as NodeId,
+      node1: srcNodeIdEncoded,
+      node2: nodeId2Encoded,
     };
     const [claimId1] = await sigchain.addClaim(cryptolink);
 
     const cryptolink2: ClaimData = {
       type: 'node',
-      node1: srcNodeId,
-      node2: 'NodeId3' as NodeId,
+      node1: srcNodeIdEncoded,
+      node2: nodeId3Encoded,
     };
     const [claimId2] = await sigchain.addClaim(cryptolink2);
 
@@ -163,8 +185,8 @@ describe('Sigchain', () => {
         seq: 1,
         data: {
           type: 'node',
-          node1: srcNodeId,
-          node2: 'NodeId2' as NodeId,
+          node1: srcNodeIdEncoded,
+          node2: nodeId2Encoded,
         },
         iat: expect.any(Number),
       },
@@ -178,8 +200,8 @@ describe('Sigchain', () => {
         seq: 2,
         data: {
           type: 'node',
-          node1: srcNodeId,
-          node2: 'NodeId3' as NodeId,
+          node1: srcNodeIdEncoded,
+          node2: nodeId3Encoded,
         },
         iat: expect.any(Number),
       },
@@ -189,10 +211,10 @@ describe('Sigchain', () => {
 
     // Check the signature is valid in each claim
     expect(Object.keys(decoded1.signatures).length).toBe(1);
-    expect(decoded1.signatures[srcNodeId]).toBeDefined;
-    expect(decoded1.signatures[srcNodeId].header).toStrictEqual({
+    expect(decoded1.signatures[srcNodeIdEncoded]).toBeDefined;
+    expect(decoded1.signatures[srcNodeIdEncoded].header).toStrictEqual({
       alg: 'RS256',
-      kid: srcNodeId,
+      kid: srcNodeIdEncoded,
     });
     const verified1 = await claimsUtils.verifyClaimSignature(
       claim1,
@@ -201,10 +223,10 @@ describe('Sigchain', () => {
     expect(verified1).toBe(true);
 
     expect(Object.keys(decoded2.signatures).length).toBe(1);
-    expect(decoded2.signatures[srcNodeId]).toBeDefined;
-    expect(decoded2.signatures[srcNodeId].header).toStrictEqual({
+    expect(decoded2.signatures[srcNodeIdEncoded]).toBeDefined;
+    expect(decoded2.signatures[srcNodeIdEncoded].header).toStrictEqual({
       alg: 'RS256',
-      kid: srcNodeId,
+      kid: srcNodeIdEncoded,
     });
     const verified2 = await claimsUtils.verifyClaimSignature(
       claim2,
@@ -236,10 +258,10 @@ describe('Sigchain', () => {
       seq: seq1 + 1,
       data: {
         type: 'node',
-        node1: 'A' as NodeId,
-        node2: 'B' as NodeId,
+        node1: nodeIdAEncoded,
+        node2: nodeIdBEncoded,
       },
-      kid: 'A' as NodeId,
+      kid: nodeIdAEncoded,
     });
     await sigchain.addExistingClaim(claim1);
     const hPrev2 = await sigchain.getHashPrevious();
@@ -254,10 +276,10 @@ describe('Sigchain', () => {
       seq: seq2 + 1,
       data: {
         type: 'node',
-        node1: 'A' as NodeId,
-        node2: 'C' as NodeId,
+        node1: nodeIdAEncoded,
+        node2: nodeIdCEncoded,
       },
-      kid: 'A' as NodeId,
+      kid: nodeIdAEncoded,
     });
     await sigchain.addExistingClaim(claim2);
     const hPrev3 = await sigchain.getHashPrevious();
@@ -272,10 +294,10 @@ describe('Sigchain', () => {
       seq: seq3 + 1,
       data: {
         type: 'node',
-        node1: 'A' as NodeId,
-        node2: 'D' as NodeId,
+        node1: nodeIdAEncoded,
+        node2: nodeIdDEncoded,
       },
-      kid: 'D' as NodeId,
+      kid: nodeIdDEncoded,
     });
     await expect(() =>
       sigchain.addExistingClaim(claimInvalidHash),
@@ -288,10 +310,10 @@ describe('Sigchain', () => {
       seq: 1,
       data: {
         type: 'node',
-        node1: 'A' as NodeId,
-        node2: 'D' as NodeId,
+        node1: nodeIdAEncoded,
+        node2: nodeIdDEncoded,
       },
-      kid: 'D' as NodeId,
+      kid: nodeIdDEncoded,
     });
     await expect(() =>
       sigchain.addExistingClaim(claimInvalidSeqNum),
@@ -299,20 +321,23 @@ describe('Sigchain', () => {
   });
   test('retrieves chain data', async () => {
     const sigchain = await Sigchain.createSigchain({ keyManager, db, logger });
+    const node2s: NodeIdEncoded[] = [];
 
     // Add 10 claims
     for (let i = 1; i <= 5; i++) {
+      const node2 = nodesUtils.encodeNodeId(testUtils.generateRandomNodeId());
+      node2s.push(node2);
       const nodeLink: ClaimData = {
         type: 'node',
-        node1: srcNodeId,
-        node2: ('NodeId' + i.toString()) as NodeId,
+        node1: srcNodeIdEncoded,
+        node2: node2,
       };
       await sigchain.addClaim(nodeLink);
     }
     for (let i = 6; i <= 10; i++) {
       const identityLink: ClaimData = {
         type: 'identity',
-        node: srcNodeId,
+        node: srcNodeIdEncoded,
         provider: ('ProviderId' + i.toString()) as ProviderId,
         identity: ('IdentityId' + i.toString()) as IdentityId,
       };
@@ -325,15 +350,16 @@ describe('Sigchain', () => {
       const claim = chainData[chainDataKeys[i - 1]];
       const decodedClaim = claimsUtils.decodeClaim(claim);
       if (i <= 5) {
+        const node2 = node2s[i - 1];
         expect(decodedClaim.payload.data).toEqual({
           type: 'node',
-          node1: srcNodeId,
-          node2: ('NodeId' + i.toString()) as NodeId,
+          node1: srcNodeIdEncoded,
+          node2: node2,
         });
       } else {
         expect(decodedClaim.payload.data).toEqual({
           type: 'identity',
-          node: srcNodeId,
+          node: srcNodeIdEncoded,
           provider: ('ProviderId' + i.toString()) as ProviderId,
           identity: ('IdentityId' + i.toString()) as IdentityId,
         });
@@ -342,22 +368,25 @@ describe('Sigchain', () => {
   });
   test('retrieves all cryptolinks (nodes and identities) from sigchain (in expected lexicographic order)', async () => {
     const sigchain = await Sigchain.createSigchain({ keyManager, db, logger });
+    const nodes: NodeIdEncoded[] = [];
 
     // Add 30 claims
     for (let i = 1; i <= 30; i++) {
       // If even, add a node link
       if (i % 2 === 0) {
+        const node2 = nodesUtils.encodeNodeId(testUtils.generateRandomNodeId());
+        nodes[i] = node2;
         const nodeLink: ClaimData = {
           type: 'node',
-          node1: srcNodeId,
-          node2: ('NodeId' + i.toString()) as NodeId,
+          node1: srcNodeIdEncoded,
+          node2: node2,
         };
         await sigchain.addClaim(nodeLink);
         // If odd, add an identity link
       } else {
         const identityLink: ClaimData = {
           type: 'identity',
-          node: srcNodeId,
+          node: srcNodeIdEncoded,
           provider: ('ProviderId' + i.toString()) as ProviderId,
           identity: ('IdentityId' + i.toString()) as IdentityId,
         };
@@ -382,6 +411,7 @@ describe('Sigchain', () => {
       expect(seqNum).toBe(expectedSeqNum);
 
       // Verify the structure of claim
+      const node2 = nodes[expectedSeqNum];
       const expected: Claim = {
         payload: {
           hPrev: claimsUtils.hashClaim(
@@ -390,8 +420,8 @@ describe('Sigchain', () => {
           seq: expectedSeqNum,
           data: {
             type: 'node',
-            node1: srcNodeId,
-            node2: ('NodeId' + expectedSeqNum.toString()) as NodeId,
+            node1: srcNodeIdEncoded,
+            node2: node2,
           },
           iat: expect.any(Number),
         },
@@ -400,10 +430,10 @@ describe('Sigchain', () => {
       expect(d).toEqual(expected);
       // Verify the signature
       expect(Object.keys(d.signatures).length).toBe(1);
-      expect(d.signatures[srcNodeId]).toBeDefined;
-      expect(d.signatures[srcNodeId].header).toStrictEqual({
+      expect(d.signatures[srcNodeIdEncoded]).toBeDefined;
+      expect(d.signatures[srcNodeIdEncoded].header).toStrictEqual({
         alg: 'RS256',
-        kid: srcNodeId,
+        kid: srcNodeIdEncoded,
       });
       const verified = await claimsUtils.verifyClaimSignature(
         nodeLinks[i],
@@ -442,7 +472,7 @@ describe('Sigchain', () => {
           seq: expectedSeqNum,
           data: {
             type: 'identity',
-            node: srcNodeId,
+            node: srcNodeIdEncoded,
             provider: ('ProviderId' + expectedSeqNum.toString()) as ProviderId,
             identity: ('IdentityId' + expectedSeqNum.toString()) as IdentityId,
           },
@@ -453,10 +483,10 @@ describe('Sigchain', () => {
       expect(id).toEqual(expected);
       // Verify the signature
       expect(Object.keys(id.signatures).length).toBe(1);
-      expect(id.signatures[srcNodeId]).toBeDefined;
-      expect(id.signatures[srcNodeId].header).toStrictEqual({
+      expect(id.signatures[srcNodeIdEncoded]).toBeDefined;
+      expect(id.signatures[srcNodeIdEncoded].header).toStrictEqual({
         alg: 'RS256',
-        kid: srcNodeId,
+        kid: srcNodeIdEncoded,
       });
       const verified = await claimsUtils.verifyClaimSignature(
         nodeLinks[i],

--- a/tests/status/Status.test.ts
+++ b/tests/status/Status.test.ts
@@ -1,17 +1,26 @@
-import type { NodeId } from '@/nodes/types';
 import type { Host, Port } from '@/network/types';
+import type { StatusLive } from '@/status/types';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import config from '@/config';
 import { Status, errors as statusErrors } from '@/status';
+import * as testUtils from '../utils';
 
 describe('Status', () => {
   const logger = new Logger(`${Status.name} Test`, LogLevel.WARN, [
     new StreamHandler(),
   ]);
   let dataDir: string;
+
+  const nodeId1 = testUtils.generateRandomNodeId();
+  // Const nodeId1Encoded = nodesUtils.encodeNodeId(nodeId1);
+  const nodeId2 = testUtils.generateRandomNodeId();
+  // Const nodeId2Encoded = nodesUtils.encodeNodeId(nodeId2);
+  const nodeId3 = testUtils.generateRandomNodeId();
+  // Const nodeId3Encoded = nodesUtils.encodeNodeId(nodeId3);
+
   beforeEach(async () => {
     dataDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'status-test-'));
   });
@@ -57,7 +66,7 @@ describe('Status', () => {
     expect(statusInfo1!.data.pid).toBe(0);
     await status.finishStart({
       pid: 0,
-      nodeId: 'node' as NodeId,
+      nodeId: nodeId1,
       clientHost: '::1' as Host,
       clientPort: 0 as Port,
       ingressHost: '127.0.0.1' as Host,
@@ -127,9 +136,9 @@ describe('Status', () => {
     await expect(status.updateStatusLive({})).rejects.toThrow(
       statusErrors.ErrorStatusLiveUpdate,
     );
-    const statusData1 = {
+    const statusData1: StatusLive['data'] = {
       pid: 0,
-      nodeId: 'node' as NodeId,
+      nodeId: nodeId1,
       clientHost: '::1' as Host,
       clientPort: 0 as Port,
       ingressHost: '127.0.0.1' as Host,
@@ -140,15 +149,15 @@ describe('Status', () => {
     };
     await status.finishStart(statusData1);
     const statusInfo = await status.updateStatusLive({
-      nodeId: 'new node' as NodeId,
-      anotherthing: 'something',
+      nodeId: nodeId2,
+      anotherThing: 'something',
     });
     expect(statusInfo).toStrictEqual({
       status: 'LIVE',
       data: {
         ...statusData1,
-        nodeId: 'new node' as NodeId,
-        anotherthing: 'something',
+        nodeId: nodeId2,
+        anotherThing: 'something',
       },
     });
     await status.beginStop({ pid: 0 });
@@ -200,7 +209,7 @@ describe('Status', () => {
       clientPort: 0 as Port,
       ingressHost: '127.0.0.1' as Host,
       ingressPort: 0 as Port,
-      nodeId: '' as NodeId,
+      nodeId: nodeId3,
       pid: 0,
     });
     const statusInfoLive = await statusWaitFor;
@@ -245,7 +254,7 @@ describe('Status', () => {
           clientPort: 0 as Port,
           ingressHost: '127.0.0.1' as Host,
           ingressPort: 3425 as Port,
-          nodeId: '' as NodeId,
+          nodeId: nodeId3,
           pid: 0,
         }),
         status.readStatus(),
@@ -257,7 +266,7 @@ describe('Status', () => {
           clientPort: 3445 as Port,
           ingressHost: '127.0.0.1' as Host,
           ingressPort: 0 as Port,
-          nodeId: '' as NodeId,
+          nodeId: nodeId3,
           pid: 0,
         }),
         status.beginStop({
@@ -269,7 +278,7 @@ describe('Status', () => {
           clientPort: 0 as Port,
           ingressHost: '127.0.0.1' as Host,
           ingressPort: 0 as Port,
-          nodeId: '' as NodeId,
+          nodeId: nodeId3,
           pid: 0,
         }),
       ]);
@@ -303,7 +312,7 @@ describe('Status', () => {
       clientPort: 0 as Port,
       ingressHost: '127.0.0.1' as Host,
       ingressPort: 0 as Port,
-      nodeId: '' as NodeId,
+      nodeId: nodeId3,
       pid: 0,
     });
     const p2 = status.beginStop({ pid: 1 });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,8 +1,10 @@
 import type { StatusLive } from '@/status/types';
+import type { NodeId } from '@/nodes/types';
 import path from 'path';
 import fs from 'fs';
 import lock from 'fd-lock';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
+import { IdInternal } from '@matrixai/id';
 import { PolykeyAgent } from '@';
 import { Status } from '@/status';
 import { utils as keysUtils } from '@/keys';
@@ -169,4 +171,10 @@ async function setupGlobalAgent(
   };
 }
 
-export { setupGlobalKeypair, setupGlobalAgent };
+function generateRandomNodeId(): NodeId {
+  // Make it easy to read with an identifier
+  const random = keysUtils.getRandomBytesSync(16).toString('hex');
+  return IdInternal.fromString<NodeId>(random);
+}
+
+export { setupGlobalKeypair, setupGlobalAgent, generateRandomNodeId };


### PR DESCRIPTION
### Description
This PR will focus on applying the new `NodeId` which is an opaque alias of `Id` (which itself is an alias of `IdInternal & number`).

1. Add some of the encoding wrappers into the `IdInternal` class, this requires a new PR in `js-id`. Include `toMultibase` and `toUUID` and `toBuffer` as instance methods, and the `fromString`, `fromMultibase`, `fromUUID`, and `fromBuffer` as static methods (these represent alternatives of creating the `IdInternal`). Make sure that these functions return `Id` as the type and not `IdInternal`.
3. This PR will focus on applying the new `NodeId` which is an opaque alias of `Id` (which itself is an alias of `IdInternal & number`).
4. All the areas which is currently using `NodeId` is expecting an encoded string. These will need to be changed to expect a sort of `type NodeIdEncoded = string;`, you still need a `nodesUtils.encodeNodeId`.
5. The encoding functions and decoding functions of `NodeId` should be inside `nodes/utils.ts`. This should be similar to how I'm doing it for `VaultId`. An alternative might be to create class extension or generics, but this seems complicated.
6. Raw usage of the `NodeId` will mostly occur inside the nodes domain, in particular the `NodeGraph` can use the `Uint8Array` directly. Note that the `js-db` currently doesn't yet allow direct usage of the `Id`, because it requires a `Buffer` type. However there is an issue https://github.com/MatrixAI/js-db/issues/3 to allow it to eventually take `Id`, so for now, just use `idUtils.toBuffer` and `idUtils.fromBuffer` when interacting with the DB.
7. Once this PR is merged into master, rebase #266 and #310 on top to benefit from it.

### Issues Fixed

- Fixes #254 
- Fixes #261 
- Related #299 

### Tasks

1. [x] Add some of the encoding wrappers into the `IdInternal` class, this requires a new PR in `js-id`. Include `toMultibase` and `toUUID` and `toBuffer` as instance methods, and the `fromString`, `fromMultibase`, `fromUUID`, and `fromBuffer` as static methods (these represent alternatives of creating the `IdInternal`). Make sure that these functions return `Id` as the type and not `IdInternal`. - Update to 3.2.0 of js-id
2. [x] Update `NodeId` type to use an opaque alias of `Id`.
3. [x] Update all uses of `NodeId` to use the new type where possible.
4. [x] Where a encoded string of `NodeId` is required, use a `NodeIdEncoded` instead.
5. [x] Don't get the NodeId from the Certificate. get the Public key from the `KeyManager` and convert it from that. 
6. ~[ ] `PolykeyAgent` should store the `NodeId`. It should be updated via the event bus. ~ - stay with using `this.keyManager.getNodeId()`.~
7. ~[ ] Anything that needs the NodeId should take a lambda that fetches it from the PolykeyAgent.~ - stick with injecting `KeyManager` where it is needed
8. [x] Add `NodeId` validation to RPC services and possibly bin commands.
9. [x] review types and utils imports.

example of usage here.
https://github.com/MatrixAI/js-polykey/issues/254#issuecomment-1016205861

Areas that need changes:

1. ~Status needs the string encoded to put into the status JSON file~ - Status file does indeed to use the encoded string, but `StatusInfo` should still use the `NodeId` and not `NodeIdEncoded` because we want to do any validation on the boundary and ensure that our internal types in the context of the program uses types that imply that the validation occurred already, and therefore the `nodeId` is indeed a valid node id.
2. GRPCClient needs the string encoded to pass as a URL parameter for the proxy
3. keymanager certificate needs to have string encoded node id
4. sigchain claims needs to have string encoded node id
5. `GestaltGraph.ts` needs to use the encoded string of the NodeId - its just because it is designed like this it's due to the `GestaltKey`
6. The `NodeInfo` for now has to use `NodeIdEncoded` because it is being put into the database as a value as part of a POJO which gets JSON encoded. Plus that `GestaltGraph` and `Discovery` uses it as a string, but in the future it may be better done as `NodeId` which follows the same reason as `1.` about validation being done on the boundary.

@tegefaulkes please flesh the above out.

Guidelines:

1. Use NodeId binary form where possible
2. Use NodeId encoded as multibase when it goes to a file, to outside network, to the console/terminal
3. Use NodeId binary string if it's put into a private POJO... - do this only when you're really sure that this will never be seen by anything else
4. Use NodeId buffers when using DB.
5. when comparing two ids for equality convert them to strings with `.toString()`

Unresolved tests addressed in other PRs:

These were failing in the commit I branched off of. May be fix in #310 or #308 
- ping.test.ts
- find.test.ts
- notificationsManager.test.ts

relevant to the vaults domain.
- vaultManager.test.ts

Part of nodes and #310 
- NodeConnection.test.ts
- nodeManager.test.ts

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
