### PR TITLE
General Data Validation - Boundary IO locations should be doing data validation and marshalling (and the decommissioning of GenericIdTypes for all IDs)

### DIFF
--- a/src/acl/types.ts
+++ b/src/acl/types.ts
@@ -1,11 +1,10 @@
 import type { Opaque } from '../types';
 import type { GestaltAction } from '../gestalts/types';
 import type { VaultActions, VaultId } from '../vaults/types';
-import type { Id, IdString } from '../GenericIdTypes';
+import type { Id } from '@matrixai/id';
 
 type PermissionId = Opaque<'PermissionId', Id>;
-
-type PermissionIdString = Opaque<'PermissionIdString', IdString>;
+type PermissionIdString = Opaque<'PermissionIdString', string>;
 
 type Permission = {
   gestalt: GestaltActions;

--- a/src/acl/utils.ts
+++ b/src/acl/utils.ts
@@ -1,27 +1,9 @@
-import type { Permission, PermissionId, PermissionIdString } from './types';
-
+import type { Permission, PermissionId } from './types';
 import { IdRandom } from '@matrixai/id';
-import { isIdString, isId, makeIdString, makeId } from '../GenericIdTypes';
 
-function isPermissionId(arg: any): arg is PermissionId {
-  return isId<PermissionId>(arg);
-}
-
-function makePermissionId(arg: any) {
-  return makeId<PermissionId>(arg);
-}
-
-function isPermissionIdString(arg: any): arg is PermissionIdString {
-  return isIdString<PermissionIdString>(arg);
-}
-
-function makePermissionIdString(arg: any) {
-  return makeIdString<PermissionIdString>(arg);
-}
-
-const randomIdGenerator = new IdRandom();
-async function generatePermId(): Promise<PermissionId> {
-  return makePermissionId(randomIdGenerator.get());
+function createPermIdGenerator() {
+  const generator = new IdRandom<PermissionId>();
+  return () => generator.get();
 }
 
 function permUnion(perm1: Permission, perm2: Permission): Permission {
@@ -44,11 +26,4 @@ function permUnion(perm1: Permission, perm2: Permission): Permission {
   return perm;
 }
 
-export {
-  generatePermId,
-  permUnion,
-  isPermissionId,
-  makePermissionId,
-  isPermissionIdString,
-  makePermissionIdString,
-};
+export { createPermIdGenerator, permUnion };

--- a/src/agent/service/nodesChainDataGet.ts
+++ b/src/agent/service/nodesChainDataGet.ts
@@ -1,5 +1,5 @@
 import type * as grpc from '@grpc/grpc-js';
-import type { ClaimIdString } from '../../claims/types';
+import type { ClaimIdEncoded } from '../../claims/types';
 import type { NodeManager } from '../../nodes';
 import type * as utilsPB from '../../proto/js/polykey/v1/utils/utils_pb';
 import { utils as grpcUtils } from '../../grpc';
@@ -18,7 +18,7 @@ function nodesChainDataGet({ nodeManager }: { nodeManager: NodeManager }) {
       const chainData = await nodeManager.getChainData();
       // Iterate through each claim in the chain, and serialize for transport
       for (const c in chainData) {
-        const claimId = c as ClaimIdString;
+        const claimId = c as ClaimIdEncoded;
         const claim = chainData[claimId];
         const claimMessage = new nodesPB.AgentClaim();
         // Will always have a payload (never undefined) so cast as string

--- a/src/agent/service/nodesChainDataGet.ts
+++ b/src/agent/service/nodesChainDataGet.ts
@@ -13,8 +13,8 @@ function nodesChainDataGet({ nodeManager }: { nodeManager: NodeManager }) {
     call: grpc.ServerUnaryCall<utilsPB.EmptyMessage, nodesPB.ChainData>,
     callback: grpc.sendUnaryData<nodesPB.ChainData>,
   ): Promise<void> => {
-    const response = new nodesPB.ChainData();
     try {
+      const response = new nodesPB.ChainData();
       const chainData = await nodeManager.getChainData();
       // Iterate through each claim in the chain, and serialize for transport
       for (const c in chainData) {
@@ -34,10 +34,12 @@ function nodesChainDataGet({ nodeManager }: { nodeManager: NodeManager }) {
         // Add the serialized claim
         response.getChainDataMap().set(claimId, claimMessage);
       }
-    } catch (err) {
-      callback(grpcUtils.fromError(err), response);
+      callback(null, response);
+      return;
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
+      return;
     }
-    callback(null, response);
   };
 }
 

--- a/src/agent/service/vaultsPermissionsCheck.ts
+++ b/src/agent/service/vaultsPermissionsCheck.ts
@@ -26,8 +26,8 @@ function vaultsPermissionsCheck(_) {
       //   response.setPermission(true);
       // }
       // callback(null, response);
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
     }
   };
 }

--- a/src/bin/identities/CommandAllow.ts
+++ b/src/bin/identities/CommandAllow.ts
@@ -1,8 +1,9 @@
 import type PolykeyClient from '../../PolykeyClient';
+import type { GestaltId } from '../../gestalts/types';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
-import * as parsers from '../utils/parsers';
+import * as binParsers from '../utils/parsers';
 import * as binProcessors from '../utils/processors';
 
 class CommandAllow extends CommandPolykey {
@@ -12,14 +13,14 @@ class CommandAllow extends CommandPolykey {
     this.description('Allow Permission for Identity');
     this.argument(
       '<gestaltId>',
-      'Node ID or `Provider Id:Identity Id`',
-      parsers.parseGestaltId,
+      'Node ID or `Provider ID:Identity ID`',
+      binParsers.parseGestaltId,
     );
     this.argument('<permissions>', 'permission to set');
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
-    this.action(async (gestaltId, permissions, options) => {
+    this.action(async (gestaltId: GestaltId, permissions, options) => {
       const { default: PolykeyClient } = await import('../../PolykeyClient');
       const identitiesPB = await import(
         '../../proto/js/polykey/v1/identities/identities_pb'
@@ -54,7 +55,7 @@ class CommandAllow extends CommandPolykey {
         });
         const setActionMessage = new permissionsPB.ActionSet();
         setActionMessage.setAction(permissions);
-        if (gestaltId.nodeId) {
+        if (gestaltId.type === 'node') {
           // Setting by Node
           const nodeMessage = new nodesPB.Node();
           nodeMessage.setNodeId(gestaltId.nodeId);

--- a/src/bin/identities/CommandDisallow.ts
+++ b/src/bin/identities/CommandDisallow.ts
@@ -1,4 +1,5 @@
 import type PolykeyClient from '../../PolykeyClient';
+import type { GestaltId } from '../../gestalts/types';
 import CommandPolykey from '../CommandPolykey';
 import * as binOptions from '../utils/options';
 import * as binUtils from '../utils';
@@ -19,7 +20,7 @@ class CommandDisallow extends CommandPolykey {
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
-    this.action(async (gestaltId, permissions, options) => {
+    this.action(async (gestaltId: GestaltId, permissions, options) => {
       const { default: PolykeyClient } = await import('../../PolykeyClient');
       const identitiesPB = await import(
         '../../proto/js/polykey/v1/identities/identities_pb'
@@ -54,8 +55,8 @@ class CommandDisallow extends CommandPolykey {
         });
         const setActionMessage = new permissionsPB.ActionSet();
         setActionMessage.setAction(permissions);
-        if (gestaltId.nodeId) {
-          // Setting by Node.
+        if (gestaltId.type === 'node') {
+          // Setting by Node
           const nodeMessage = new nodesPB.Node();
           nodeMessage.setNodeId(gestaltId.nodeId);
           setActionMessage.setNode(nodeMessage);

--- a/src/bin/identities/CommandDiscover.ts
+++ b/src/bin/identities/CommandDiscover.ts
@@ -1,4 +1,5 @@
 import type PolykeyClient from '../../PolykeyClient';
+import type { GestaltId } from '../../gestalts/types';
 import CommandPolykey from '../CommandPolykey';
 import * as binOptions from '../utils/options';
 import * as binUtils from '../utils';
@@ -14,13 +15,13 @@ class CommandDiscover extends CommandPolykey {
     );
     this.argument(
       '<gestaltId>',
-      'Node ID or `Provider Id:Identity Id`',
+      'Node ID or `Provider ID:Identity ID`',
       parsers.parseGestaltId,
     );
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
-    this.action(async (gestaltId, options) => {
+    this.action(async (gestaltId: GestaltId, options) => {
       const { default: PolykeyClient } = await import('../../PolykeyClient');
       const identitiesPB = await import(
         '../../proto/js/polykey/v1/identities/identities_pb'
@@ -50,8 +51,8 @@ class CommandDiscover extends CommandPolykey {
           port: clientOptions.clientPort,
           logger: this.logger.getChild(PolykeyClient.name),
         });
-        if (gestaltId.nodeId != null) {
-          // Discovery by Node.
+        if (gestaltId.type === 'node') {
+          // Discovery by Node
           const nodeMessage = new nodesPB.Node();
           nodeMessage.setNodeId(gestaltId.nodeId);
           await binUtils.retryAuthentication(

--- a/src/bin/identities/CommandGet.ts
+++ b/src/bin/identities/CommandGet.ts
@@ -1,5 +1,6 @@
-import type gestaltsPB from '../../proto/js/polykey/v1/gestalts/gestalts_pb';
 import type PolykeyClient from '../../PolykeyClient';
+import type { GestaltId } from '../../gestalts/types';
+import type gestaltsPB from '../../proto/js/polykey/v1/gestalts/gestalts_pb';
 import CommandPolykey from '../CommandPolykey';
 import * as binOptions from '../utils/options';
 import * as binUtils from '../utils';
@@ -15,13 +16,13 @@ class CommandGet extends CommandPolykey {
     );
     this.argument(
       '<gestaltId>',
-      'Node ID or `Provider Id:Identity Id`',
+      'Node ID or `Provider ID:Identity ID`',
       parsers.parseGestaltId,
     );
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
-    this.action(async (gestaltId, options) => {
+    this.action(async (gestaltId: GestaltId, options) => {
       const { default: PolykeyClient } = await import('../../PolykeyClient');
       const identitiesPB = await import(
         '../../proto/js/polykey/v1/identities/identities_pb'
@@ -52,8 +53,8 @@ class CommandGet extends CommandPolykey {
           logger: this.logger.getChild(PolykeyClient.name),
         });
         let res: gestaltsPB.Graph;
-        if (gestaltId.nodeId) {
-          // Getting from node.
+        if (gestaltId.type === 'node') {
+          // Getting from node
           const nodeMessage = new nodesPB.Node();
           nodeMessage.setNodeId(gestaltId.nodeId);
           res = await binUtils.retryAuthentication(

--- a/src/bin/identities/CommandPermissions.ts
+++ b/src/bin/identities/CommandPermissions.ts
@@ -1,4 +1,5 @@
 import type PolykeyClient from '../../PolykeyClient';
+import type { GestaltId } from '../../gestalts/types';
 import CommandPolykey from '../CommandPolykey';
 import * as binOptions from '../utils/options';
 import * as binUtils from '../utils';
@@ -12,13 +13,13 @@ class CommandPermissions extends CommandPolykey {
     this.description('Gets the Permissions for a Node or Identity');
     this.argument(
       '<gestaltId>',
-      'Node ID or `Provider Id:Identity Id`',
+      'Node ID or `Provider ID:Identity ID`',
       parsers.parseGestaltId,
     );
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
-    this.action(async (gestaltId, options) => {
+    this.action(async (gestaltId: GestaltId, options) => {
       const { default: PolykeyClient } = await import('../../PolykeyClient');
       const identitiesPB = await import(
         '../../proto/js/polykey/v1/identities/identities_pb'
@@ -49,8 +50,8 @@ class CommandPermissions extends CommandPolykey {
           logger: this.logger.getChild(PolykeyClient.name),
         });
         let actions: string[] = [];
-        if (gestaltId.nodeId) {
-          // Getting by Node.
+        if (gestaltId.type === 'node') {
+          // Getting by Node
           const nodeMessage = new nodesPB.Node();
           nodeMessage.setNodeId(gestaltId.nodeId);
           const res = await binUtils.retryAuthentication(

--- a/src/bin/identities/CommandTrust.ts
+++ b/src/bin/identities/CommandTrust.ts
@@ -1,4 +1,5 @@
 import type PolykeyClient from '../../PolykeyClient';
+import type { GestaltId } from '../../gestalts/types';
 import CommandPolykey from '../CommandPolykey';
 import * as binOptions from '../utils/options';
 import * as binUtils from '../utils';
@@ -12,13 +13,13 @@ class CommandTrust extends CommandPolykey {
     this.description('Trust a Keynode or Identity');
     this.argument(
       '<gestaltId>',
-      'Node ID or `Provider Id:Identity Id`',
+      'Node ID or `Provider ID:Identity ID`',
       parsers.parseGestaltId,
     );
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
-    this.action(async (gestaltId, options) => {
+    this.action(async (gestaltId: GestaltId, options) => {
       const { default: PolykeyClient } = await import('../../PolykeyClient');
       const identitiesPB = await import(
         '../../proto/js/polykey/v1/identities/identities_pb'
@@ -54,8 +55,8 @@ class CommandTrust extends CommandPolykey {
         const action = 'notify';
         const setActionMessage = new permissionsPB.ActionSet();
         setActionMessage.setAction(action);
-        if (gestaltId.nodeId) {
-          // Setting by Node.
+        if (gestaltId.type === 'node') {
+          // Setting by Node
           const nodeMessage = new nodesPB.Node();
           nodeMessage.setNodeId(gestaltId.nodeId);
           setActionMessage.setNode(nodeMessage);

--- a/src/bin/identities/CommandUntrust.ts
+++ b/src/bin/identities/CommandUntrust.ts
@@ -1,4 +1,5 @@
 import type PolykeyClient from '../../PolykeyClient';
+import type { GestaltId } from '../../gestalts/types';
 import CommandPolykey from '../CommandPolykey';
 import * as binOptions from '../utils/options';
 import * as binUtils from '../utils';
@@ -12,13 +13,13 @@ class CommandUntrust extends CommandPolykey {
     this.description('Untrust a Keynode or Identity');
     this.argument(
       '<gestaltId>',
-      'Node ID or `Provider Id:Identity Id`',
+      'Node ID or `Provider ID:Identity ID`',
       parsers.parseGestaltId,
     );
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
-    this.action(async (gestaltId, options) => {
+    this.action(async (gestaltId: GestaltId, options) => {
       const { default: PolykeyClient } = await import('../../PolykeyClient');
       const identitiesPB = await import(
         '../../proto/js/polykey/v1/identities/identities_pb'
@@ -54,7 +55,7 @@ class CommandUntrust extends CommandPolykey {
         const action = 'notify';
         const setActionMessage = new permissionsPB.ActionSet();
         setActionMessage.setAction(action);
-        if (gestaltId.nodeId) {
+        if (gestaltId.type === 'node') {
           // Setting by Node.
           const nodeMessage = new nodesPB.Node();
           nodeMessage.setNodeId(gestaltId.nodeId);

--- a/src/bin/nodes/CommandAdd.ts
+++ b/src/bin/nodes/CommandAdd.ts
@@ -1,22 +1,26 @@
 import type PolykeyClient from '../../PolykeyClient';
+import type { NodeId } from '../../nodes/types';
+import type { Host, Port } from '../../network/types';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils/utils';
 import * as binProcessors from '../utils/processors';
 import * as binOptions from '../utils/options';
+import * as binParsers from '../utils/parsers';
 
 class CommandAdd extends CommandPolykey {
   constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
     super(...args);
     this.name('add');
     this.description('Add a Node to the Node Graph');
-    this.argument('<nodeId>', 'Id of the node to add');
-    this.argument('<host>', 'Address of the node');
-    this.argument('<port>', 'Port of the node');
+    this.argument('<nodeId>', 'Id of the node to add', binParsers.parseNodeId);
+    this.argument('<host>', 'Address of the node', binParsers.parseHost);
+    this.argument('<port>', 'Port of the node', binParsers.parsePort);
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
-    this.action(async (nodeId, host, port, options) => {
+    this.action(async (nodeId: NodeId, host: Host, port: Port, options) => {
       const { default: PolykeyClient } = await import('../../PolykeyClient');
+      const nodesUtils = await import('../../nodes/utils');
       const nodesPB = await import('../../proto/js/polykey/v1/nodes/nodes_pb');
       const clientOptions = await binProcessors.processClientOptions(
         options.nodePath,
@@ -43,7 +47,7 @@ class CommandAdd extends CommandPolykey {
           logger: this.logger.getChild(PolykeyClient.name),
         });
         const nodeAddressMessage = new nodesPB.NodeAddress();
-        nodeAddressMessage.setNodeId(nodeId);
+        nodeAddressMessage.setNodeId(nodesUtils.encodeNodeId(nodeId));
         nodeAddressMessage.setAddress(
           new nodesPB.Address().setHost(host).setPort(port),
         );

--- a/src/bin/nodes/CommandClaim.ts
+++ b/src/bin/nodes/CommandClaim.ts
@@ -1,15 +1,21 @@
 import type PolykeyClient from '../../PolykeyClient';
+import type { NodeId } from '../../nodes/types';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
 import * as binProcessors from '../utils/processors';
+import * as binParsers from '../utils/parsers';
 
 class CommandClaim extends CommandPolykey {
   constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
     super(...args);
     this.name('claim');
     this.description('Claim another Keynode');
-    this.argument('<nodeId>', 'Id of the node to claim');
+    this.argument(
+      '<nodeId>',
+      'Id of the node to claim',
+      binParsers.parseNodeId,
+    );
     this.option(
       '-f, --force-invite',
       '(optional) Flag to force a Gestalt Invitation to be sent rather than a node claim.',
@@ -17,8 +23,9 @@ class CommandClaim extends CommandPolykey {
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
-    this.action(async (nodeId, options) => {
+    this.action(async (nodeId: NodeId, options) => {
       const { default: PolykeyClient } = await import('../../PolykeyClient');
+      const nodesUtils = await import('../../nodes/utils');
       const nodesPB = await import('../../proto/js/polykey/v1/nodes/nodes_pb');
       const clientOptions = await binProcessors.processClientOptions(
         options.nodePath,
@@ -45,7 +52,7 @@ class CommandClaim extends CommandPolykey {
           logger: this.logger.getChild(PolykeyClient.name),
         });
         const nodeClaimMessage = new nodesPB.Claim();
-        nodeClaimMessage.setNodeId(nodeId);
+        nodeClaimMessage.setNodeId(nodesUtils.encodeNodeId(nodeId));
         if (options.forceInvite) {
           nodeClaimMessage.setForceInvite(true);
         } else {
@@ -61,7 +68,9 @@ class CommandClaim extends CommandPolykey {
             binUtils.outputFormatter({
               type: options.format === 'json' ? 'json' : 'list',
               data: [
-                `Successfully generated a cryptolink claim on Keynode with ID ${nodeId}`,
+                `Successfully generated a cryptolink claim on Keynode with ID ${nodesUtils.encodeNodeId(
+                  nodeId,
+                )}`,
               ],
             }),
           );
@@ -70,7 +79,9 @@ class CommandClaim extends CommandPolykey {
             binUtils.outputFormatter({
               type: options.format === 'json' ? 'json' : 'list',
               data: [
-                `Successfully sent Gestalt Invite notification to Keynode with ID ${nodeId}`,
+                `Successfully sent Gestalt Invite notification to Keynode with ID ${nodesUtils.encodeNodeId(
+                  nodeId,
+                )}`,
               ],
             }),
           );

--- a/src/bin/utils/index.ts
+++ b/src/bin/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './utils';
 export * as options from './options';
 export * as parsers from './parsers';
+export * as processors from './processors';
 export { default as ExitHandlers } from './ExitHandlers';

--- a/src/bin/utils/options.ts
+++ b/src/bin/utils/options.ts
@@ -1,6 +1,8 @@
 /**
  * Options and Arguments used by commands
- * Use PolykeyCommand.addOption or PolykeyCommand.addArgument
+ * Use `PolykeyCommand.addOption`
+ * The option parsers will parse parameters and environment variables
+ * but not the default value
  * @module
  */
 import commander from 'commander';
@@ -48,7 +50,9 @@ const fresh = new commander.Option(
 /**
  * Node ID used for connecting to a remote agent
  */
-const nodeId = new commander.Option('-ni, --node-id <id>').env('PK_NODE_ID');
+const nodeId = new commander.Option('-ni, --node-id <id>')
+  .env('PK_NODE_ID')
+  .argParser(binParsers.parseNodeId);
 
 /**
  * Client host used for connecting to remote agent
@@ -56,7 +60,9 @@ const nodeId = new commander.Option('-ni, --node-id <id>').env('PK_NODE_ID');
 const clientHost = new commander.Option(
   '-ch, --client-host <host>',
   'Client Host Address',
-).env('PK_CLIENT_HOST');
+)
+  .env('PK_CLIENT_HOST')
+  .argParser(binParsers.parseHost);
 
 /**
  * Client port used for connecting to remote agent
@@ -65,29 +71,30 @@ const clientPort = new commander.Option(
   '-cp, --client-port <port>',
   'Client Port',
 )
-  .argParser(binParsers.parseNumber)
-  .env('PK_CLIENT_PORT');
+  .env('PK_CLIENT_PORT')
+  .argParser(binParsers.parsePort);
 
 const ingressHost = new commander.Option(
   '-ih, --ingress-host <host>',
   'Ingress host',
 )
   .env('PK_INGRESS_HOST')
+  .argParser(binParsers.parseHost)
   .default(config.defaults.networkConfig.ingressHost);
 
 const ingressPort = new commander.Option(
   '-ip, --ingress-port <port>',
   'Ingress Port',
 )
-  .argParser(binParsers.parseNumber)
   .env('PK_INGRESS_PORT')
+  .argParser(binParsers.parsePort)
   .default(config.defaults.networkConfig.ingressPort);
 
 const connTimeoutTime = new commander.Option(
   '--connection-timeout <ms>',
   'Timeout value for connection establishment between nodes',
 )
-  .argParser(binParsers.parseNumber)
+  .argParser(binParsers.parseInteger)
   .default(config.defaults.forwardProxyConfig.connTimeoutTime);
 
 const passwordFile = new commander.Option(
@@ -123,7 +130,7 @@ const backgroundErrFile = new commander.Option(
 const rootKeyPairBits = new commander.Option(
   '-rkpb --root-key-pair-bits <bitsize>',
   'Bit size of root key pair',
-).argParser(binParsers.parseNumber);
+).argParser(binParsers.parseInteger);
 
 const seedNodes = new commander.Option(
   '-sn, --seed-nodes [nodeId1@host:port;nodeId2@host:port;...]',

--- a/src/bin/utils/processors.ts
+++ b/src/bin/utils/processors.ts
@@ -1,6 +1,6 @@
 import type { FileSystem } from '../../types';
 import type { RecoveryCode } from '../../keys/types';
-import type { NodeId, NodeIdEncoded } from '../../nodes/types';
+import type { NodeId } from '../../nodes/types';
 import type { Host, Port } from '../../network/types';
 import type {
   StatusStarting,
@@ -17,7 +17,6 @@ import * as binErrors from '../errors';
 import * as clientUtils from '../../client/utils';
 import { Status } from '../../status';
 import config from '../../config';
-import { utils as nodesUtils } from '../../nodes';
 
 /**
  * Prompts for existing password
@@ -192,7 +191,7 @@ async function processRecoveryCode(
  */
 async function processClientOptions(
   nodePath: string,
-  nodeId?: NodeIdEncoded,
+  nodeId?: NodeId,
   clientHost?: Host,
   clientPort?: Port,
   fs = require('fs'),
@@ -215,15 +214,14 @@ async function processClientOptions(
     if (statusInfo === undefined || statusInfo.status !== 'LIVE') {
       throw new binErrors.ErrorCLIStatusNotLive();
     }
-    if (nodeId == null)
-      nodeId = nodesUtils.encodeNodeId(statusInfo.data.nodeId);
+    if (nodeId == null) nodeId = statusInfo.data.nodeId;
     if (clientHost == null) clientHost = statusInfo.data.clientHost;
     if (clientPort == null) clientPort = statusInfo.data.clientPort;
   }
   return {
-    nodeId: nodesUtils.decodeNodeId(nodeId),
-    clientHost: clientHost,
-    clientPort: clientPort,
+    nodeId,
+    clientHost,
+    clientPort,
   };
 }
 
@@ -235,7 +233,7 @@ async function processClientOptions(
  */
 async function processClientStatus(
   nodePath: string,
-  nodeId?: NodeIdEncoded,
+  nodeId?: NodeId,
   clientHost?: Host,
   clientPort?: Port,
   fs = require('fs'),
@@ -263,14 +261,12 @@ async function processClientStatus(
       clientPort: Port;
     }
 > {
-  let nodeIdDecoded: NodeId | undefined =
-    nodeId != null ? nodesUtils.decodeNodeId(nodeId) : undefined;
   // If all parameters are set, no status and no statusInfo is used
-  if (nodeIdDecoded != null && clientHost != null && clientPort != null) {
+  if (nodeId != null && clientHost != null && clientPort != null) {
     return {
       statusInfo: undefined,
       status: undefined,
-      nodeId: nodeIdDecoded,
+      nodeId,
       clientHost,
       clientPort,
     };
@@ -290,13 +286,13 @@ async function processClientStatus(
     throw new binErrors.ErrorCLIStatusMissing();
   }
   if (statusInfo.status === 'LIVE') {
-    if (nodeIdDecoded == null) nodeIdDecoded = statusInfo.data.nodeId;
+    if (nodeId == null) nodeId = statusInfo.data.nodeId;
     if (clientHost == null) clientHost = statusInfo.data.clientHost;
     if (clientPort == null) clientPort = statusInfo.data.clientPort;
     return {
       statusInfo,
       status,
-      nodeId: nodeIdDecoded,
+      nodeId,
       clientHost,
       clientPort,
     };
@@ -304,7 +300,7 @@ async function processClientStatus(
   return {
     statusInfo,
     status,
-    nodeId: nodeIdDecoded,
+    nodeId,
     clientHost,
     clientPort,
   };

--- a/src/bin/vaults/CommandClone.ts
+++ b/src/bin/vaults/CommandClone.ts
@@ -1,8 +1,10 @@
 import type PolykeyClient from '../../PolykeyClient';
+import type { NodeId } from '../../nodes/types';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
 import * as binProcessors from '../utils/processors';
+import * as binParsers from '../utils/parsers';
 
 class CommandClone extends CommandPolykey {
   constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
@@ -10,12 +12,17 @@ class CommandClone extends CommandPolykey {
     this.name('clone');
     this.description('Clone a Vault from Another Node');
     this.argument('<vaultNameOrId>', 'Id of the vault to be cloned');
-    this.argument('<nodeId>', 'Id of the node to clone the vault from');
+    this.argument(
+      '<nodeId>',
+      'Id of the node to clone the vault from',
+      binParsers.parseNodeId,
+    );
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
-    this.action(async (vaultNameOrId, nodeId, options) => {
+    this.action(async (vaultNameOrId, nodeId: NodeId, options) => {
       const { default: PolykeyClient } = await import('../../PolykeyClient');
+      const nodesUtils = await import('../../nodes/utils');
       const vaultsPB = await import(
         '../../proto/js/polykey/v1/vaults/vaults_pb'
       );
@@ -49,7 +56,7 @@ class CommandClone extends CommandPolykey {
         const vaultCloneMessage = new vaultsPB.Clone();
         vaultCloneMessage.setVault(vaultMessage);
         vaultCloneMessage.setNode(nodeMessage);
-        nodeMessage.setNodeId(nodeId);
+        nodeMessage.setNodeId(nodesUtils.encodeNodeId(nodeId));
         vaultMessage.setNameOrId(vaultNameOrId);
         await binUtils.retryAuthentication(
           (auth) => pkClient.grpcClient.vaultsClone(vaultCloneMessage, auth),

--- a/src/bin/vaults/CommandPull.ts
+++ b/src/bin/vaults/CommandPull.ts
@@ -1,21 +1,28 @@
 import type PolykeyClient from '../../PolykeyClient';
+import type { NodeId } from '../../nodes/types';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
 import * as binProcessors from '../utils/processors';
+import * as binParsers from '../utils/parsers';
 
 class CommandPull extends CommandPolykey {
   constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
     super(...args);
     this.name('pull');
     this.description('Pull a Vault from Another Node');
-    this.argument('<nodeId>', 'Id of the node to pull the vault from');
+    this.argument(
+      '<nodeId>',
+      'Id of the node to pull the vault from',
+      binParsers.parseNodeId,
+    );
     this.argument('<vaultName>', 'Name of the vault to be pulled');
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
-    this.action(async (nodeId, vaultName, options) => {
+    this.action(async (nodeId: NodeId, vaultName, options) => {
       const { default: PolykeyClient } = await import('../../PolykeyClient');
+      const nodesUtils = await import('../../nodes/utils');
       const vaultsPB = await import(
         '../../proto/js/polykey/v1/vaults/vaults_pb'
       );
@@ -49,7 +56,7 @@ class CommandPull extends CommandPolykey {
         const vaultPullMessage = new vaultsPB.Pull();
         vaultPullMessage.setVault(vaultMessage);
         vaultPullMessage.setNode(nodeMessage);
-        nodeMessage.setNodeId(nodeId);
+        nodeMessage.setNodeId(nodesUtils.encodeNodeId(nodeId));
         vaultMessage.setNameOrId(vaultName);
         await binUtils.retryAuthentication(
           (auth) => pkClient.grpcClient.vaultsPull(vaultPullMessage, auth),

--- a/src/bin/vaults/CommandShare.ts
+++ b/src/bin/vaults/CommandShare.ts
@@ -1,8 +1,10 @@
 import type PolykeyClient from '../../PolykeyClient';
+import type { NodeId } from '../../nodes/types';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
 import * as binProcessors from '../utils/processors';
+import * as binParsers from '../utils/parsers';
 
 class CommandShare extends CommandPolykey {
   constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
@@ -10,12 +12,17 @@ class CommandShare extends CommandPolykey {
     this.name('share');
     this.description('Set the Permissions of a Vault for a Node');
     this.argument('<vaultName>', 'Name of the vault to be shared');
-    this.argument('<nodeId>', 'Id of the node to share to');
+    this.argument(
+      '<nodeId>',
+      'Id of the node to share to',
+      binParsers.parseNodeId,
+    );
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
-    this.action(async (vaultName, nodeId, options) => {
+    this.action(async (vaultName, nodeId: NodeId, options) => {
       const { default: PolykeyClient } = await import('../../PolykeyClient');
+      const nodesUtils = await import('../../nodes/utils');
       const vaultsPB = await import(
         '../../proto/js/polykey/v1/vaults/vaults_pb'
       );
@@ -50,7 +57,7 @@ class CommandShare extends CommandPolykey {
         setVaultPermsMessage.setVault(vaultMessage);
         setVaultPermsMessage.setNode(nodeMessage);
         vaultMessage.setNameOrId(vaultName);
-        nodeMessage.setNodeId(nodeId);
+        nodeMessage.setNodeId(nodesUtils.encodeNodeId(nodeId));
         await binUtils.retryAuthentication(
           (auth) =>
             pkClient.grpcClient.vaultsPermissionsSet(

--- a/src/bin/vaults/CommandUnshare.ts
+++ b/src/bin/vaults/CommandUnshare.ts
@@ -1,8 +1,10 @@
 import type PolykeyClient from '../../PolykeyClient';
+import type { NodeId } from '../../nodes/types';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';
 import * as binProcessors from '../utils/processors';
+import * as binParsers from '../utils/parsers';
 
 class CommandUnshare extends CommandPolykey {
   constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
@@ -10,12 +12,17 @@ class CommandUnshare extends CommandPolykey {
     this.name('unshare');
     this.description('Unset the Permissions of a Vault for a Node');
     this.argument('<vaultName>', 'Name of the vault to be unshared');
-    this.argument('<nodeId>', 'Id of the node to unshare with');
+    this.argument(
+      '<nodeId>',
+      'Id of the node to unshare with',
+      binParsers.parseNodeId,
+    );
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
-    this.action(async (vaultName, nodeId, options) => {
+    this.action(async (vaultName, nodeId: NodeId, options) => {
       const { default: PolykeyClient } = await import('../../PolykeyClient');
+      const nodesUtils = await import('../../nodes/utils');
       const vaultsPB = await import(
         '../../proto/js/polykey/v1/vaults/vaults_pb'
       );
@@ -50,7 +57,7 @@ class CommandUnshare extends CommandPolykey {
         unsetVaultPermsMessage.setVault(vaultMessage);
         unsetVaultPermsMessage.setNode(nodeMessage);
         vaultMessage.setNameOrId(vaultName);
-        nodeMessage.setNodeId(nodeId);
+        nodeMessage.setNodeId(nodesUtils.encodeNodeId(nodeId));
         await binUtils.retryAuthentication(
           (auth) =>
             pkClient.grpcClient.vaultsPermissionsUnset(

--- a/src/claims/types.ts
+++ b/src/claims/types.ts
@@ -1,8 +1,8 @@
+import type { Id } from '@matrixai/id';
+import type { GeneralJWS, FlattenedJWSInput } from 'jose';
 import type { Opaque } from '../types';
 import type { NodeIdEncoded } from '../nodes/types';
 import type { ProviderId, IdentityId } from '../identities/types';
-import type { GeneralJWS, FlattenedJWSInput } from 'jose';
-import type { Id, IdString } from '../GenericIdTypes';
 
 /**
  * A JSON-ified, decoded version of the ClaimEncoded type.
@@ -43,13 +43,13 @@ type SignatureData = {
 };
 
 /**
- * An arbitraty string serving as a unique identitifer for a particular claim.
+ * An arbitrary string serving as a unique identitifer for a particular claim.
  * Depending on the domain the claim is used in, its implementation detail will
  * differ. For example, the sigchain domain uses a lexicographic-integer as the
  * claim ID (representing the sequence number key of the claim).
  */
 type ClaimId = Opaque<'ClaimId', Id>;
-type ClaimIdString = Opaque<'ClaimIdString', IdString>;
+type ClaimIdEncoded = Opaque<'ClaimIdEncoded', string>;
 
 type ClaimIdGenerator = () => ClaimId;
 
@@ -104,7 +104,7 @@ export type {
   ClaimIntermediary,
   SignatureData,
   ClaimId,
-  ClaimIdString,
+  ClaimIdEncoded,
   ClaimIdGenerator,
   ClaimEncoded,
   ClaimData,

--- a/src/client/errors.ts
+++ b/src/client/errors.ts
@@ -1,30 +1,25 @@
-import { ErrorPolykey } from '../errors';
+import { ErrorPolykey, sysexits } from '../errors';
 
 class ErrorClient extends ErrorPolykey {}
 
 class ErrorClientClientDestroyed extends ErrorClient {
   description = 'GRPCClientClient has been destroyed';
-  exitCode = 64;
+  exitCode = sysexits.USAGE;
 }
 
 class ErrorClientAuthMissing extends ErrorClient {
   description = 'Authorisation metadata is required but missing';
-  exitCode = 77;
+  exitCode = sysexits.NOPERM;
 }
 
 class ErrorClientAuthFormat extends ErrorClient {
   description = 'Authorisation metadata has invalid format';
-  exitCode = 64;
+  exitCode = sysexits.USAGE;
 }
 
 class ErrorClientAuthDenied extends ErrorClient {
   description = 'Authorisation metadata is incorrect or expired';
-  exitCode = 77;
-}
-
-class ErrorClientInvalidProvider extends ErrorClient {
-  description = 'Provider Id is invalid or does not exist';
-  exitCode = 70;
+  exitCode = sysexits.NOPERM;
 }
 
 export {
@@ -33,5 +28,4 @@ export {
   ErrorClientAuthMissing,
   ErrorClientAuthFormat,
   ErrorClientAuthDenied,
-  ErrorClientInvalidProvider,
 };

--- a/src/client/service/agentLockAll.ts
+++ b/src/client/service/agentLockAll.ts
@@ -15,15 +15,15 @@ function agentLockAll({
     call: grpc.ServerUnaryCall<utilsPB.EmptyMessage, utilsPB.EmptyMessage>,
     callback: grpc.sendUnaryData<utilsPB.EmptyMessage>,
   ): Promise<void> => {
-    const response = new utilsPB.EmptyMessage();
     try {
+      const response = new utilsPB.EmptyMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
       await sessionManager.resetKey();
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/agentStatus.ts
+++ b/src/client/service/agentStatus.ts
@@ -28,8 +28,8 @@ function agentStatus({
     call: grpc.ServerUnaryCall<utilsPB.EmptyMessage, agentPB.InfoMessage>,
     callback: grpc.sendUnaryData<agentPB.InfoMessage>,
   ): Promise<void> => {
-    const response = new agentPB.InfoMessage();
     try {
+      const response = new agentPB.InfoMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
       response.setPid(process.pid);
@@ -49,8 +49,8 @@ function agentStatus({
       response.setRootCertChainPem(await keyManager.getRootCertChainPem());
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/agentStop.ts
+++ b/src/client/service/agentStop.ts
@@ -27,8 +27,8 @@ function agentStop({
       call.sendMetadata(metadata);
       // Respond first to close the GRPC connection
       callback(null, response);
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
     // Stop is called after GRPC resources are cleared

--- a/src/client/service/agentUnlock.ts
+++ b/src/client/service/agentUnlock.ts
@@ -8,14 +8,14 @@ function agentUnlock({ authenticate }: { authenticate: Authenticate }) {
     call: grpc.ServerUnaryCall<utilsPB.EmptyMessage, utilsPB.EmptyMessage>,
     callback: grpc.sendUnaryData<utilsPB.EmptyMessage>,
   ): Promise<void> => {
-    const response = new utilsPB.EmptyMessage();
     try {
+      const response = new utilsPB.EmptyMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/gestaltsActionsSetByIdentity.ts
+++ b/src/client/service/gestaltsActionsSetByIdentity.ts
@@ -1,10 +1,12 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { Authenticate } from '../types';
 import type { GestaltGraph } from '../../gestalts';
+import type { GestaltAction } from '../../gestalts/types';
 import type { IdentityId, ProviderId } from '../../identities/types';
 import type * as permissionsPB from '../../proto/js/polykey/v1/permissions/permissions_pb';
 import { utils as grpcUtils } from '../../grpc';
-import { utils as gestaltsUtils } from '../../gestalts';
+import { validateSync, utils as validationUtils } from '../../validation';
+import { matchSync } from '../../utils';
 import * as utilsPB from '../../proto/js/polykey/v1/utils/utils_pb';
 
 function gestaltsActionsSetByIdentity({
@@ -18,15 +20,33 @@ function gestaltsActionsSetByIdentity({
     call: grpc.ServerUnaryCall<permissionsPB.ActionSet, utilsPB.EmptyMessage>,
     callback: grpc.sendUnaryData<utilsPB.EmptyMessage>,
   ): Promise<void> => {
-    const info = call.request;
-    const response = new utilsPB.EmptyMessage();
     try {
+      const response = new utilsPB.EmptyMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
-      // Setting the action.
-      const action = gestaltsUtils.makeGestaltAction(info.getAction());
-      const providerId = info.getIdentity()?.getProviderId() as ProviderId;
-      const identityId = info.getIdentity()?.getIdentityId() as IdentityId;
+      const {
+        action,
+        providerId,
+        identityId,
+      }: {
+        action: GestaltAction;
+        providerId: ProviderId;
+        identityId: IdentityId;
+      } = validateSync(
+        (keyPath, value) => {
+          return matchSync(keyPath)(
+            [['action'], () => validationUtils.parseGestaltAction(value)],
+            [['providerId'], () => validationUtils.parseProviderId(value)],
+            [['identityId'], () => validationUtils.parseIdentityId(value)],
+            () => value,
+          );
+        },
+        {
+          action: call.request.getAction(),
+          providerId: call.request.getIdentity()?.getProviderId(),
+          identityId: call.request.getIdentity()?.getIdentityId(),
+        },
+      );
       await gestaltGraph.setGestaltActionByIdentity(
         providerId,
         identityId,
@@ -34,8 +54,8 @@ function gestaltsActionsSetByIdentity({
       );
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/gestaltsActionsSetByNode.ts
+++ b/src/client/service/gestaltsActionsSetByNode.ts
@@ -1,10 +1,12 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { Authenticate } from '../types';
 import type { GestaltGraph } from '../../gestalts';
+import type { GestaltAction } from '../../gestalts/types';
+import type { NodeId } from '../../nodes/types';
 import type * as permissionsPB from '../../proto/js/polykey/v1/permissions/permissions_pb';
 import { utils as grpcUtils } from '../../grpc';
-import { utils as nodesUtils } from '../../nodes';
-import { utils as gestaltsUtils } from '../../gestalts';
+import { validateSync, utils as validationUtils } from '../../validation';
+import { matchSync } from '../../utils';
 import * as utilsPB from '../../proto/js/polykey/v1/utils/utils_pb';
 
 function gestaltsActionsSetByNode({
@@ -18,19 +20,29 @@ function gestaltsActionsSetByNode({
     call: grpc.ServerUnaryCall<permissionsPB.ActionSet, utilsPB.EmptyMessage>,
     callback: grpc.sendUnaryData<utilsPB.EmptyMessage>,
   ): Promise<void> => {
-    const info = call.request;
-    const response = new utilsPB.EmptyMessage();
     try {
+      const response = new utilsPB.EmptyMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
-      // Setting the action.
-      const action = gestaltsUtils.makeGestaltAction(info.getAction());
-      const nodeId = nodesUtils.decodeNodeId(info.getNode()!.getNodeId());
+      const { nodeId, action }: { nodeId: NodeId; action: GestaltAction } =
+        validateSync(
+          (keyPath, value) => {
+            return matchSync(keyPath)(
+              [['nodeId'], () => validationUtils.parseNodeId(value)],
+              [['action'], () => validationUtils.parseGestaltAction(value)],
+              () => value,
+            );
+          },
+          {
+            nodeId: call.request.getNode()?.getNodeId(),
+            action: call.request.getAction(),
+          },
+        );
       await gestaltGraph.setGestaltActionByNode(nodeId, action);
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/gestaltsActionsUnsetByIdentity.ts
+++ b/src/client/service/gestaltsActionsUnsetByIdentity.ts
@@ -1,10 +1,12 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { Authenticate } from '../types';
 import type { GestaltGraph } from '../../gestalts';
+import type { GestaltAction } from '../../gestalts/types';
 import type { IdentityId, ProviderId } from '../../identities/types';
 import type * as permissionsPB from '../../proto/js/polykey/v1/permissions/permissions_pb';
 import { utils as grpcUtils } from '../../grpc';
-import { utils as gestaltsUtils } from '../../gestalts';
+import { validateSync, utils as validationUtils } from '../../validation';
+import { matchSync } from '../../utils';
 import * as utilsPB from '../../proto/js/polykey/v1/utils/utils_pb';
 
 function gestaltsActionsUnsetByIdentity({
@@ -18,15 +20,33 @@ function gestaltsActionsUnsetByIdentity({
     call: grpc.ServerUnaryCall<permissionsPB.ActionSet, utilsPB.EmptyMessage>,
     callback: grpc.sendUnaryData<utilsPB.EmptyMessage>,
   ): Promise<void> => {
-    const info = call.request;
-    const response = new utilsPB.EmptyMessage();
     try {
+      const response = new utilsPB.EmptyMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
-      // Setting the action.
-      const action = gestaltsUtils.makeGestaltAction(info.getAction());
-      const providerId = info.getIdentity()?.getProviderId() as ProviderId;
-      const identityId = info.getIdentity()?.getIdentityId() as IdentityId;
+      const {
+        action,
+        providerId,
+        identityId,
+      }: {
+        action: GestaltAction;
+        providerId: ProviderId;
+        identityId: IdentityId;
+      } = validateSync(
+        (keyPath, value) => {
+          return matchSync(keyPath)(
+            [['action'], () => validationUtils.parseGestaltAction(value)],
+            [['providerId'], () => validationUtils.parseProviderId(value)],
+            [['identityId'], () => validationUtils.parseIdentityId(value)],
+            () => value,
+          );
+        },
+        {
+          action: call.request.getAction(),
+          providerId: call.request.getIdentity()?.getProviderId(),
+          identityId: call.request.getIdentity()?.getIdentityId(),
+        },
+      );
       await gestaltGraph.unsetGestaltActionByIdentity(
         providerId,
         identityId,
@@ -34,8 +54,8 @@ function gestaltsActionsUnsetByIdentity({
       );
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/gestaltsActionsUnsetByNode.ts
+++ b/src/client/service/gestaltsActionsUnsetByNode.ts
@@ -1,10 +1,12 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { Authenticate } from '../types';
 import type { GestaltGraph } from '../../gestalts';
+import type { GestaltAction } from '../../gestalts/types';
+import type { NodeId } from '../../nodes/types';
 import type * as permissionsPB from '../../proto/js/polykey/v1/permissions/permissions_pb';
 import { utils as grpcUtils } from '../../grpc';
-import { utils as nodesUtils } from '../../nodes';
-import { utils as gestaltsUtils } from '../../gestalts';
+import { validateSync, utils as validationUtils } from '../../validation';
+import { matchSync } from '../../utils';
 import * as utilsPB from '../../proto/js/polykey/v1/utils/utils_pb';
 
 function gestaltsActionsUnsetByNode({
@@ -18,19 +20,29 @@ function gestaltsActionsUnsetByNode({
     call: grpc.ServerUnaryCall<permissionsPB.ActionSet, utilsPB.EmptyMessage>,
     callback: grpc.sendUnaryData<utilsPB.EmptyMessage>,
   ): Promise<void> => {
-    const info = call.request;
-    const response = new utilsPB.EmptyMessage();
     try {
+      const response = new utilsPB.EmptyMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
-      // Setting the action.
-      const action = gestaltsUtils.makeGestaltAction(info.getAction());
-      const nodeId = nodesUtils.decodeNodeId(info.getNode()!.getNodeId());
+      const { nodeId, action }: { nodeId: NodeId; action: GestaltAction } =
+        validateSync(
+          (keyPath, value) => {
+            return matchSync(keyPath)(
+              [['nodeId'], () => validationUtils.parseNodeId(value)],
+              [['action'], () => validationUtils.parseGestaltAction(value)],
+              () => value,
+            );
+          },
+          {
+            nodeId: call.request.getNode()?.getNodeId(),
+            action: call.request.getAction(),
+          },
+        );
       await gestaltGraph.unsetGestaltActionByNode(nodeId, action);
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/gestaltsGestaltList.ts
+++ b/src/client/service/gestaltsGestaltList.ts
@@ -29,8 +29,8 @@ function gestaltsGestaltList({
       }
       await genWritable.next(null);
       return;
-    } catch (err) {
-      await genWritable.throw(err);
+    } catch (e) {
+      await genWritable.throw(e);
       return;
     }
   };

--- a/src/client/service/identitiesProvidersList.ts
+++ b/src/client/service/identitiesProvidersList.ts
@@ -16,17 +16,16 @@ function identitiesProvidersList({
     call: grpc.ServerUnaryCall<utilsPB.EmptyMessage, identitiesPB.Provider>,
     callback: grpc.sendUnaryData<identitiesPB.Provider>,
   ): Promise<void> => {
-    const response = new identitiesPB.Provider();
     try {
+      const response = new identitiesPB.Provider();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
-
       const providers = identitiesManager.getProviders();
       response.setProviderId(JSON.stringify(Object.keys(providers)));
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/identitiesTokenDelete.ts
+++ b/src/client/service/identitiesTokenDelete.ts
@@ -4,6 +4,8 @@ import type { IdentitiesManager } from '../../identities';
 import type { IdentityId, ProviderId } from '../../identities/types';
 import type * as identitiesPB from '../../proto/js/polykey/v1/identities/identities_pb';
 import { utils as grpcUtils } from '../../grpc';
+import { validateSync, utils as validationUtils } from '../../validation';
+import { matchSync } from '../../utils';
 import * as utilsPB from '../../proto/js/polykey/v1/utils/utils_pb';
 
 function identitiesTokenDelete({
@@ -17,18 +19,34 @@ function identitiesTokenDelete({
     call: grpc.ServerUnaryCall<identitiesPB.Provider, utilsPB.EmptyMessage>,
     callback: grpc.sendUnaryData<utilsPB.EmptyMessage>,
   ): Promise<void> => {
-    const response = new utilsPB.EmptyMessage();
     try {
+      const response = new utilsPB.EmptyMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
-      await identitiesManager.delToken(
-        call.request.getProviderId() as ProviderId,
-        call.request.getIdentityId() as IdentityId,
+      const {
+        providerId,
+        identityId,
+      }: {
+        providerId: ProviderId;
+        identityId: IdentityId;
+      } = validateSync(
+        (keyPath, value) => {
+          return matchSync(keyPath)(
+            [['providerId'], () => validationUtils.parseProviderId(value)],
+            [['identityId'], () => validationUtils.parseIdentityId(value)],
+            () => value,
+          );
+        },
+        {
+          providerId: call.request.getProviderId(),
+          identityId: call.request.getIdentityId(),
+        },
       );
+      await identitiesManager.delToken(providerId, identityId);
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/identitiesTokenGet.ts
+++ b/src/client/service/identitiesTokenGet.ts
@@ -3,6 +3,8 @@ import type { Authenticate } from '../types';
 import type { IdentitiesManager } from '../../identities';
 import type { IdentityId, ProviderId } from '../../identities/types';
 import { utils as grpcUtils } from '../../grpc';
+import { validateSync, utils as validationUtils } from '../../validation';
+import { matchSync } from '../../utils';
 import * as identitiesPB from '../../proto/js/polykey/v1/identities/identities_pb';
 
 function identitiesTokenGet({
@@ -16,19 +18,35 @@ function identitiesTokenGet({
     call: grpc.ServerUnaryCall<identitiesPB.Provider, identitiesPB.Token>,
     callback: grpc.sendUnaryData<identitiesPB.Token>,
   ): Promise<void> => {
-    const response = new identitiesPB.Token();
     try {
+      const response = new identitiesPB.Token();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
-      const tokens = await identitiesManager.getToken(
-        call.request.getProviderId() as ProviderId,
-        call.request.getIdentityId() as IdentityId,
+      const {
+        providerId,
+        identityId,
+      }: {
+        providerId: ProviderId;
+        identityId: IdentityId;
+      } = validateSync(
+        (keyPath, value) => {
+          return matchSync(keyPath)(
+            [['providerId'], () => validationUtils.parseProviderId(value)],
+            [['identityId'], () => validationUtils.parseIdentityId(value)],
+            () => value,
+          );
+        },
+        {
+          providerId: call.request.getProviderId(),
+          identityId: call.request.getIdentityId(),
+        },
       );
+      const tokens = await identitiesManager.getToken(providerId, identityId);
       response.setToken(JSON.stringify(tokens));
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/identitiesTokenPut.ts
+++ b/src/client/service/identitiesTokenPut.ts
@@ -4,6 +4,8 @@ import type { IdentitiesManager } from '../../identities';
 import type { IdentityId, ProviderId, TokenData } from '../../identities/types';
 import type * as identitiesPB from '../../proto/js/polykey/v1/identities/identities_pb';
 import { utils as grpcUtils } from '../../grpc';
+import { validateSync, utils as validationUtils } from '../../validation';
+import { matchSync } from '../../utils';
 import * as utilsPB from '../../proto/js/polykey/v1/utils/utils_pb';
 
 function identitiesTokenPut({
@@ -20,20 +22,36 @@ function identitiesTokenPut({
     >,
     callback: grpc.sendUnaryData<utilsPB.EmptyMessage>,
   ): Promise<void> => {
-    const response = new utilsPB.EmptyMessage();
     try {
+      const response = new utilsPB.EmptyMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
-      const provider = call.request.getProvider();
-      await identitiesManager.putToken(
-        provider?.getProviderId() as ProviderId,
-        provider?.getIdentityId() as IdentityId,
-        { accessToken: call.request.getToken() } as TokenData,
+      const {
+        providerId,
+        identityId,
+      }: {
+        providerId: ProviderId;
+        identityId: IdentityId;
+      } = validateSync(
+        (keyPath, value) => {
+          return matchSync(keyPath)(
+            [['providerId'], () => validationUtils.parseProviderId(value)],
+            [['identityId'], () => validationUtils.parseIdentityId(value)],
+            () => value,
+          );
+        },
+        {
+          providerId: call.request.getProvider()?.getProviderId(),
+          identityId: call.request.getProvider()?.getIdentityId(),
+        },
       );
+      await identitiesManager.putToken(providerId, identityId, {
+        accessToken: call.request.getToken(),
+      } as TokenData);
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/keysCertsChainGet.ts
+++ b/src/client/service/keysCertsChainGet.ts
@@ -19,7 +19,6 @@ function keysCertsChainGet({
     try {
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
-
       const certs: Array<string> = await keyManager.getRootCertChainPems();
       let certMessage: keysPB.Certificate;
       for (const cert of certs) {
@@ -29,8 +28,8 @@ function keysCertsChainGet({
       }
       await genWritable.next(null);
       return;
-    } catch (err) {
-      await genWritable.throw(err);
+    } catch (e) {
+      await genWritable.throw(e);
       return;
     }
   };

--- a/src/client/service/keysCertsGet.ts
+++ b/src/client/service/keysCertsGet.ts
@@ -16,16 +16,16 @@ function keysCertsGet({
     call: grpc.ServerUnaryCall<utilsPB.EmptyMessage, keysPB.Certificate>,
     callback: grpc.sendUnaryData<keysPB.Certificate>,
   ): Promise<void> => {
-    const response = new keysPB.Certificate();
     try {
+      const response = new keysPB.Certificate();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
       const cert = keyManager.getRootCertPem();
       response.setCert(cert);
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/keysDecrypt.ts
+++ b/src/client/service/keysDecrypt.ts
@@ -15,8 +15,8 @@ function keysDecrypt({
     call: grpc.ServerUnaryCall<keysPB.Crypto, keysPB.Crypto>,
     callback: grpc.sendUnaryData<keysPB.Crypto>,
   ): Promise<void> => {
-    const response = new keysPB.Crypto();
     try {
+      const response = new keysPB.Crypto();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
       const data = await keyManager.decryptWithRootKeyPair(
@@ -25,8 +25,8 @@ function keysDecrypt({
       response.setData(data.toString('binary'));
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/keysEncrypt.ts
+++ b/src/client/service/keysEncrypt.ts
@@ -15,8 +15,8 @@ function keysEncrypt({
     call: grpc.ServerUnaryCall<keysPB.Crypto, keysPB.Crypto>,
     callback: grpc.sendUnaryData<keysPB.Crypto>,
   ): Promise<void> => {
-    const response = new keysPB.Crypto();
     try {
+      const response = new keysPB.Crypto();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
       const data = await keyManager.encryptWithRootKeyPair(
@@ -25,8 +25,8 @@ function keysEncrypt({
       response.setData(data.toString('binary'));
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/keysKeyPairRenew.ts
+++ b/src/client/service/keysKeyPairRenew.ts
@@ -16,8 +16,8 @@ function keysKeyPairRenew({
     call: grpc.ServerUnaryCall<keysPB.Key, utilsPB.EmptyMessage>,
     callback: grpc.sendUnaryData<utilsPB.EmptyMessage>,
   ): Promise<void> => {
-    const response = new utilsPB.EmptyMessage();
     try {
+      const response = new utilsPB.EmptyMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
       // Other domains will be updated accordingly via the `EventBus` so we
@@ -25,8 +25,8 @@ function keysKeyPairRenew({
       await keyManager.renewRootKeyPair(call.request.getName());
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/keysKeyPairReset.ts
+++ b/src/client/service/keysKeyPairReset.ts
@@ -16,8 +16,8 @@ function keysKeyPairReset({
     call: grpc.ServerUnaryCall<keysPB.Key, utilsPB.EmptyMessage>,
     callback: grpc.sendUnaryData<utilsPB.EmptyMessage>,
   ): Promise<void> => {
-    const response = new utilsPB.EmptyMessage();
     try {
+      const response = new utilsPB.EmptyMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
       // Other domains will be updated accordingly via the `EventBus` so we
@@ -25,8 +25,8 @@ function keysKeyPairReset({
       await keyManager.resetRootKeyPair(call.request.getName());
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/keysKeyPairRoot.ts
+++ b/src/client/service/keysKeyPairRoot.ts
@@ -16,8 +16,8 @@ function keysKeyPairRoot({
     call: grpc.ServerUnaryCall<utilsPB.EmptyMessage, keysPB.KeyPair>,
     callback: grpc.sendUnaryData<keysPB.KeyPair>,
   ): Promise<void> => {
-    const response = new keysPB.KeyPair();
     try {
+      const response = new keysPB.KeyPair();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
       const keyPair = keyManager.getRootKeyPairPem();
@@ -25,8 +25,8 @@ function keysKeyPairRoot({
       response.setPrivate(keyPair.privateKey);
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/keysPasswordChange.ts
+++ b/src/client/service/keysPasswordChange.ts
@@ -16,16 +16,15 @@ function keysPasswordChange({
     call: grpc.ServerUnaryCall<sessionsPB.Password, utilsPB.EmptyMessage>,
     callback: grpc.sendUnaryData<utilsPB.EmptyMessage>,
   ): Promise<void> => {
-    const response = new utilsPB.EmptyMessage();
     try {
+      const response = new utilsPB.EmptyMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
-
       await keyManager.changePassword(call.request.getPassword());
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/keysSign.ts
+++ b/src/client/service/keysSign.ts
@@ -15,19 +15,18 @@ function keysSign({
     call: grpc.ServerUnaryCall<keysPB.Crypto, keysPB.Crypto>,
     callback: grpc.sendUnaryData<keysPB.Crypto>,
   ): Promise<void> => {
-    const response = new keysPB.Crypto();
     try {
+      const response = new keysPB.Crypto();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
-
       const signature = await keyManager.signWithRootKeyPair(
         Buffer.from(call.request.getData(), 'binary'),
       );
       response.setSignature(signature.toString('binary'));
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/keysVerify.ts
+++ b/src/client/service/keysVerify.ts
@@ -16,8 +16,8 @@ function keysVerify({
     call: grpc.ServerUnaryCall<keysPB.Crypto, utilsPB.StatusMessage>,
     callback: grpc.sendUnaryData<utilsPB.StatusMessage>,
   ): Promise<void> => {
-    const response = new utilsPB.StatusMessage();
     try {
+      const response = new utilsPB.StatusMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
       const status = await keyManager.verifyWithRootKeyPair(
@@ -27,8 +27,8 @@ function keysVerify({
       response.setSuccess(status);
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/nodesClaim.ts
+++ b/src/client/service/nodesClaim.ts
@@ -1,11 +1,12 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { Authenticate } from '../types';
 import type { NodeManager } from '../../nodes';
-import type { NotificationData } from '../../notifications/types';
+import type { NodeId } from '../../nodes/types';
 import type { NotificationsManager } from '../../notifications';
 import type * as nodesPB from '../../proto/js/polykey/v1/nodes/nodes_pb';
-import { utils as nodesUtils } from '../../nodes';
 import { utils as grpcUtils } from '../../grpc';
+import { validateSync, utils as validationUtils } from '../../validation';
+import { matchSync } from '../../utils';
 import * as utilsPB from '../../proto/js/polykey/v1/utils/utils_pb';
 
 /**
@@ -26,31 +27,44 @@ function nodesClaim({
     call: grpc.ServerUnaryCall<nodesPB.Claim, utilsPB.StatusMessage>,
     callback: grpc.sendUnaryData<utilsPB.StatusMessage>,
   ): Promise<void> => {
-    const response = new utilsPB.StatusMessage();
     try {
+      const response = new utilsPB.StatusMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
-      const remoteNodeId = nodesUtils.decodeNodeId(call.request.getNodeId());
+      const {
+        nodeId,
+      }: {
+        nodeId: NodeId;
+      } = validateSync(
+        (keyPath, value) => {
+          return matchSync(keyPath)(
+            [['nodeId'], () => validationUtils.parseNodeId(value)],
+            () => value,
+          );
+        },
+        {
+          nodeId: call.request.getNodeId(),
+        },
+      );
       const gestaltInvite = await notificationsManager.findGestaltInvite(
-        remoteNodeId,
+        nodeId,
       );
       // Check first whether there is an existing gestalt invite from the remote node
       // or if we want to force an invitation rather than a claim
       if (gestaltInvite === undefined || call.request.getForceInvite()) {
-        const data = {
+        await notificationsManager.sendNotification(nodeId, {
           type: 'GestaltInvite',
-        } as NotificationData;
-        await notificationsManager.sendNotification(remoteNodeId, data);
+        });
         response.setSuccess(false);
       } else {
         // There is an existing invitation, and we want to claim the node
-        await nodeManager.claimNode(remoteNodeId);
+        await nodeManager.claimNode(nodeId);
         response.setSuccess(true);
       }
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/nodesPing.ts
+++ b/src/client/service/nodesPing.ts
@@ -1,9 +1,11 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { Authenticate } from '../types';
 import type { NodeManager } from '../../nodes';
+import type { NodeId } from '../../nodes/types';
 import type * as nodesPB from '../../proto/js/polykey/v1/nodes/nodes_pb';
-import { utils as nodesUtils } from '../../nodes';
 import { utils as grpcUtils } from '../../grpc';
+import { validateSync, utils as validationUtils } from '../../validation';
+import { matchSync } from '../../utils';
 import * as utilsPB from '../../proto/js/polykey/v1/utils/utils_pb';
 
 /**
@@ -20,17 +22,31 @@ function nodesPing({
     call: grpc.ServerUnaryCall<nodesPB.Node, utilsPB.StatusMessage>,
     callback: grpc.sendUnaryData<utilsPB.StatusMessage>,
   ): Promise<void> => {
-    const response = new utilsPB.StatusMessage();
     try {
+      const response = new utilsPB.StatusMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
-      const nodeId = nodesUtils.decodeNodeId(call.request.getNodeId());
+      const {
+        nodeId,
+      }: {
+        nodeId: NodeId;
+      } = validateSync(
+        (keyPath, value) => {
+          return matchSync(keyPath)(
+            [['nodeId'], () => validationUtils.parseNodeId(value)],
+            () => value,
+          );
+        },
+        {
+          nodeId: call.request.getNodeId(),
+        },
+      );
       const status = await nodeManager.pingNode(nodeId);
       response.setSuccess(status);
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/notificationsClear.ts
+++ b/src/client/service/notificationsClear.ts
@@ -15,16 +15,15 @@ function notificationsClear({
     call: grpc.ServerUnaryCall<utilsPB.EmptyMessage, utilsPB.EmptyMessage>,
     callback: grpc.sendUnaryData<utilsPB.EmptyMessage>,
   ): Promise<void> => {
-    const response = new utilsPB.EmptyMessage();
     try {
+      const response = new utilsPB.EmptyMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
-
       await notificationsManager.clearNotifications();
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/notificationsRead.ts
+++ b/src/client/service/notificationsRead.ts
@@ -15,8 +15,8 @@ function notificationsRead({
     call: grpc.ServerUnaryCall<notificationsPB.Read, notificationsPB.List>,
     callback: grpc.sendUnaryData<notificationsPB.List>,
   ): Promise<void> => {
-    const response = new notificationsPB.List();
     try {
+      const response = new notificationsPB.List();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
       const unread = call.request.getUnread();
@@ -63,8 +63,8 @@ function notificationsRead({
       response.setNotificationList(notifMessages);
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/vaultsClone.ts
+++ b/src/client/service/vaultsClone.ts
@@ -9,8 +9,8 @@ function vaultsClone({ authenticate }: { authenticate: Authenticate }) {
     call: grpc.ServerUnaryCall<vaultsPB.Clone, utilsPB.StatusMessage>,
     callback: grpc.sendUnaryData<utilsPB.StatusMessage>,
   ): Promise<void> => {
-    const response = new utilsPB.StatusMessage();
     try {
+      const response = new utilsPB.StatusMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
 
@@ -35,8 +35,8 @@ function vaultsClone({ authenticate }: { authenticate: Authenticate }) {
       response.setSuccess(true);
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/vaultsCreate.ts
+++ b/src/client/service/vaultsCreate.ts
@@ -29,8 +29,8 @@ function vaultsCreate({
       response.setNameOrId(vaultsUtils.makeVaultIdPretty(vault.vaultId));
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/vaultsDelete.ts
+++ b/src/client/service/vaultsDelete.ts
@@ -26,8 +26,8 @@ function vaultsDelete({
     callback: grpc.sendUnaryData<utilsPB.StatusMessage>,
   ): Promise<void> => {
     const vaultMessage = call.request;
-    const response = new utilsPB.StatusMessage();
     try {
+      const response = new utilsPB.StatusMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
       const nameOrId = vaultMessage.getNameOrId();
@@ -38,8 +38,8 @@ function vaultsDelete({
       response.setSuccess(true);
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/vaultsList.ts
+++ b/src/client/service/vaultsList.ts
@@ -33,8 +33,8 @@ function vaultsList({
       }
       await genWritable.next(null);
       return;
-    } catch (err) {
-      await genWritable.throw(err);
+    } catch (e) {
+      await genWritable.throw(e);
       return;
     }
   };

--- a/src/client/service/vaultsLog.ts
+++ b/src/client/service/vaultsLog.ts
@@ -56,8 +56,8 @@ function vaultsLog({
       }
       await genWritable.next(null);
       return;
-    } catch (err) {
-      await genWritable.throw(err);
+    } catch (e) {
+      await genWritable.throw(e);
       return;
     }
   };

--- a/src/client/service/vaultsPermissions.ts
+++ b/src/client/service/vaultsPermissions.ts
@@ -43,8 +43,8 @@ function vaultsPermissions({ authenticate }: { authenticate: Authenticate }) {
       // }
       await genWritable.next(null);
       return;
-    } catch (err) {
-      await genWritable.throw(err);
+    } catch (e) {
+      await genWritable.throw(e);
       return;
     }
   };

--- a/src/client/service/vaultsPermissionsSet.ts
+++ b/src/client/service/vaultsPermissionsSet.ts
@@ -35,8 +35,8 @@ function vaultsPermissionsSet({
       response.setSuccess(true);
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/vaultsPermissionsUnset.ts
+++ b/src/client/service/vaultsPermissionsUnset.ts
@@ -35,8 +35,8 @@ function vaultsPermissionsUnset({
       response.setSuccess(true);
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/vaultsPull.ts
+++ b/src/client/service/vaultsPull.ts
@@ -9,8 +9,8 @@ function vaultsPull({ authenticate }: { authenticate: Authenticate }) {
     call: grpc.ServerUnaryCall<vaultsPB.Pull, utilsPB.StatusMessage>,
     callback: grpc.sendUnaryData<utilsPB.StatusMessage>,
   ): Promise<void> => {
-    const response = new utilsPB.StatusMessage();
     try {
+      const response = new utilsPB.StatusMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
 
@@ -33,8 +33,8 @@ function vaultsPull({ authenticate }: { authenticate: Authenticate }) {
       response.setSuccess(true);
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/vaultsRename.ts
+++ b/src/client/service/vaultsRename.ts
@@ -24,8 +24,8 @@ function vaultsRename({
     call: grpc.ServerUnaryCall<vaultsPB.Rename, vaultsPB.Vault>,
     callback: grpc.sendUnaryData<vaultsPB.Vault>,
   ): Promise<void> => {
-    const response = new vaultsPB.Vault();
     try {
+      const response = new vaultsPB.Vault();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
       const vaultMessage = call.request.getVault();
@@ -42,8 +42,8 @@ function vaultsRename({
       response.setNameOrId(vaultsUtils.makeVaultIdPretty(vaultId));
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/vaultsScan.ts
+++ b/src/client/service/vaultsScan.ts
@@ -17,12 +17,9 @@ function vaultsScan({
     call: grpc.ServerWritableStream<nodesPB.Node, vaultsPB.List>,
   ): Promise<void> => {
     const genWritable = grpcUtils.generatorWritable(call);
-    // Const possibleNodeId = nodesUtils.decodeNodeId(call.request.getNodeId());
-    // const nodeId = nodesUtils.validateNodeId(possibleNodeId);
     try {
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
-
       const vaults = await vaultManager.listVaults();
       vaults.forEach(async (vaultId, vaultName) => {
         const vaultListMessage = new vaultsPB.List();
@@ -32,8 +29,8 @@ function vaultsScan({
       });
       await genWritable.next(null);
       return;
-    } catch (err) {
-      await genWritable.throw(err);
+    } catch (e) {
+      await genWritable.throw(e);
       return;
     }
   };

--- a/src/client/service/vaultsSecretsDelete.ts
+++ b/src/client/service/vaultsSecretsDelete.ts
@@ -25,8 +25,8 @@ function vaultsSecretsDelete({
     call: grpc.ServerUnaryCall<secretsPB.Secret, utilsPB.StatusMessage>,
     callback: grpc.sendUnaryData<utilsPB.StatusMessage>,
   ): Promise<void> => {
-    const response = new utilsPB.StatusMessage();
     try {
+      const response = new utilsPB.StatusMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
 
@@ -45,8 +45,8 @@ function vaultsSecretsDelete({
       response.setSuccess(true);
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/vaultsSecretsEdit.ts
+++ b/src/client/service/vaultsSecretsEdit.ts
@@ -25,8 +25,8 @@ function vaultsSecretsEdit({
     call: grpc.ServerUnaryCall<secretsPB.Secret, utilsPB.StatusMessage>,
     callback: grpc.sendUnaryData<utilsPB.StatusMessage>,
   ): Promise<void> => {
-    const response = new utilsPB.StatusMessage();
     try {
+      const response = new utilsPB.StatusMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
 
@@ -51,8 +51,8 @@ function vaultsSecretsEdit({
       response.setSuccess(true);
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/vaultsSecretsGet.ts
+++ b/src/client/service/vaultsSecretsGet.ts
@@ -25,8 +25,8 @@ function vaultsSecretsGet({
     call: grpc.ServerUnaryCall<secretsPB.Secret, utilsPB.EmptyMessage>,
     callback: grpc.sendUnaryData<secretsPB.Secret>,
   ): Promise<void> => {
-    const response = new secretsPB.Secret();
     try {
+      const response = new secretsPB.Secret();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
 
@@ -45,8 +45,8 @@ function vaultsSecretsGet({
       response.setSecretContent(secretContent);
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/vaultsSecretsList.ts
+++ b/src/client/service/vaultsSecretsList.ts
@@ -43,8 +43,8 @@ function vaultsSecretsList({
       }
       await genWritable.next(null);
       return;
-    } catch (err) {
-      await genWritable.throw(err);
+    } catch (e) {
+      await genWritable.throw(e);
       return;
     }
   };

--- a/src/client/service/vaultsSecretsMkdir.ts
+++ b/src/client/service/vaultsSecretsMkdir.ts
@@ -25,8 +25,8 @@ function vaultsSecretsMkdir({
     call: grpc.ServerUnaryCall<vaultsPB.Mkdir, utilsPB.EmptyMessage>,
     callback: grpc.sendUnaryData<utilsPB.StatusMessage>,
   ): Promise<void> => {
-    const response = new utilsPB.StatusMessage();
     try {
+      const response = new utilsPB.StatusMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
 
@@ -47,8 +47,8 @@ function vaultsSecretsMkdir({
       response.setSuccess(true);
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/vaultsSecretsNew.ts
+++ b/src/client/service/vaultsSecretsNew.ts
@@ -25,8 +25,8 @@ function vaultsSecretsNew({
     call: grpc.ServerUnaryCall<secretsPB.Secret, utilsPB.StatusMessage>,
     callback: grpc.sendUnaryData<utilsPB.StatusMessage>,
   ): Promise<void> => {
-    const response = new utilsPB.StatusMessage();
     try {
+      const response = new utilsPB.StatusMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
 
@@ -46,8 +46,8 @@ function vaultsSecretsNew({
       response.setSuccess(true);
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/vaultsSecretsNewDir.ts
+++ b/src/client/service/vaultsSecretsNewDir.ts
@@ -28,8 +28,8 @@ function vaultsSecretsNewDir({
     call: grpc.ServerUnaryCall<secretsPB.Directory, utilsPB.EmptyMessage>,
     callback: grpc.sendUnaryData<utilsPB.StatusMessage>,
   ): Promise<void> => {
-    const response = new utilsPB.StatusMessage();
     try {
+      const response = new utilsPB.StatusMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
 
@@ -48,8 +48,8 @@ function vaultsSecretsNewDir({
       response.setSuccess(true);
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/vaultsSecretsRename.ts
+++ b/src/client/service/vaultsSecretsRename.ts
@@ -25,8 +25,8 @@ function vaultsSecretsRename({
     call: grpc.ServerUnaryCall<secretsPB.Rename, utilsPB.StatusMessage>,
     callback: grpc.sendUnaryData<utilsPB.StatusMessage>,
   ): Promise<void> => {
-    const response = new utilsPB.StatusMessage();
     try {
+      const response = new utilsPB.StatusMessage();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
       const secretMessage = call.request.getOldSecret();
@@ -50,8 +50,8 @@ function vaultsSecretsRename({
       response.setSuccess(true);
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/vaultsSecretsStat.ts
+++ b/src/client/service/vaultsSecretsStat.ts
@@ -8,8 +8,8 @@ function vaultsSecretsStat({ authenticate }: { authenticate: Authenticate }) {
     call: grpc.ServerUnaryCall<vaultsPB.Vault, vaultsPB.Stat>,
     callback: grpc.sendUnaryData<vaultsPB.Stat>,
   ): Promise<void> => {
-    const response = new vaultsPB.Stat();
     try {
+      const response = new vaultsPB.Stat();
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
 
@@ -22,8 +22,8 @@ function vaultsSecretsStat({ authenticate }: { authenticate: Authenticate }) {
       // response.setStats(JSON.stringify(stats)););
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/client/service/vaultsVersion.ts
+++ b/src/client/service/vaultsVersion.ts
@@ -24,8 +24,8 @@ function vaultsVersion({
     call: grpc.ServerUnaryCall<vaultsPB.Version, vaultsPB.VersionResult>,
     callback: grpc.sendUnaryData<vaultsPB.VersionResult>,
   ): Promise<void> => {
-    const response = new vaultsPB.VersionResult();
     try {
+      const response = new vaultsPB.VersionResult();
       // Checking session token
       const metadata = await authenticate(call.metadata);
       call.sendMetadata(metadata);
@@ -60,8 +60,8 @@ function vaultsVersion({
       // Sending message
       callback(null, response);
       return;
-    } catch (err) {
-      callback(grpcUtils.fromError(err), null);
+    } catch (e) {
+      callback(grpcUtils.fromError(e));
       return;
     }
   };

--- a/src/discovery/Discovery.ts
+++ b/src/discovery/Discovery.ts
@@ -113,7 +113,7 @@ class Discovery {
         // The sigchain data of the vertex (containing all cryptolinks)
         let vertexChainData: ChainData = {};
         // If the vertex we've found is our own node, we simply get our own chain
-        const nodeId = nodesUtils.decodeNodeId(vertexGId.nodeId);
+        const nodeId = nodesUtils.decodeNodeId(vertexGId.nodeId)!;
         if (nodeId.equals(this.nodeManager.getNodeId())) {
           const vertexChainDataEncoded = await this.nodeManager.getChainData();
           // Decode all our claims - no need to verify (on our own sigchain)
@@ -152,7 +152,7 @@ class Discovery {
             // Get the chain data of the linked node
             const linkedVertexNodeId = nodesUtils.decodeNodeId(
               claim.payload.data.node2,
-            );
+            )!;
             const linkedVertexChainData =
               await this.nodeManager.requestChainData(linkedVertexNodeId);
             // With this verified chain, we can link
@@ -224,7 +224,7 @@ class Discovery {
           // Claims on an identity provider will always be node -> identity
           // So just cast payload data as such
           const data = claim.payload.data as ClaimLinkIdentity;
-          const linkedVertexNodeId = nodesUtils.decodeNodeId(data.node);
+          const linkedVertexNodeId = nodesUtils.decodeNodeId(data.node)!;
           // Get the chain data of this claimed node (so that we can link in GG)
           const linkedVertexChainData = await this.nodeManager.requestChainData(
             linkedVertexNodeId,
@@ -316,7 +316,9 @@ class Discovery {
       // Verify the claim with the public key of the node
       const verified = await claimsUtils.verifyClaimSignature(
         encoded,
-        await this.nodeManager.getPublicKey(nodesUtils.decodeNodeId(data.node)),
+        await this.nodeManager.getPublicKey(
+          nodesUtils.decodeNodeId(data.node)!,
+        ),
       );
       // If verified, add to the record
       if (verified) {

--- a/src/discovery/Discovery.ts
+++ b/src/discovery/Discovery.ts
@@ -10,7 +10,7 @@ import type {
 } from '../identities/types';
 import type { NodeManager } from '../nodes';
 import type { Provider, IdentitiesManager } from '../identities';
-import type { Claim, ClaimIdString, ClaimLinkIdentity } from '../claims/types';
+import type { Claim, ClaimIdEncoded, ClaimLinkIdentity } from '../claims/types';
 
 import type { ChainData } from '../sigchain/types';
 import Logger from '@matrixai/logger';
@@ -118,7 +118,7 @@ class Discovery {
           const vertexChainDataEncoded = await this.nodeManager.getChainData();
           // Decode all our claims - no need to verify (on our own sigchain)
           for (const c in vertexChainDataEncoded) {
-            const claimId = c as ClaimIdString;
+            const claimId = c as ClaimIdEncoded;
             vertexChainData[claimId] = claimsUtils.decodeClaim(
               vertexChainDataEncoded[claimId],
             );
@@ -145,7 +145,7 @@ class Discovery {
         // that this will iterate in lexicographical order of keys. For now,
         // this doesn't matter though (because of the previous comment).
         for (const claimId in vertexChainData) {
-          const claim: Claim = vertexChainData[claimId as ClaimIdString];
+          const claim: Claim = vertexChainData[claimId as ClaimIdEncoded];
 
           // If the claim is to a node
           if (claim.payload.data.type === 'node') {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -60,4 +60,5 @@ export * from './bootstrap/errors';
 export * from './notifications/errors';
 export * from './schema/errors';
 export * from './status/errors';
+export * from './validation/errors';
 export * from './utils/errors';

--- a/src/gestalts/GestaltGraph.ts
+++ b/src/gestalts/GestaltGraph.ts
@@ -283,7 +283,7 @@ class GestaltGraph {
       if (gId.type === 'node') {
         ops.push(
           ...(await this.unlinkNodeAndIdentityOps(
-            nodesUtils.decodeNodeId(gId.nodeId),
+            nodesUtils.decodeNodeId(gId.nodeId)!,
             providerId,
             identityId,
           )),
@@ -318,7 +318,7 @@ class GestaltGraph {
   @ready(new gestaltsErrors.ErrorGestaltsGraphNotRunning())
   public async setNodeOps(nodeInfo: NodeInfo): Promise<Array<DBOp>> {
     const nodeKey = gestaltsUtils.keyFromNode(
-      nodesUtils.decodeNodeId(nodeInfo.id),
+      nodesUtils.decodeNodeId(nodeInfo.id)!,
     );
     const ops: Array<DBOp> = [];
     let nodeKeyKeys = await this.db.get<GestaltKeySet>(
@@ -330,7 +330,7 @@ class GestaltGraph {
       // Sets the gestalt in the acl
       ops.push(
         ...(await this.acl.setNodePermOps(
-          nodesUtils.decodeNodeId(nodeInfo.id),
+          nodesUtils.decodeNodeId(nodeInfo.id)!,
           {
             gestalt: {},
             vaults: {},
@@ -392,7 +392,7 @@ class GestaltGraph {
         ops.push(
           ...(await this.unlinkNodeAndNodeOps(
             nodeId,
-            nodesUtils.decodeNodeId(gId.nodeId),
+            nodesUtils.decodeNodeId(gId.nodeId)!,
           )),
         );
       } else if (gId.type === 'identity') {
@@ -437,7 +437,7 @@ class GestaltGraph {
   ): Promise<Array<DBOp>> {
     const ops: Array<DBOp> = [];
     const nodeKey = gestaltsUtils.keyFromNode(
-      nodesUtils.decodeNodeId(nodeInfo.id),
+      nodesUtils.decodeNodeId(nodeInfo.id)!,
     );
     const identityKey = gestaltsUtils.keyFromIdentity(
       identityInfo.providerId,
@@ -489,7 +489,7 @@ class GestaltGraph {
     if (nodeNew && identityNew) {
       ops.push(
         ...(await this.acl.setNodePermOps(
-          nodesUtils.decodeNodeId(nodeInfo.id),
+          nodesUtils.decodeNodeId(nodeInfo.id)!,
           {
             gestalt: {},
             vaults: {},
@@ -510,7 +510,7 @@ class GestaltGraph {
       );
       // These must exist
       const nodePerm = (await this.acl.getNodePerm(
-        nodesUtils.decodeNodeId(nodeInfo.id),
+        nodesUtils.decodeNodeId(nodeInfo.id)!,
       )) as Permission;
       const identityPerm = (await this.acl.getNodePerm(
         identityNodeIds[0],
@@ -522,7 +522,7 @@ class GestaltGraph {
       // and the perm record update
       ops.push(
         ...(await this.acl.joinNodePermOps(
-          nodesUtils.decodeNodeId(nodeInfo.id),
+          nodesUtils.decodeNodeId(nodeInfo.id)!,
           identityNodeIds,
           permNew,
         )),
@@ -531,7 +531,7 @@ class GestaltGraph {
       if (utils.isEmptyObject(identityKeyKeys)) {
         ops.push(
           ...(await this.acl.setNodePermOps(
-            nodesUtils.decodeNodeId(nodeInfo.id),
+            nodesUtils.decodeNodeId(nodeInfo.id)!,
             {
               gestalt: {},
               vaults: {},
@@ -547,7 +547,7 @@ class GestaltGraph {
         const identityNodeId = gestaltsUtils.nodeFromKey(identityNodeKey!);
         ops.push(
           ...(await this.acl.joinNodePermOps(identityNodeId, [
-            nodesUtils.decodeNodeId(nodeInfo.id),
+            nodesUtils.decodeNodeId(nodeInfo.id)!,
           ])),
         );
       }
@@ -602,8 +602,8 @@ class GestaltGraph {
     nodeInfo2: NodeInfo,
   ): Promise<Array<DBOp>> {
     const ops: Array<DBOp> = [];
-    const nodeIdEncoded1 = nodesUtils.decodeNodeId(nodeInfo1.id);
-    const nodeIdEncoded2 = nodesUtils.decodeNodeId(nodeInfo2.id);
+    const nodeIdEncoded1 = nodesUtils.decodeNodeId(nodeInfo1.id)!;
+    const nodeIdEncoded2 = nodesUtils.decodeNodeId(nodeInfo2.id)!;
     const nodeKey1 = gestaltsUtils.keyFromNode(nodeIdEncoded1);
     const nodeKey2 = gestaltsUtils.keyFromNode(nodeIdEncoded2);
     let nodeKeyKeys1 = await this.db.get<GestaltKeySet>(

--- a/src/gestalts/errors.ts
+++ b/src/gestalts/errors.ts
@@ -12,8 +12,6 @@ class ErrorGestaltsGraphNodeIdMissing extends ErrorGestalts {}
 
 class ErrorGestaltsGraphIdentityIdMissing extends ErrorGestalts {}
 
-class ErrorGestaltsInvalidAction extends ErrorGestalts {}
-
 export {
   ErrorGestalts,
   ErrorGestaltsGraphRunning,
@@ -21,5 +19,4 @@ export {
   ErrorGestaltsGraphDestroyed,
   ErrorGestaltsGraphNodeIdMissing,
   ErrorGestaltsGraphIdentityIdMissing,
-  ErrorGestaltsInvalidAction,
 };

--- a/src/gestalts/types.ts
+++ b/src/gestalts/types.ts
@@ -2,7 +2,9 @@ import type { Opaque } from '../types';
 import type { NodeIdEncoded, NodeInfo } from '../nodes/types';
 import type { IdentityId, ProviderId, IdentityInfo } from '../identities/types';
 
-type GestaltAction = 'notify' | 'scan';
+const gestaltActions = ['notify', 'scan'] as const;
+
+type GestaltAction = typeof gestaltActions[number];
 type GestaltActions = Partial<Record<GestaltAction, null>>;
 
 type GestaltId = GestaltNodeId | GestaltIdentityId;
@@ -29,6 +31,8 @@ type Gestalt = {
   nodes: GestaltNodes;
   identities: GestaltIdentities;
 };
+
+export { gestaltActions };
 
 export type {
   GestaltAction,

--- a/src/gestalts/utils.ts
+++ b/src/gestalts/utils.ts
@@ -60,16 +60,14 @@ function keyFromIdentity(
 
 /**
  * Deconstruct GestaltKey to NodeId
- * This is a partial function.
  */
 function nodeFromKey(nodeKey: GestaltNodeKey): NodeId {
   const node = ungestaltKey(nodeKey) as GestaltNodeId;
-  return nodesUtils.decodeNodeId(node.nodeId);
+  return nodesUtils.decodeNodeId(node.nodeId)!;
 }
 
 /**
  * Deconstruct GestaltKey to IdentityId and ProviderId
- * This is a partial function.
  */
 function identityFromKey(
   identityKey: GestaltIdentityKey,

--- a/src/gestalts/utils.ts
+++ b/src/gestalts/utils.ts
@@ -9,9 +9,8 @@ import type {
 } from './types';
 import type { NodeId } from '../nodes/types';
 import type { IdentityId, ProviderId } from '../identities/types';
-
 import canonicalize from 'canonicalize';
-import { ErrorGestaltsInvalidAction } from './errors';
+import { gestaltActions } from './types';
 import { utils as nodesUtils } from '../nodes';
 
 /**
@@ -76,15 +75,9 @@ function identityFromKey(
   return [identity.providerId, identity.identityId];
 }
 
-const validGestaltAction = ['notify', 'scan'];
-function isGestaltAction(arg: any): arg is GestaltAction {
-  if (typeof arg !== 'string') return false;
-  return validGestaltAction.includes(arg);
-}
-
-function makeGestaltAction(value: string): GestaltAction {
-  if (isGestaltAction(value)) return value;
-  throw new ErrorGestaltsInvalidAction(`${value} is not a valid GestaltAction`);
+function isGestaltAction(action: any): action is GestaltAction {
+  if (typeof action !== 'string') return false;
+  return (gestaltActions as Readonly<Array<string>>).includes(action);
 }
 
 export {
@@ -95,5 +88,4 @@ export {
   nodeFromKey,
   identityFromKey,
   isGestaltAction,
-  makeGestaltAction,
 };

--- a/src/grpc/utils/utils.ts
+++ b/src/grpc/utils/utils.ts
@@ -144,15 +144,20 @@ function getClientSession(
 }
 
 /**
- * Serializes ErrorPolykey instances into GRPC errors
+ * Serializes Error instances into GRPC errors
  * Use this on the sending side to send exceptions
  * Do not send exceptions to clients you do not trust
  */
-function fromError(error: errors.ErrorPolykey): ServerStatusResponse {
+function fromError(error: Error): ServerStatusResponse {
   const metadata = new grpc.Metadata();
+  // If the error is not ErrorPolykey, wrap it up so it can be serialised
+  // TODO: add additional metadata regarding the network location of the error
+  if (!(error instanceof errors.ErrorPolykey)) {
+    error = new errors.ErrorPolykey(error.message);
+  }
   metadata.set('name', error.name);
   metadata.set('message', error.message);
-  metadata.set('data', JSON.stringify(error.data));
+  metadata.set('data', JSON.stringify((error as errors.ErrorPolykey).data));
   return {
     metadata,
   };

--- a/src/identities/Provider.ts
+++ b/src/identities/Provider.ts
@@ -95,6 +95,7 @@ abstract class Provider {
     } catch (e) {
       return;
     }
+    // TODO: Add node ID validation here?
     if (!schema.claimIdentityValidate(claim)) {
       return;
     }

--- a/src/identities/errors.ts
+++ b/src/identities/errors.ts
@@ -3,7 +3,9 @@ import { ErrorPolykey } from '../errors';
 class ErrorIdentities extends ErrorPolykey {}
 
 class ErrorIdentitiesManagerRunning extends ErrorIdentities {}
+
 class ErrorIdentitiesManagerNotRunning extends ErrorIdentities {}
+
 class ErrorIdentitiesManagerDestroyed extends ErrorIdentities {}
 
 class ErrorProviderDuplicate extends ErrorIdentities {}
@@ -16,6 +18,8 @@ class ErrorProviderUnauthenticated extends ErrorIdentities {}
 
 class ErrorProviderUnimplemented extends ErrorIdentities {}
 
+class ErrorProviderMissing extends ErrorIdentities {}
+
 export {
   ErrorIdentities,
   ErrorIdentitiesManagerRunning,
@@ -26,4 +30,5 @@ export {
   ErrorProviderAuthentication,
   ErrorProviderUnauthenticated,
   ErrorProviderUnimplemented,
+  ErrorProviderMissing,
 };

--- a/src/network/ConnectionForward.ts
+++ b/src/network/ConnectionForward.ts
@@ -295,7 +295,7 @@ class ConnectionForward extends Connection {
 
   @ready(new networkErrors.ErrorConnectionNotRunning())
   public getServerNodeIds(): Array<NodeId> {
-    return this.serverCertChain.map((c) => networkUtils.certNodeId(c));
+    return this.serverCertChain.map((c) => keysUtils.certNodeId(c)!);
   }
 
   protected async startKeepAliveInterval(): Promise<void> {

--- a/src/network/ConnectionReverse.ts
+++ b/src/network/ConnectionReverse.ts
@@ -328,7 +328,7 @@ class ConnectionReverse extends Connection {
     if (!this._composed) {
       throw new networkErrors.ErrorConnectionNotComposed();
     }
-    return this.clientCertChain.map((c) => networkUtils.certNodeId(c));
+    return this.clientCertChain.map((c) => keysUtils.certNodeId(c)!);
   }
 
   protected startKeepAliveTimeout() {

--- a/src/network/types.ts
+++ b/src/network/types.ts
@@ -6,11 +6,24 @@ import type {
 } from '../keys/types';
 import type { Opaque } from '../types';
 
-// Host is always an IP address
+/**
+ * Host is always an IP address
+ */
 type Host = Opaque<'Host', string>;
-// Specifically for hostname domain names (i.e. to be resolved to an IP address)
+
+/**
+ * Hostnames are resolved to IP addresses
+ */
 type Hostname = Opaque<'Hostname', string>;
+
+/**
+ * Ports are numbers from 0 to 65535
+ */
 type Port = Opaque<'Port', number>;
+
+/**
+ * Combination of `<HOST>:<PORT>`
+ */
 type Address = Opaque<'Address', string>;
 
 type TLSConfig = {

--- a/src/network/utils.ts
+++ b/src/network/utils.ts
@@ -8,9 +8,9 @@ import { Buffer } from 'buffer';
 import dns from 'dns';
 import { IPv4, IPv6, Validator } from 'ip-num';
 import * as networkErrors from './errors';
-import { isEmptyObject, promisify } from '../utils';
 import { utils as keysUtils } from '../keys';
 import { utils as nodesUtils } from '../nodes';
+import { isEmptyObject, promisify } from '../utils';
 
 const pingBuffer = serializeNetworkMessage({
   type: 'ping',
@@ -19,6 +19,35 @@ const pingBuffer = serializeNetworkMessage({
 const pongBuffer = serializeNetworkMessage({
   type: 'pong',
 });
+
+/**
+ * Validates that a provided host address is a valid IPv4 or IPv6 address.
+ */
+function isHost(host: any): host is Host {
+  if (typeof host !== 'string') return false;
+  const [isIPv4] = Validator.isValidIPv4String(host);
+  const [isIPv6] = Validator.isValidIPv6String(host);
+  return isIPv4 || isIPv6;
+}
+
+/**
+ * Validates hostname as per RFC 1123
+ */
+function isHostname(hostname: any): hostname is Hostname {
+  if (typeof hostname !== 'string') return false;
+  const regex =
+    /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
+  return regex.test(hostname);
+}
+
+/**
+ * Ports must be numbers between 0 and 65535 inclusive
+ */
+function isPort(port: any): port is Port {
+  if (typeof port !== 'number') return false;
+  if (port < 0 || port > 65535) return false;
+  return true;
+}
 
 /**
  * Given a bearer token, return a authentication token string.
@@ -56,31 +85,11 @@ function parseAddress(address: string): [Host, Port] {
 }
 
 /**
- * Validates that a provided host address is a valid IPv4 or IPv6 address.
- */
-function isValidHost(host: string): boolean {
-  const [isIPv4] = Validator.isValidIPv4String(host);
-  const [isIPv6] = Validator.isValidIPv6String(host);
-  return isIPv4 || isIPv6;
-}
-
-/**
- * Validates that a provided hostname is valid, as per RFC 1123.
- */
-function isValidHostname(hostname: string): boolean {
-  return hostname.match(
-    /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/,
-  )
-    ? true
-    : false;
-}
-
-/**
- * Resolves a provided hostname to its respective IP address (type Host).
+ * Resolves a provided hostname to its respective IP address (type Host)
  */
 async function resolveHost(host: Host | Hostname): Promise<Host> {
   // If already IPv4/IPv6 address, return it
-  if (isValidHost(host)) {
+  if (isHost(host)) {
     return host as Host;
   }
   const lookup = promisify(dns.lookup).bind(dns);
@@ -344,11 +353,12 @@ function verifyClientCertificateChain(certChain: Array<Certificate>): void {
 export {
   pingBuffer,
   pongBuffer,
+  isHost,
+  isHostname,
+  isPort,
   toAuthToken,
   buildAddress,
   parseAddress,
-  isValidHost,
-  isValidHostname,
   resolveHost,
   resolvesZeroIP,
   serializeNetworkMessage,

--- a/src/network/utils.ts
+++ b/src/network/utils.ts
@@ -165,14 +165,6 @@ function isTLSSocket(socket: Socket | TLSSocket): socket is TLSSocket {
 }
 
 /**
- * Acquires the NodeId from a certificate
- */
-function certNodeId(cert: Certificate): NodeId {
-  const commonName = cert.subject.getField({ type: '2.5.4.3' });
-  return nodesUtils.decodeNodeId(commonName.value);
-}
-
-/**
  * Verify the server certificate chain when connecting to it from a client
  * This is a custom verification intended to verify that the server owned
  * the relevant NodeId.
@@ -362,7 +354,6 @@ export {
   serializeNetworkMessage,
   unserializeNetworkMessage,
   isTLSSocket,
-  certNodeId,
   getCertificateChain,
   verifyServerCertificateChain,
   verifyClientCertificateChain,

--- a/src/nodes/NodeConnection.ts
+++ b/src/nodes/NodeConnection.ts
@@ -7,7 +7,7 @@ import type { Certificate, PublicKey, PublicKeyPem } from '../keys/types';
 import type {
   ClaimEncoded,
   ClaimIntermediary,
-  ClaimIdString,
+  ClaimIdEncoded,
 } from '../claims/types';
 
 import type { ForwardProxy } from '../network';
@@ -332,7 +332,7 @@ class NodeConnection {
     const response = await this.client.nodesChainDataGet(emptyMsg);
     // Reconstruct each claim from the returned ChainDataMessage
     response.getChainDataMap().forEach((claimMsg, id: string) => {
-      const claimId = id as ClaimIdString;
+      const claimId = id as ClaimIdEncoded;
       // Reconstruct the signatures array
       const signatures: Array<{ signature: string; protected: string }> = [];
       for (const signatureData of claimMsg.getSignaturesList()) {

--- a/src/nodes/NodeConnection.ts
+++ b/src/nodes/NodeConnection.ts
@@ -246,7 +246,7 @@ class NodeConnection {
     const certificates = this.getRootCertChain();
     let publicKey: PublicKeyPem | null = null;
     for (const cert of certificates) {
-      if (networkUtils.certNodeId(cert).equals(expectedNodeId)) {
+      if (keysUtils.certNodeId(cert)!.equals(expectedNodeId)) {
         publicKey = keysUtils.publicKeyToPem(
           cert.publicKey as PublicKey,
         ) as PublicKeyPem;

--- a/src/nodes/NodeConnection.ts
+++ b/src/nodes/NodeConnection.ts
@@ -271,7 +271,7 @@ class NodeConnection {
     const nodes: Array<NodeData> = [];
     // Loop over each map element (from the returned response) and populate nodes
     response.getNodeTableMap().forEach((address, nodeIdEncoded: string) => {
-      const nodeId: NodeId = nodesUtils.decodeNodeId(nodeIdEncoded);
+      const nodeId: NodeId = nodesUtils.decodeNodeId(nodeIdEncoded)!;
       nodes.push({
         id: nodeId,
         address: {

--- a/src/nodes/NodeManager.ts
+++ b/src/nodes/NodeManager.ts
@@ -2,7 +2,7 @@ import type { KeyManager } from '../keys';
 import type { PublicKeyPem } from '../keys/types';
 import type { Sigchain } from '../sigchain';
 import type { ChainData, ChainDataEncoded } from '../sigchain/types';
-import type { ClaimIdString } from '../claims/types';
+import type { ClaimIdEncoded } from '../claims/types';
 import type {
   NodeId,
   NodeAddress,
@@ -312,7 +312,7 @@ class NodeManager {
     // node on the other end of the claim
     // e.g. a node claim from A -> B, verify with B's public key
     for (const c in verifiedChainData) {
-      const claimId = c as ClaimIdString;
+      const claimId = c as ClaimIdEncoded;
       const payload = verifiedChainData[claimId].payload;
       if (payload.data.type === 'node') {
         const endNodeId = nodesUtils.decodeNodeId(payload.data.node2);

--- a/src/nodes/NodeManager.ts
+++ b/src/nodes/NodeManager.ts
@@ -485,7 +485,7 @@ class NodeManager {
     const targetAddress = await this.findNode(targetNodeId);
     // If the stored host is not a valid host (IP address), then we assume it to
     // be a hostname
-    const targetHostname = !(await networkUtils.isValidHost(targetAddress.host))
+    const targetHostname = !(await networkUtils.isHost(targetAddress.host))
       ? (targetAddress.host as Hostname)
       : undefined;
     const connection = await NodeConnection.createNodeConnection({

--- a/src/nodes/NodeManager.ts
+++ b/src/nodes/NodeManager.ts
@@ -315,7 +315,8 @@ class NodeManager {
       const claimId = c as ClaimIdEncoded;
       const payload = verifiedChainData[claimId].payload;
       if (payload.data.type === 'node') {
-        const endNodeId = nodesUtils.decodeNodeId(payload.data.node2);
+        // TODO: remove ! assertion and perform exception handling in #310
+        const endNodeId = nodesUtils.decodeNodeId(payload.data.node2)!;
         let endPublicKey: PublicKeyPem;
         // If the claim points back to our own node, don't attempt to connect
         if (endNodeId.equals(this.getNodeId())) {
@@ -402,11 +403,11 @@ class NodeManager {
   @ready(new nodesErrors.ErrorNodeManagerNotRunning())
   public async relayHolePunchMessage(message: nodesPB.Relay): Promise<void> {
     const conn = await this.getConnectionToNode(
-      nodesUtils.decodeNodeId(message.getTargetId()),
+      nodesUtils.decodeNodeId(message.getTargetId())!,
     );
     await conn.sendHolePunchMessage(
-      nodesUtils.decodeNodeId(message.getSrcId()),
-      nodesUtils.decodeNodeId(message.getTargetId()),
+      nodesUtils.decodeNodeId(message.getSrcId())!,
+      nodesUtils.decodeNodeId(message.getTargetId())!,
       message.getEgressAddress(),
       Buffer.from(message.getSignature()),
     );

--- a/src/nodes/errors.ts
+++ b/src/nodes/errors.ts
@@ -45,16 +45,6 @@ class ErrorNodeConnectionInfoNotExist extends ErrorNodes {}
 
 class ErrorNodeConnectionPublicKeyNotFound extends ErrorNodes {}
 
-class ErrorInvalidNodeId extends ErrorNodes {
-  description: string = 'Invalid node ID.';
-  exitCode: number = 64;
-}
-
-class ErrorInvalidHost extends ErrorNodes {
-  description: string = 'Invalid IP address.';
-  exitCode: number = 64;
-}
-
 export {
   ErrorNodes,
   ErrorNodeManagerRunning,
@@ -76,6 +66,4 @@ export {
   ErrorNodeConnectionNotExist,
   ErrorNodeConnectionInfoNotExist,
   ErrorNodeConnectionPublicKeyNotFound,
-  ErrorInvalidNodeId,
-  ErrorInvalidHost,
 };

--- a/src/nodes/utils.ts
+++ b/src/nodes/utils.ts
@@ -1,7 +1,5 @@
 import type { NodeData, NodeId, NodeIdEncoded } from './types';
-
-import { IdInternal, utils as idUtils } from '@matrixai/id';
-import * as nodesErrors from './errors';
+import { IdInternal } from '@matrixai/id';
 
 /**
  * Compute the distance between two nodes.
@@ -68,19 +66,22 @@ function sortByDistance(a: NodeData, b: NodeData) {
 }
 
 function encodeNodeId(nodeId: NodeId): NodeIdEncoded {
-  return idUtils.toMultibase(nodeId, 'base32hex') as NodeIdEncoded;
+  return nodeId.toMultibase('base32hex') as NodeIdEncoded;
 }
 
-function decodeNodeId(nodeIdEncoded: NodeIdEncoded | string): NodeId {
+function decodeNodeId(nodeIdEncoded: any): NodeId | undefined {
+  if (typeof nodeIdEncoded !== 'string') {
+    return;
+  }
   const nodeId = IdInternal.fromMultibase<NodeId>(nodeIdEncoded);
-  if (nodeId == null)
-    throw new nodesErrors.ErrorInvalidNodeId(
-      `Was not a valid multibase: ${nodeIdEncoded}`,
-    );
-  if (nodeId.length !== 32)
-    throw new nodesErrors.ErrorInvalidNodeId(
-      `Was not 32 bytes long: ${nodeIdEncoded}`,
-    );
+  if (nodeId == null) {
+    return;
+  }
+  // All NodeIds are 32 bytes long
+  // The NodeGraph requires a fixed size for Node Ids
+  if (nodeId.length !== 32) {
+    return;
+  }
   return nodeId;
 }
 

--- a/src/notifications/NotificationsManager.ts
+++ b/src/notifications/NotificationsManager.ts
@@ -207,7 +207,7 @@ class NotificationsManager {
   public async receiveNotification(notification: Notification) {
     await this._transaction(async () => {
       const nodePerms = await this.acl.getNodePerm(
-        nodesUtils.decodeNodeId(notification.senderId),
+        nodesUtils.decodeNodeId(notification.senderId)!,
       );
       if (nodePerms === undefined) {
         throw new notificationsErrors.ErrorNotificationsPermissionsNotFound();
@@ -296,7 +296,7 @@ class NotificationsManager {
     for (const notification of notifications) {
       if (
         notification.data.type === 'GestaltInvite' &&
-        nodesUtils.decodeNodeId(notification.senderId).equals(fromNode)
+        nodesUtils.decodeNodeId(notification.senderId)!.equals(fromNode)
       ) {
         return notification;
       }

--- a/src/notifications/utils.ts
+++ b/src/notifications/utils.ts
@@ -10,11 +10,9 @@ import type {
 import type { KeyPairPem } from '../keys/types';
 import type { NodeId } from '../nodes/types';
 import type { VaultId } from '../vaults/types';
-
 import type { DefinedError } from 'ajv';
 import { createPublicKey, createPrivateKey } from 'crypto';
 import { SignJWT, exportJWK, jwtVerify, EmbeddedJWK } from 'jose';
-
 import { IdSortable } from '@matrixai/id';
 import {
   notificationValidate,
@@ -23,23 +21,14 @@ import {
   vaultShareNotificationValidate,
 } from './schema';
 import * as notificationsErrors from './errors';
-import { isId, makeId } from '../GenericIdTypes';
-
-function isNotificationId(arg: any): arg is NotificationId {
-  return isId<NotificationId>(arg);
-}
-
-function makeNotificationId(arg: any) {
-  return makeId<NotificationId>(arg);
-}
 
 function createNotificationIdGenerator(
   lastId?: NotificationId,
 ): NotificationIdGenerator {
-  const idSortableGenerator = new IdSortable({
+  const generator = new IdSortable<NotificationId>({
     lastId,
   });
-  return (): NotificationId => makeNotificationId(idSortableGenerator.get());
+  return () => generator.get();
 }
 
 function constructGestaltInviteMessage(nodeId: NodeId): string {
@@ -149,8 +138,6 @@ function validateVaultShareNotification(
 }
 
 export {
-  isNotificationId,
-  makeNotificationId,
   createNotificationIdGenerator,
   signNotification,
   verifyAndDecodeNotif,

--- a/src/notifications/utils.ts
+++ b/src/notifications/utils.ts
@@ -21,6 +21,7 @@ import {
   vaultShareNotificationValidate,
 } from './schema';
 import * as notificationsErrors from './errors';
+import * as nodesUtils from '../nodes/utils';
 
 function createNotificationIdGenerator(
   lastId?: NotificationId,
@@ -88,7 +89,11 @@ async function verifyAndDecodeNotif(notifJWT: string): Promise<Notification> {
 function validateNotification(
   notification: Record<string, unknown>,
 ): Notification {
-  if (notificationValidate(notification)) {
+  // Also ensure the sender's node ID is valid
+  if (
+    notificationValidate(notification) &&
+    nodesUtils.decodeNodeId(notification['senderId'])
+  ) {
     return notification as Notification;
   } else {
     for (const err of notificationValidate.errors as DefinedError[]) {

--- a/src/sigchain/types.ts
+++ b/src/sigchain/types.ts
@@ -1,16 +1,16 @@
-import type { Claim, ClaimEncoded, ClaimIdString } from '../claims/types';
+import type { Claim, ClaimEncoded, ClaimIdEncoded } from '../claims/types';
 
 /**
  * Serialized version of a node's sigchain.
  * Currently used for storage in the gestalt graph.
  */
-type ChainData = Record<ClaimIdString, Claim>;
+type ChainData = Record<ClaimIdEncoded, Claim>;
 
 /**
  * Serialized version of a node's sigchain, but with the claims as
  * Should be used when needing to transport ChainData, such that the claims can
  * be verified without having to be re-encoded as ClaimEncoded types.
  */
-type ChainDataEncoded = Record<ClaimIdString, ClaimEncoded>;
+type ChainDataEncoded = Record<ClaimIdEncoded, ClaimEncoded>;
 
 export type { ChainData, ChainDataEncoded };

--- a/src/sigchain/utils.ts
+++ b/src/sigchain/utils.ts
@@ -1,11 +1,6 @@
 import type { PublicKeyPem } from '../keys/types';
 import type { ChainData, ChainDataEncoded } from './types';
-import type { ClaimId, ClaimIdString } from '../claims/types';
-import type { NodeIdEncoded } from '../nodes/types';
-
-import { IdInternal, IdSortable } from '@matrixai/id';
 import * as claimsUtils from '../claims/utils';
-import { isIdString, isId, makeIdString, makeId } from '../GenericIdTypes';
 
 /**
  * Verifies each claim in a ChainDataEncoded record, and returns a ChainData
@@ -29,35 +24,4 @@ async function verifyChainData(
   return decodedChain;
 }
 
-function isClaimId(arg): arg is ClaimId {
-  return isId<ClaimId>(arg);
-}
-
-function makeClaimId(arg) {
-  return makeId<ClaimId>(arg);
-}
-
-function isClaimIdString(arg): arg is ClaimIdString {
-  return isIdString<ClaimIdString>(arg);
-}
-
-function makeClaimIdString(arg) {
-  return makeIdString<ClaimIdString>(arg);
-}
-
-function createClaimIdGenerator(nodeId: NodeIdEncoded, lastClaimId?: ClaimId) {
-  const generator = new IdSortable({
-    lastId: lastClaimId,
-    nodeId: IdInternal.fromString(nodeId).toBuffer(),
-  });
-  return () => makeClaimId(Buffer.from(generator.get()));
-}
-
-export {
-  verifyChainData,
-  isClaimId,
-  makeClaimId,
-  isClaimIdString,
-  makeClaimIdString,
-  createClaimIdGenerator,
-};
+export { verifyChainData };

--- a/src/status/Status.ts
+++ b/src/status/Status.ts
@@ -312,14 +312,23 @@ class Status {
     return statusInfo;
   }
 
-  protected statusReplacer = (key, value) => {
+  /**
+   * Replacer used during encoding to JSON
+   * This is a function expression and not an arrow function expression
+   * because it needs to access the `this` inside the JSON.stringify
+   * in order to encode the `NodeId` before the `toJSON` of IdInternal is called
+   */
+  protected statusReplacer = function (key: string, value: any): any {
     if (key === 'nodeId') {
-      return nodesUtils.encodeNodeId(value.data);
+      return nodesUtils.encodeNodeId(this[key]);
     }
     return value;
   };
 
-  protected statusReviver = (key, value) => {
+  /**
+   * Reviver used during decoding from JSON
+   */
+  protected statusReviver = function (key: string, value: any): any {
     if (key === 'nodeId') {
       value = nodesUtils.decodeNodeId(value);
       if (value == null) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,4 +2,5 @@ export { default as sysexits } from './sysexits';
 export * from './locks';
 export * from './context';
 export * from './utils';
+export * from './matchers';
 export * as errors from './errors';

--- a/src/utils/matchers.ts
+++ b/src/utils/matchers.ts
@@ -1,0 +1,70 @@
+import { isDeepStrictEqual } from 'util';
+
+type Proc<T> = (data: any) => Promise<T> | T;
+type Case<T> = [...patterns: [any, ...Array<any>], proc: Proc<T>];
+
+type ProcSync<T> = (data: any) => T;
+type CaseSync<T> = [...patterns: [any, ...Array<any>], proc: ProcSync<T>];
+
+/**
+ * Poor man's pattern matching in JS
+ * Use it like a switch-case that is capable of doing deep equality
+ * Unlike switch-case, it cannot assert the data type in the procedure
+ * Without a default case, the returned value is undefined
+ */
+function match<T>(
+  data: any,
+): (
+  ...cases: readonly [...Array<Case<T>>, Proc<T>] | readonly [...Array<Case<T>>]
+) => Promise<T> {
+  return async (...cases) => {
+    for (const case_ of cases) {
+      // Default case
+      if (typeof case_ === 'function') {
+        return await case_(data);
+      }
+      // Last item has to be the procedure
+      const [proc, ...patterns] = [case_.pop(), ...case_];
+      for (const p of patterns) {
+        if (isDeepStrictEqual(data, p)) {
+          return await proc(data);
+        }
+      }
+    }
+    return;
+  };
+}
+
+/**
+ * Poor man's pattern matching in JS
+ * Use it like a switch-case that is capable of doing deep equality
+ * Unlike switch-case, it cannot assert the data type in the procedure
+ * Without a default case, the returned value is undefined
+ * Synchronous version
+ */
+function matchSync<T>(
+  data: any,
+): (
+  ...cases:
+    | readonly [...Array<CaseSync<T>>, ProcSync<T>]
+    | readonly [...Array<CaseSync<T>>]
+) => T {
+  return (...cases) => {
+    for (const case_ of cases) {
+      // Default case
+      if (typeof case_ === 'function') {
+        return case_(data);
+      }
+      // Last item has to be the procedure
+      const [proc, ...patterns] = [case_.pop(), ...case_];
+      for (const p of patterns) {
+        if (isDeepStrictEqual(data, p)) {
+          return proc(data);
+        }
+      }
+    }
+    return;
+  };
+}
+
+export { match, matchSync };

--- a/src/validation/errors.ts
+++ b/src/validation/errors.ts
@@ -1,0 +1,42 @@
+import { CustomError } from 'ts-custom-error';
+import { ErrorPolykey, sysexits } from '../errors';
+
+/**
+ * This packages the `ErrorParse` array into the `data` property
+ * This is to allow encoding to and decoding from GRPC errors
+ */
+class ErrorValidation extends ErrorPolykey {
+  public readonly errors: Array<ErrorParse>;
+  constructor(errors: Array<ErrorParse>) {
+    const message = errors.map((e) => e.message).join('; ');
+    const data = {
+      errors: errors.map((e) => ({
+        message: e.message,
+        keyPath: e.keyPath,
+        value: e.value.valueOf(),
+      })),
+    };
+    super(message, data);
+    this.description = 'Input data failed validation';
+    this.exitCode = sysexits.DATAERR;
+    this.errors = errors;
+  }
+}
+
+/**
+ * Exception to be thrown during parsing failure
+ * This is not part of the Polykey exception hierarchy
+ * This is because it plain exception wrapper parsing error data
+ * While JS allows us to throw POJOs directly, having a nominal type
+ * is easier to check against
+ */
+class ErrorParse extends CustomError {
+  public keyPath: Array<string>;
+  public value: any;
+  public context: object;
+  constructor(message?: string) {
+    super(message);
+  }
+}
+
+export { ErrorValidation, ErrorParse };

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -1,0 +1,107 @@
+import * as validationErrors from './errors';
+import * as validationUtils from './utils';
+
+async function validate(
+  parser: (keyPath: Array<string>, value: any) => Promise<any>,
+  data: any,
+  options: { mode: 'greedy' | 'lazy' } = { mode: 'lazy' },
+): Promise<any> {
+  const errors: Array<validationErrors.ErrorParse> = [];
+  const parse_ = async (
+    keyPath: Array<string>,
+    value: any,
+    context: object,
+  ) => {
+    if (typeof value === 'object' && value != null) {
+      for (const key in value) {
+        value[key] = await parse_([...keyPath, key], value[key], value);
+      }
+    }
+    try {
+      value = await parser.bind(context)(keyPath, value);
+    } catch (e) {
+      if (e instanceof validationErrors.ErrorParse) {
+        e.keyPath = keyPath;
+        e.value = value;
+        e.context = context;
+        errors.push(e);
+        // If lazy mode, short circuit evaluation
+        // And throw the error up
+        if (options.mode === 'lazy') {
+          throw e;
+        }
+      } else {
+        throw e;
+      }
+    }
+    return value;
+  };
+  try {
+    // The root context is an object containing the root data but keyed with undefined
+    data = await parse_([], data, { undefined: data });
+  } catch (e) {
+    if (e instanceof validationErrors.ErrorParse) {
+      throw new validationErrors.ErrorValidation(errors);
+    } else {
+      throw e;
+    }
+  }
+  if (errors.length > 0) {
+    throw new validationErrors.ErrorValidation(errors);
+  }
+  return data;
+}
+
+function validateSync(
+  parser: (keyPath: Array<string>, value: any) => any,
+  data: any,
+  options: { mode: 'greedy' | 'lazy' } = { mode: 'lazy' },
+): any {
+  const errors: Array<validationErrors.ErrorParse> = [];
+  const parse_ = (keyPath: Array<string>, value: any, context: object) => {
+    if (typeof value === 'object' && value != null) {
+      for (const key in value) {
+        value[key] = parse_([...keyPath, key], value[key], value);
+      }
+    }
+    try {
+      value = parser.bind(context)(keyPath, value);
+    } catch (e) {
+      if (e instanceof validationErrors.ErrorParse) {
+        e.keyPath = keyPath;
+        e.value = value;
+        e.context = context;
+        errors.push(e);
+        // If lazy mode, short circuit evaluation
+        // And throw the error up
+        if (options.mode === 'lazy') {
+          throw e;
+        }
+      } else {
+        throw e;
+      }
+    }
+    return value;
+  };
+  try {
+    // The root context is an object containing the root data but keyed with undefined
+    data = parse_([], data, { undefined: data });
+  } catch (e) {
+    if (e instanceof validationErrors.ErrorParse) {
+      throw new validationErrors.ErrorValidation(errors);
+    } else {
+      throw e;
+    }
+  }
+  if (errors.length > 0) {
+    throw new validationErrors.ErrorValidation(errors);
+  }
+  return data;
+}
+
+export {
+  validate,
+  validateSync,
+  validationErrors as errors,
+  validationUtils as utils,
+};

--- a/src/validation/utils.ts
+++ b/src/validation/utils.ts
@@ -1,0 +1,190 @@
+/**
+ * Parsing utilities for validating all input data
+ * This pulls in domain types and performs procedural-validation
+ * All functions here must marshal `data: any` into their respective domain type
+ * Failing to do so, they must throw the `validationErrors.ErrorParse`
+ * The parse error message must focus on why the validation failed
+ * @module
+ */
+import type { NodeId } from '../nodes/types';
+import type { ProviderId, IdentityId } from '../identities/types';
+import type { GestaltAction, GestaltId } from '../gestalts/types';
+import type { VaultAction } from '../vaults/types';
+import type { Host, Hostname, Port } from '../network/types';
+import type { ClaimId } from '../claims/types';
+import * as validationErrors from './errors';
+import * as nodesUtils from '../nodes/utils';
+import * as gestaltsUtils from '../gestalts/utils';
+import * as vaultsUtils from '../vaults/utils';
+import * as networkUtils from '../network/utils';
+import * as claimsUtils from '../claims/utils';
+
+function parseInteger(data: any): number {
+  data = parseInt(data);
+  if (isNaN(data)) {
+    throw new validationErrors.ErrorParse('Number is invalid');
+  }
+  return data;
+}
+
+function parseNumber(data: any): number {
+  data = parseFloat(data);
+  if (isNaN(data)) {
+    throw new validationErrors.ErrorParse('Number is invalid');
+  }
+  return data;
+}
+
+function parseNodeId(data: any): NodeId {
+  data = nodesUtils.decodeNodeId(data);
+  if (data == null) {
+    throw new validationErrors.ErrorParse(
+      'Node ID must be multibase base32hex encoded public-keys',
+    );
+  }
+  return data;
+}
+
+function parseGestaltId(data: any): GestaltId {
+  if (typeof data !== 'string') {
+    throw new validationErrors.ErrorParse('Gestalt ID must be string');
+  }
+  data = nodesUtils.decodeNodeId(data);
+  if (data != null) {
+    return {
+      type: 'node',
+      nodeId: data,
+    };
+  }
+  const match = (data as string).match(/^(.+):(.+)$/);
+  if (match == null) {
+    throw new validationErrors.ErrorParse(
+      'Gestalt ID must be either a Node ID or `Provider ID:Identity ID`',
+    );
+  }
+  const providerId = parseProviderId(match[1]);
+  const identityId = parseIdentityId(match[2]);
+  return {
+    type: 'identity',
+    providerId,
+    identityId,
+  };
+}
+
+function parseClaimId(data: any): ClaimId {
+  data = claimsUtils.decodeClaimId(data);
+  if (data == null) {
+    throw new validationErrors.ErrorParse(
+      'Claim ID must be multibase base32hex encoded strings',
+    );
+  }
+  return data;
+}
+
+function parseGestaltAction(data: any): GestaltAction {
+  if (!gestaltsUtils.isGestaltAction(data)) {
+    throw new validationErrors.ErrorParse(
+      'Gestalt action must be `notify` or `scan`',
+    );
+  }
+  return data;
+}
+
+function parseVaultAction(data: any): VaultAction {
+  if (!vaultsUtils.isVaultAction(data)) {
+    throw new validationErrors.ErrorParse(
+      'Vault action must be `clone` or `pull`',
+    );
+  }
+  return data;
+}
+
+function parseProviderId(data: any): ProviderId {
+  if (typeof data !== 'string') {
+    throw new validationErrors.ErrorParse('Provider ID must be a string');
+  }
+  if (data.length < 1) {
+    throw new validationErrors.ErrorParse(
+      'Provider ID length must be greater than 0',
+    );
+  }
+  return data as ProviderId;
+}
+
+function parseIdentityId(data: any): IdentityId {
+  if (typeof data !== 'string') {
+    throw new validationErrors.ErrorParse('Provider ID must be a string');
+  }
+  if (data.length < 1) {
+    throw new validationErrors.ErrorParse(
+      'Identity ID length must be greater than 0',
+    );
+  }
+  return data as IdentityId;
+}
+
+function parseHost(data: any): Host {
+  if (!networkUtils.isHost(data)) {
+    throw new validationErrors.ErrorParse(
+      'Host must be an IPv4 or IPv6 address',
+    );
+  }
+  return data;
+}
+
+function parseHostname(data: any): Hostname {
+  if (!networkUtils.isHostname(data)) {
+    throw new validationErrors.ErrorParse(
+      'Hostname must follow RFC 1123 standard',
+    );
+  }
+  return data;
+}
+
+function parseHostOrHostname(data: any): Host | Hostname {
+  if (!networkUtils.isHost(data) && !networkUtils.isHostname(data)) {
+    throw new validationErrors.ErrorParse(
+      'Host must be IPv4 or IPv6 address or hostname',
+    );
+  }
+  return data;
+}
+
+/**
+ * Parses number into a Port
+ * Data can be a string-number
+ */
+function parsePort(data: any): Port {
+  if (typeof data === 'string') {
+    try {
+      data = parseInteger(data);
+    } catch (e) {
+      if (e instanceof validationErrors.ErrorParse) {
+        e.message = 'Port must be a number';
+      }
+      throw e;
+    }
+  }
+  if (!networkUtils.isPort(data)) {
+    throw new validationErrors.ErrorParse(
+      'Port must be a number between 0 and 65535 inclusive',
+    );
+  }
+  return data;
+}
+
+export {
+  parseInteger,
+  parseNumber,
+  parseNodeId,
+  parseGestaltId,
+  parseClaimId,
+  parseGestaltAction,
+  parseVaultAction,
+  parseProviderId,
+  parseIdentityId,
+  parseHost,
+  parseHostname,
+  parseHostOrHostname,
+  parsePort,
+};

--- a/src/vaults/VaultManager.ts
+++ b/src/vaults/VaultManager.ts
@@ -357,12 +357,12 @@ class VaultManager {
           await this.acl.setNodeAction(nodeId, 'scan');
           await this.acl.setVaultAction(
             vaultId,
-            nodesUtils.decodeNodeId(nodes[node].id),
+            nodesUtils.decodeNodeId(nodes[node].id)!,
             'pull',
           );
           await this.acl.setVaultAction(
             vaultId,
-            nodesUtils.decodeNodeId(nodes[node].id),
+            nodesUtils.decodeNodeId(nodes[node].id)!,
             'clone',
           );
         }

--- a/src/vaults/types.ts
+++ b/src/vaults/types.ts
@@ -7,6 +7,8 @@ import type { FdIndex } from 'encryptedfs/dist/fd/types';
 import type { EncryptedFS } from 'encryptedfs';
 import type { Id, IdString } from '../GenericIdTypes';
 
+const vaultActions = ['clone', 'pull'] as const;
+
 /**
  * Randomly generated vault ID for each new vault
  */
@@ -21,7 +23,7 @@ type VaultKey = Opaque<'VaultKey', Buffer>;
 /**
  * Actions relating to what is possible with vaults
  */
-type VaultAction = 'clone' | 'pull';
+type VaultAction = typeof vaultActions[number];
 
 type VaultList = Map<VaultName, VaultId>;
 
@@ -147,6 +149,8 @@ type CommitLog = {
   timeStamp: number;
   message: string;
 };
+
+export { vaultActions };
 
 export type {
   VaultId,

--- a/src/vaults/utils.ts
+++ b/src/vaults/utils.ts
@@ -4,16 +4,17 @@ import type {
   VaultKey,
   VaultList,
   VaultName,
+  VaultAction,
   FileSystemReadable,
   VaultIdPretty,
 } from './types';
 import type { FileSystem } from '../types';
 import type { NodeId } from '../nodes/types';
-
 import type { GRPCClientAgent } from '../agent';
 import path from 'path';
 import { IdRandom } from '@matrixai/id';
 import * as grpc from '@grpc/grpc-js';
+import { vaultActions } from './types';
 import * as vaultsErrors from './errors';
 import { GitRequest } from '../git';
 import { promisify } from '../utils';
@@ -244,6 +245,11 @@ async function requestVaultNames(
   return data;
 }
 
+function isVaultAction(action: any): action is VaultAction {
+  if (typeof action !== 'string') return false;
+  return (vaultActions as Readonly<Array<string>>).includes(action);
+}
+
 export {
   isVaultId,
   isVaultIdPretty,
@@ -257,4 +263,5 @@ export {
   readdirRecursivelyEFS2,
   constructGitHandler,
   searchVaultName,
+  isVaultAction,
 };

--- a/tests/agent/GRPCClientAgent.test.ts
+++ b/tests/agent/GRPCClientAgent.test.ts
@@ -1,6 +1,6 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { NodeAddress, NodeIdEncoded, NodeInfo } from '@/nodes/types';
-import type { ClaimIdString, ClaimIntermediary } from '@/claims/types';
+import type { ClaimIdEncoded, ClaimIntermediary } from '@/claims/types';
 import type { Host, Port, TLSConfig } from '@/network/types';
 import fs from 'fs';
 import os from 'os';
@@ -389,7 +389,7 @@ describe(GRPCClientAgent.name, () => {
         expect(Object.keys(chain).length).toBe(1);
         // Iterate just to be safe, but expected to only have this single claim
         for (const c of Object.keys(chain)) {
-          const claimId = c as ClaimIdString;
+          const claimId = c as ClaimIdEncoded;
           expect(chain[claimId]).toStrictEqual(doublyResponse);
         }
       },

--- a/tests/agent/GRPCClientAgent.test.ts
+++ b/tests/agent/GRPCClientAgent.test.ts
@@ -37,7 +37,7 @@ describe(GRPCClientAgent.name, () => {
     id: 'v359vgrgmqf1r5g4fvisiddjknjko6bmm4qv7646jr7fi9enbfuug' as NodeIdEncoded,
     chain: {},
   };
-  const nodeId1 = nodesUtils.decodeNodeId(node1.id);
+  const nodeId1 = nodesUtils.decodeNodeId(node1.id)!;
   let mockedGenerateKeyPair: jest.SpyInstance;
   let mockedGenerateDeterministicKeyPair: jest.SpyInstance;
   beforeAll(async () => {
@@ -255,11 +255,11 @@ describe(GRPCClientAgent.name, () => {
 
     const nodeIdX = nodesUtils.decodeNodeId(
       'vrsc24a1er424epq77dtoveo93meij0pc8ig4uvs9jbeld78n9nl0',
-    );
+    )!;
     const nodeIdXEncoded = nodesUtils.encodeNodeId(nodeIdX);
     const nodeIdY = nodesUtils.decodeNodeId(
       'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
-    );
+    )!;
     const nodeIdYEncoded = nodesUtils.encodeNodeId(nodeIdY);
 
     beforeEach(async () => {

--- a/tests/bin/identities/identities.test.ts
+++ b/tests/bin/identities/identities.test.ts
@@ -39,10 +39,10 @@ describe('CLI Identities', () => {
   // Defining constants
   const nodeId1Encoded =
     'vrsc24a1er424epq77dtoveo93meij0pc8ig4uvs9jbeld78n9nl0' as NodeIdEncoded;
-  const nodeId1 = nodesUtils.decodeNodeId(nodeId1Encoded);
+  const nodeId1 = nodesUtils.decodeNodeId(nodeId1Encoded)!;
   const nodeId2Encoded =
     'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg' as NodeIdEncoded;
-  const nodeId2 = nodesUtils.decodeNodeId(nodeId2Encoded);
+  const nodeId2 = nodesUtils.decodeNodeId(nodeId2Encoded)!;
   const nodeId3Encoded =
     'v359vgrgmqf1r5g4fvisiddjknjko6bmm4qv7646jr7fi9enbfuug' as NodeIdEncoded;
   // Const nodeId3 = nodesUtils.decodeNodeId(nodeId3Encoded);

--- a/tests/bin/nodes/add.test.ts
+++ b/tests/bin/nodes/add.test.ts
@@ -6,6 +6,7 @@ import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import { IdInternal } from '@matrixai/id';
 import PolykeyAgent from '@/PolykeyAgent';
 import * as nodesUtils from '@/nodes/utils';
+import { sysexits } from '@/utils';
 import * as testBinUtils from '../utils';
 import * as testUtils from '../../utils';
 
@@ -92,8 +93,7 @@ describe('add', () => {
         port.toString(),
       ]);
       const result = await testBinUtils.pkStdio(commands, {}, dataDir);
-      expect(result.exitCode).not.toBe(0);
-      expect(result.stderr).toContain('Invalid node ID.');
+      expect(result.exitCode).toBe(sysexits.USAGE);
     },
     global.failedConnectionTimeout,
   );
@@ -107,8 +107,7 @@ describe('add', () => {
         port.toString(),
       ]);
       const result = await testBinUtils.pkStdio(commands, {}, dataDir);
-      expect(result.exitCode).not.toBe(0);
-      expect(result.stderr).toContain('Invalid IP address.');
+      expect(result.exitCode).toBe(sysexits.USAGE);
 
       // Checking if node was added.
       const res = await polykeyAgent.nodeManager.getNode(validNodeId);

--- a/tests/bin/nodes/find.test.ts
+++ b/tests/bin/nodes/find.test.ts
@@ -177,7 +177,7 @@ describe('find', () => {
     async () => {
       const unknownNodeId = nodesUtils.decodeNodeId(
         'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
-      );
+      )!;
       const commands = genCommands([
         'find',
         nodesUtils.encodeNodeId(unknownNodeId),

--- a/tests/bin/nodes/ping.test.ts
+++ b/tests/bin/nodes/ping.test.ts
@@ -124,7 +124,7 @@ describe('ping', () => {
     async () => {
       const fakeNodeId = nodesUtils.decodeNodeId(
         'vrsc24a1er424epq77dtoveo93meij0pc8ig4uvs9jbeld78n9nl0',
-      );
+      )!;
       const commands = genCommands([
         'ping',
         nodesUtils.encodeNodeId(fakeNodeId),

--- a/tests/bin/vaults/vaults.test.ts
+++ b/tests/bin/vaults/vaults.test.ts
@@ -41,7 +41,7 @@ describe('CLI vaults', () => {
   // Constants
   const nodeId1Encoded =
     'vrsc24a1er424epq77dtoveo93meij0pc8ig4uvs9jbeld78n9nl0' as NodeIdEncoded;
-  const nodeId1 = nodesUtils.decodeNodeId(nodeId1Encoded);
+  const nodeId1 = nodesUtils.decodeNodeId(nodeId1Encoded)!;
   const nodeId2Encoded =
     'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg' as NodeIdEncoded;
   // Const nodeId2 = nodesUtils.decodeNodeId(nodeId2Encoded);

--- a/tests/client/rpcGestalts.test.ts
+++ b/tests/client/rpcGestalts.test.ts
@@ -49,7 +49,7 @@ describe('Client service', () => {
 
   const nodeId2Encoded =
     'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg' as NodeIdEncoded;
-  const nodeId2 = nodesUtils.decodeNodeId(nodeId2Encoded);
+  const nodeId2 = nodesUtils.decodeNodeId(nodeId2Encoded)!;
 
   const testToken = {
     providerId: 'test-provider' as ProviderId,

--- a/tests/client/service/agentUnlock.test.ts
+++ b/tests/client/service/agentUnlock.test.ts
@@ -35,7 +35,7 @@ describe('agentUnlock', () => {
     grpcClient = await GRPCClientClient.createGRPCClientClient({
       nodeId: nodesUtils.decodeNodeId(
         'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
-      ),
+      )!,
       host: '127.0.0.1' as Host,
       port: grpcServer.port,
       logger,

--- a/tests/client/service/identitiesAuthenticate.test.ts
+++ b/tests/client/service/identitiesAuthenticate.test.ts
@@ -68,7 +68,7 @@ describe('identitiesAuthenticate', () => {
     grpcClient = await GRPCClientClient.createGRPCClientClient({
       nodeId: nodesUtils.decodeNodeId(
         'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
-      ),
+      )!,
       host: '127.0.0.1' as Host,
       port: grpcServer.port,
       logger,

--- a/tests/client/service/identitiesClaim.test.ts
+++ b/tests/client/service/identitiesClaim.test.ts
@@ -22,7 +22,6 @@ import {
 import identitiesClaim from '@/client/service/identitiesClaim';
 import * as identitiesPB from '@/proto/js/polykey/v1/identities/identities_pb';
 import * as claimsUtils from '@/claims/utils';
-import { createClaimIdGenerator } from '@/sigchain/utils';
 import TestProvider from '../../identities/TestProvider';
 import * as testUtils from '../../utils';
 
@@ -46,7 +45,7 @@ describe('identitiesClaim', () => {
     provider: testToken.providerId,
     identity: testToken.identityId,
   };
-  const claimId = createClaimIdGenerator(claimData.node)();
+  const claimId = claimsUtils.createClaimIdGenerator(claimData.node)();
   let mockedGenerateKeyPair: jest.SpyInstance;
   let mockedGenerateDeterministicKeyPair: jest.SpyInstance;
   let mockedAddClaim: jest.SpyInstance;

--- a/tests/client/service/identitiesInfoGet.test.ts
+++ b/tests/client/service/identitiesInfoGet.test.ts
@@ -77,7 +77,7 @@ describe('identitiesInfoGet', () => {
     grpcClient = await GRPCClientClient.createGRPCClientClient({
       nodeId: nodesUtils.decodeNodeId(
         'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
-      ),
+      )!,
       host: '127.0.0.1' as Host,
       port: grpcServer.port,
       logger,

--- a/tests/client/service/identitiesInfoGetConnected.test.ts
+++ b/tests/client/service/identitiesInfoGetConnected.test.ts
@@ -95,7 +95,7 @@ describe('identitiesInfoGetConnected', () => {
     grpcClient = await GRPCClientClient.createGRPCClientClient({
       nodeId: nodesUtils.decodeNodeId(
         'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
-      ),
+      )!,
       host: '127.0.0.1' as Host,
       port: grpcServer.port,
       logger,

--- a/tests/client/service/identitiesProvidersList.test.ts
+++ b/tests/client/service/identitiesProvidersList.test.ts
@@ -73,7 +73,7 @@ describe('identitiesProvidersList', () => {
     grpcClient = await GRPCClientClient.createGRPCClientClient({
       nodeId: nodesUtils.decodeNodeId(
         'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
-      ),
+      )!,
       host: '127.0.0.1' as Host,
       port: grpcServer.port,
       logger,

--- a/tests/client/service/identitiesTokenDelete.test.ts
+++ b/tests/client/service/identitiesTokenDelete.test.ts
@@ -67,7 +67,7 @@ describe('identitiesTokenDelete', () => {
     grpcClient = await GRPCClientClient.createGRPCClientClient({
       nodeId: nodesUtils.decodeNodeId(
         'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
-      ),
+      )!,
       host: '127.0.0.1' as Host,
       port: grpcServer.port,
       logger,

--- a/tests/client/service/identitiesTokenGet.test.ts
+++ b/tests/client/service/identitiesTokenGet.test.ts
@@ -66,7 +66,7 @@ describe('identitiesTokenGet', () => {
     grpcClient = await GRPCClientClient.createGRPCClientClient({
       nodeId: nodesUtils.decodeNodeId(
         'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
-      ),
+      )!,
       host: '127.0.0.1' as Host,
       port: grpcServer.port,
       logger,

--- a/tests/client/service/identitiesTokenPut.test.ts
+++ b/tests/client/service/identitiesTokenPut.test.ts
@@ -67,7 +67,7 @@ describe('identitiesTokenPut', () => {
     grpcClient = await GRPCClientClient.createGRPCClientClient({
       nodeId: nodesUtils.decodeNodeId(
         'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
-      ),
+      )!,
       host: '127.0.0.1' as Host,
       port: grpcServer.port,
       logger,

--- a/tests/client/service/nodesAdd.test.ts
+++ b/tests/client/service/nodesAdd.test.ts
@@ -149,7 +149,7 @@ describe('nodesAdd', () => {
     const result = await nodeManager.getNode(
       nodesUtils.decodeNodeId(
         'vrsc24a1er424epq77dtoveo93meij0pc8ig4uvs9jbeld78n9nl0',
-      ),
+      )!,
     );
     expect(result).toBeDefined();
     expect(result!.host).toBe('127.0.0.1');

--- a/tests/grpc/GRPCClient.test.ts
+++ b/tests/grpc/GRPCClient.test.ts
@@ -12,7 +12,6 @@ import { DB } from '@matrixai/db';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import { utils as keysUtils } from '@/keys';
 import { Session, SessionManager } from '@/sessions';
-import { utils as networkUtils } from '@/network';
 import { errors as grpcErrors } from '@/grpc';
 import * as clientUtils from '@/client/utils';
 import * as utilsPB from '@/proto/js/polykey/v1/utils/utils_pb';
@@ -47,7 +46,7 @@ describe('GRPCClient', () => {
       serverKeyPair.privateKey,
       31536000,
     );
-    nodeIdServer = networkUtils.certNodeId(serverCert);
+    nodeIdServer = keysUtils.certNodeId(serverCert)!;
     const dbPath = path.join(dataDir, 'db');
     db = await DB.createDB({
       dbPath,

--- a/tests/grpc/GRPCServer.test.ts
+++ b/tests/grpc/GRPCServer.test.ts
@@ -8,7 +8,6 @@ import { DB } from '@matrixai/db';
 import { GRPCServer, utils as grpcUtils } from '@/grpc';
 import { KeyManager, utils as keysUtils } from '@/keys';
 import { SessionManager } from '@/sessions';
-import * as networkUtils from '@/network/utils';
 import * as utilsPB from '@/proto/js/polykey/v1/utils/utils_pb';
 import * as grpcErrors from '@/grpc/errors';
 import * as clientUtils from '@/client/utils';
@@ -143,7 +142,7 @@ describe('GRPCServer', () => {
         certChainPem: keysUtils.certToPem(serverCert),
       },
     });
-    const nodeIdServer = networkUtils.certNodeId(serverCert);
+    const nodeIdServer = keysUtils.certNodeId(serverCert)!;
     const clientKeyPair = await keysUtils.generateKeyPair(4096);
     const clientCert = keysUtils.generateCertificate(
       clientKeyPair.publicKey,
@@ -203,7 +202,7 @@ describe('GRPCServer', () => {
       31536000,
     );
     // First client connection
-    const nodeIdServer1 = networkUtils.certNodeId(serverCert1);
+    const nodeIdServer1 = keysUtils.certNodeId(serverCert1)!;
     const client1 = await testGrpcUtils.openTestClientSecure(
       nodeIdServer1,
       server.port,
@@ -240,7 +239,7 @@ describe('GRPCServer', () => {
     const m2_ = await pCall2;
     expect(m2_.getChallenge()).toBe(m2.getChallenge());
     // Second client connection
-    const nodeIdServer2 = networkUtils.certNodeId(serverCert2);
+    const nodeIdServer2 = keysUtils.certNodeId(serverCert2)!;
     const client2 = await testGrpcUtils.openTestClientSecure(
       nodeIdServer2,
       server.port,
@@ -286,7 +285,7 @@ describe('GRPCServer', () => {
         certChainPem: keysUtils.certToPem(serverCert),
       },
     });
-    const nodeIdServer = networkUtils.certNodeId(serverCert);
+    const nodeIdServer = keysUtils.certNodeId(serverCert)!;
     const clientKeyPair = await keysUtils.generateKeyPair(4096);
     const clientCert = keysUtils.generateCertificate(
       clientKeyPair.publicKey,

--- a/tests/network/ForwardProxy.test.ts
+++ b/tests/network/ForwardProxy.test.ts
@@ -762,7 +762,7 @@ describe(ForwardProxy.name, () => {
       86400,
     );
     const serverCertPem = keysUtils.certToPem(serverCert);
-    const serverNodeId = networkUtils.certNodeId(serverCert);
+    const serverNodeId = keysUtils.certNodeId(serverCert)!;
     const fwdProxy = new ForwardProxy({
       authToken,
       logger: logger.getChild(
@@ -886,7 +886,7 @@ describe(ForwardProxy.name, () => {
       86400,
     );
     const serverCertPem = keysUtils.certToPem(serverCert);
-    const serverNodeId = networkUtils.certNodeId(serverCert);
+    const serverNodeId = keysUtils.certNodeId(serverCert)!;
     const fwdProxy = new ForwardProxy({
       authToken,
       connEndTime: 5000,
@@ -1034,7 +1034,7 @@ describe(ForwardProxy.name, () => {
       86400,
     );
     const serverCertPem = keysUtils.certToPem(serverCert);
-    const serverNodeId = networkUtils.certNodeId(serverCert);
+    const serverNodeId = keysUtils.certNodeId(serverCert)!;
     const serverNodeIdEncoded = nodesUtils.encodeNodeId(serverNodeId);
     const fwdProxy = new ForwardProxy({
       authToken,
@@ -1181,7 +1181,7 @@ describe(ForwardProxy.name, () => {
       86400,
     );
     const serverCertPem = keysUtils.certToPem(serverCert);
-    const serverNodeId = networkUtils.certNodeId(serverCert);
+    const serverNodeId = keysUtils.certNodeId(serverCert)!;
     const serverNodeIdEncoded = nodesUtils.encodeNodeId(serverNodeId);
     const fwdProxy = new ForwardProxy({
       authToken,
@@ -1351,7 +1351,7 @@ describe(ForwardProxy.name, () => {
       86400,
     );
     const serverCertPem = keysUtils.certToPem(serverCert);
-    const serverNodeId = networkUtils.certNodeId(serverCert);
+    const serverNodeId = keysUtils.certNodeId(serverCert)!;
     const serverNodeIdEncoded = nodesUtils.encodeNodeId(serverNodeId);
     const fwdProxy = new ForwardProxy({
       authToken,
@@ -1508,7 +1508,7 @@ describe(ForwardProxy.name, () => {
       86400,
     );
     const serverCertPem = keysUtils.certToPem(serverCert);
-    const serverNodeId = networkUtils.certNodeId(serverCert);
+    const serverNodeId = keysUtils.certNodeId(serverCert)!;
     const serverNodeIdEncoded = nodesUtils.encodeNodeId(serverNodeId);
     const fwdProxy = new ForwardProxy({
       authToken,
@@ -1637,7 +1637,7 @@ describe(ForwardProxy.name, () => {
       86400,
     );
     const serverCertPem = keysUtils.certToPem(serverCert);
-    const serverNodeId = networkUtils.certNodeId(serverCert);
+    const serverNodeId = keysUtils.certNodeId(serverCert)!;
     const fwdProxy = new ForwardProxy({
       authToken,
       connKeepAliveTimeoutTime: 1000,
@@ -1752,7 +1752,7 @@ describe(ForwardProxy.name, () => {
       86400,
     );
     const serverCertPem = keysUtils.certToPem(serverCert);
-    const serverNodeId = networkUtils.certNodeId(serverCert);
+    const serverNodeId = keysUtils.certNodeId(serverCert)!;
     const serverNodeIdEncoded = nodesUtils.encodeNodeId(serverNodeId);
     const fwdProxy = new ForwardProxy({
       authToken,
@@ -1892,7 +1892,7 @@ describe(ForwardProxy.name, () => {
       86400,
     );
     const serverCertPem = keysUtils.certToPem(serverCert);
-    const serverNodeId = networkUtils.certNodeId(serverCert);
+    const serverNodeId = keysUtils.certNodeId(serverCert)!;
     const fwdProxy = new ForwardProxy({
       authToken,
       logger,
@@ -1986,7 +1986,7 @@ describe(ForwardProxy.name, () => {
       86400,
     );
     const serverCertPem1 = keysUtils.certToPem(serverCert1);
-    const serverNodeId1 = networkUtils.certNodeId(serverCert1);
+    const serverNodeId1 = keysUtils.certNodeId(serverCert1)!;
     // Second server keys
     const serverKeyPair2 = await keysUtils.generateKeyPair(1024);
     const serverKeyPairPem2 = keysUtils.keyPairToPem(serverKeyPair2);
@@ -1997,7 +1997,7 @@ describe(ForwardProxy.name, () => {
       86400,
     );
     const serverCertPem2 = keysUtils.certToPem(serverCert2);
-    const serverNodeId2 = networkUtils.certNodeId(serverCert2);
+    const serverNodeId2 = keysUtils.certNodeId(serverCert2)!;
     const fwdProxy = new ForwardProxy({
       authToken,
       logger,

--- a/tests/network/index.test.ts
+++ b/tests/network/index.test.ts
@@ -2,7 +2,7 @@ import type { Host, Port } from '@/network/types';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import grpc from '@grpc/grpc-js';
 import { utils as keysUtils } from '@/keys';
-import { ForwardProxy, ReverseProxy, utils as networkUtils } from '@/network';
+import { ForwardProxy, ReverseProxy } from '@/network';
 import * as utilsPB from '@/proto/js/polykey/v1/utils/utils_pb';
 import { sleep } from '@/utils';
 import { openTestServer, closeTestServer, GRPCClientTest } from '../grpc/utils';
@@ -30,7 +30,7 @@ describe('network index', () => {
       12332432423,
     );
     clientCertPem = keysUtils.certToPem(clientCert);
-    clientNodeId = networkUtils.certNodeId(clientCert);
+    clientNodeId = keysUtils.certNodeId(clientCert)!;
     // Server keys
     const serverKeyPair = await keysUtils.generateKeyPair(1024);
     serverKeyPairPem = keysUtils.keyPairToPem(serverKeyPair);
@@ -41,7 +41,7 @@ describe('network index', () => {
       12332432423,
     );
     serverCertPem = keysUtils.certToPem(serverCert);
-    serverNodeId = networkUtils.certNodeId(serverCert);
+    serverNodeId = keysUtils.certNodeId(serverCert)!;
   });
   let server;
   let revProxy;

--- a/tests/network/utils.test.ts
+++ b/tests/network/utils.test.ts
@@ -28,7 +28,7 @@ describe('utils', () => {
       networkUtils.resolveHost('www.google.com' as Host),
     ).resolves.toBeDefined();
     const host = await networkUtils.resolveHost('www.google.com' as Host);
-    expect(networkUtils.isValidHost(host)).toBeTruthy();
+    expect(networkUtils.isHost(host)).toBeTruthy();
     await expect(
       networkUtils.resolveHost('invalidHostname' as Host),
     ).rejects.toThrow(networkErrors.ErrorHostnameResolutionFailed);

--- a/tests/nodes/NodeGraph.test.ts
+++ b/tests/nodes/NodeGraph.test.ts
@@ -43,7 +43,7 @@ describe('NodeGraph', () => {
   // const nodeId3 = makeNodeId('v359vgrgmqf1r5g4fvisiddjknjko6bmm4qv7646jr7fi9enbfuug');
   const dummyNode = nodesUtils.decodeNodeId(
     'vi3et1hrpv2m2lrplcm7cu913kr45v51cak54vm68anlbvuf83ra0',
-  );
+  )!;
 
   const logger = new Logger('NodeGraph Test', LogLevel.WARN, [
     new StreamHandler(),

--- a/tests/nodes/NodeManager.test.ts
+++ b/tests/nodes/NodeManager.test.ts
@@ -45,13 +45,13 @@ describe('NodeManager', () => {
 
   const nodeId1 = nodesUtils.decodeNodeId(
     'vrsc24a1er424epq77dtoveo93meij0pc8ig4uvs9jbeld78n9nl0',
-  );
+  )!;
   const nodeId2 = nodesUtils.decodeNodeId(
     'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
-  );
+  )!;
   const dummyNode = nodesUtils.decodeNodeId(
     'vi3et1hrpv2m2lrplcm7cu913kr45v51cak54vm68anlbvuf83ra0',
-  );
+  )!;
 
   beforeEach(async () => {
     dataDir = await fs.promises.mkdtemp(

--- a/tests/nodes/NodeManager.test.ts
+++ b/tests/nodes/NodeManager.test.ts
@@ -1,4 +1,4 @@
-import type { ClaimIdString } from '@/claims/types';
+import type { ClaimIdEncoded } from '@/claims/types';
 import type { CertificatePem, KeyPairPem, PublicKeyPem } from '@/keys/types';
 import type { Host, Port } from '@/network/types';
 import type { NodeId, NodeAddress } from '@/nodes/types';
@@ -505,7 +505,7 @@ describe('NodeManager', () => {
       expect(Object.keys(xChain).length).toBe(1);
       // Iterate just to be safe, but expected to only have this single claim
       for (const c of Object.keys(xChain)) {
-        const claimId = c as ClaimIdString;
+        const claimId = c as ClaimIdEncoded;
         const claim = xChain[claimId];
         const decoded = claimsUtils.decodeClaim(claim);
         expect(decoded).toStrictEqual({
@@ -541,7 +541,7 @@ describe('NodeManager', () => {
       expect(Object.keys(yChain).length).toBe(1);
       // Iterate just to be safe, but expected to only have this single claim
       for (const c of Object.keys(yChain)) {
-        const claimId = c as ClaimIdString;
+        const claimId = c as ClaimIdEncoded;
         const claim = yChain[claimId];
         const decoded = claimsUtils.decodeClaim(claim);
         expect(decoded).toStrictEqual({

--- a/tests/notifications/NotificationsManager.test.ts
+++ b/tests/notifications/NotificationsManager.test.ts
@@ -19,8 +19,6 @@ import { NodeManager } from '@/nodes';
 import { NotificationsManager } from '@/notifications';
 import { ForwardProxy, ReverseProxy } from '@/network';
 import { AgentServiceService, createAgentService } from '@/agent';
-
-import * as networkUtils from '@/network/utils';
 import { generateVaultId } from '@/vaults/utils';
 import { utils as nodesUtils } from '@/nodes';
 import * as testUtils from '../utils';
@@ -95,7 +93,7 @@ describe('NotificationsManager', () => {
     });
     senderKeyPairPem = senderKeyManager.getRootKeyPairPem();
     senderCertPem = senderKeyManager.getRootCertPem();
-    senderNodeId = networkUtils.certNodeId(senderKeyManager.getRootCert());
+    senderNodeId = keysUtils.certNodeId(senderKeyManager.getRootCert())!;
     fwdTLSConfig = {
       keyPrivatePem: senderKeyPairPem.privateKey,
       certChainPem: senderCertPem,
@@ -186,7 +184,7 @@ describe('NotificationsManager', () => {
         messageCap: 5,
         logger: logger,
       });
-    receiverNodeId = networkUtils.certNodeId(receiverKeyManager.getRootCert());
+    receiverNodeId = keysUtils.certNodeId(receiverKeyManager.getRootCert())!;
     await receiverGestaltGraph.setNode(node);
     await receiverNodeManager.start();
 

--- a/tests/validation/index.test.ts
+++ b/tests/validation/index.test.ts
@@ -1,0 +1,412 @@
+import {
+  validate,
+  validateSync,
+  errors as validationErrors,
+} from '@/validation';
+
+describe('validation/index', () => {
+  test('validate primitives', async () => {
+    expect(
+      await validate((keyPath, value) => {
+        expect(keyPath).toEqual([]);
+        expect(value).toBe(123);
+        return value;
+      }, 123),
+    ).toBe(123);
+    expect(
+      await validate(async (keyPath, value) => {
+        expect(keyPath).toEqual([]);
+        expect(value).toBe('hello world');
+        return value;
+      }, 'hello world'),
+    ).toBe('hello world');
+    expect(
+      await validate((keyPath, value) => {
+        expect(keyPath).toEqual([]);
+        expect(value).toBe(null);
+        return value;
+      }, null),
+    ).toBe(null);
+    expect(
+      await validate((keyPath, value) => {
+        expect(keyPath).toEqual([]);
+        expect(value).toBe(undefined);
+        return value;
+      }, undefined),
+    ).toBeUndefined();
+  });
+  test('validate primitives - sync', () => {
+    expect(
+      validateSync((keyPath, value) => {
+        expect(keyPath).toEqual([]);
+        expect(value).toBe(123);
+        return value;
+      }, 123),
+    ).toBe(123);
+    expect(
+      validateSync((keyPath, value) => {
+        expect(keyPath).toEqual([]);
+        expect(value).toBe('hello world');
+        return value;
+      }, 'hello world'),
+    ).toBe('hello world');
+    expect(
+      validateSync((keyPath, value) => {
+        expect(keyPath).toEqual([]);
+        expect(value).toBe(null);
+        return value;
+      }, null),
+    ).toBe(null);
+    expect(
+      validateSync((keyPath, value) => {
+        expect(keyPath).toEqual([]);
+        expect(value).toBe(undefined);
+        return value;
+      }, undefined),
+    ).toBeUndefined();
+  });
+  test('validate objects', async () => {
+    // POJO
+    expect(
+      await validate(
+        (keyPath, value) => {
+          switch (keyPath.join('.')) {
+            case 'a':
+              value = value + 1;
+              break;
+            case 'b':
+              value = value + '!';
+              break;
+          }
+          return value;
+        },
+        {
+          a: 123,
+          b: 'hello world',
+        },
+      ),
+    ).toStrictEqual({
+      a: 124,
+      b: 'hello world!',
+    });
+    // Array
+    expect(
+      await validate(
+        async (keyPath, value) => {
+          switch (keyPath.join('.')) {
+            case '0':
+              value = value + 1;
+              break;
+            case '1':
+              value = value + '!';
+              break;
+          }
+          return value;
+        },
+        [123, 'hello world'],
+      ),
+    ).toStrictEqual([124, 'hello world!']);
+    // Nested POJO and Array
+    expect(
+      await validate(
+        (keyPath, value) => {
+          switch (keyPath.join('.')) {
+            case 'arr.0.a':
+            case 'obj.arr.0':
+              if (value !== 123) {
+                throw new validationErrors.ErrorParse('should be 123');
+              }
+              break;
+            case 'arr.0.b':
+            case 'obj.arr.1':
+              if (value !== 'hello world') {
+                throw new validationErrors.ErrorParse('should be hello world');
+              }
+              break;
+            case 'arr':
+              expect(value).toStrictEqual([
+                {
+                  a: 123,
+                  b: 'hello world',
+                },
+              ]);
+              break;
+            case 'obj':
+              expect(value).toStrictEqual({
+                arr: [123, 'hello world'],
+              });
+              break;
+          }
+          return value;
+        },
+        {
+          arr: [
+            {
+              a: 123,
+              b: 'hello world',
+            },
+          ],
+          obj: {
+            arr: [123, 'hello world'],
+          },
+        },
+      ),
+    ).toStrictEqual({
+      arr: [
+        {
+          a: 123,
+          b: 'hello world',
+        },
+      ],
+      obj: {
+        arr: [123, 'hello world'],
+      },
+    });
+  });
+  test('validate objects - sync', () => {
+    // POJO
+    expect(
+      validateSync(
+        (keyPath, value) => {
+          switch (keyPath.join('.')) {
+            case 'a':
+              value = value + 1;
+              break;
+            case 'b':
+              value = value + '!';
+              break;
+          }
+          return value;
+        },
+        {
+          a: 123,
+          b: 'hello world',
+        },
+      ),
+    ).toStrictEqual({
+      a: 124,
+      b: 'hello world!',
+    });
+    // Array
+    expect(
+      validateSync(
+        (keyPath, value) => {
+          switch (keyPath.join('.')) {
+            case '0':
+              value = value + 1;
+              break;
+            case '1':
+              value = value + '!';
+              break;
+          }
+          return value;
+        },
+        [123, 'hello world'],
+      ),
+    ).toStrictEqual([124, 'hello world!']);
+    // Nested POJO and Array
+    expect(
+      validateSync(
+        (keyPath, value) => {
+          switch (keyPath.join('.')) {
+            case 'arr.0.a':
+            case 'obj.arr.0':
+              if (value !== 123) {
+                throw new validationErrors.ErrorParse('should be 123');
+              }
+              break;
+            case 'arr.0.b':
+            case 'obj.arr.1':
+              if (value !== 'hello world') {
+                throw new validationErrors.ErrorParse('should be hello world');
+              }
+              break;
+            case 'arr':
+              expect(value).toStrictEqual([
+                {
+                  a: 123,
+                  b: 'hello world',
+                },
+              ]);
+              break;
+            case 'obj':
+              expect(value).toStrictEqual({
+                arr: [123, 'hello world'],
+              });
+              break;
+          }
+          return value;
+        },
+        {
+          arr: [
+            {
+              a: 123,
+              b: 'hello world',
+            },
+          ],
+          obj: {
+            arr: [123, 'hello world'],
+          },
+        },
+      ),
+    ).toStrictEqual({
+      arr: [
+        {
+          a: 123,
+          b: 'hello world',
+        },
+      ],
+      obj: {
+        arr: [123, 'hello world'],
+      },
+    });
+  });
+  test('validation error contains parse errors', async () => {
+    // Lazy mode
+    const f = () =>
+      validateSync(
+        (keyPath, value) => {
+          switch (keyPath.join('.')) {
+            case 'arr.0.a':
+            case 'obj.arr.0':
+              if (value !== 123) {
+                throw new validationErrors.ErrorParse('should be 123');
+              }
+              break;
+            case 'arr.0.b':
+            case 'obj.arr.1':
+              if (value !== 'hello world') {
+                throw new validationErrors.ErrorParse('should be hello world');
+              }
+              break;
+          }
+          return value;
+        },
+        {
+          arr: [
+            {
+              a: '123',
+              b: 'foo bar',
+            },
+          ],
+          obj: {
+            arr: ['123', 'foo bar'],
+          },
+        },
+      );
+    expect(f).toThrow(validationErrors.ErrorValidation);
+    try {
+      f();
+    } catch (e) {
+      expect(e).toBeInstanceOf(validationErrors.ErrorValidation);
+      const e_ = e as validationErrors.ErrorValidation;
+      // Lazy mode should only return 1 parse error
+      expect(e_.errors.length).toBe(1);
+      expect(e_.errors[0]).toBeInstanceOf(validationErrors.ErrorParse);
+      expect(e_.errors[0].keyPath).toStrictEqual(['arr', '0', 'a']);
+      expect(e_.errors[0].value).toBe('123');
+      expect(e_.errors[0].context).toStrictEqual({ a: '123', b: 'foo bar' });
+    }
+    // Greedy mode
+    const g = async () =>
+      validate(
+        (keyPath, value) => {
+          switch (keyPath.join('.')) {
+            case 'arr.0.a':
+            case 'obj.arr.0':
+              if (value !== 123) {
+                throw new validationErrors.ErrorParse('should be 123');
+              }
+              break;
+            case 'arr.0.b':
+            case 'obj.arr.1':
+              if (value !== 'hello world') {
+                throw new validationErrors.ErrorParse('should be hello world');
+              }
+              break;
+          }
+          return value;
+        },
+        {
+          arr: [
+            {
+              a: '123',
+              b: 'foo bar',
+            },
+          ],
+          obj: {
+            arr: ['123', 'foo bar'],
+          },
+        },
+        {
+          mode: 'greedy',
+        },
+      );
+    await expect(g).rejects.toThrow(validationErrors.ErrorValidation);
+    try {
+      await g();
+    } catch (e) {
+      expect(e).toBeInstanceOf(validationErrors.ErrorValidation);
+      const e_ = e as validationErrors.ErrorValidation;
+      // Greedy mode should only return 4 parse errors
+      expect(e_.errors.length).toBe(4);
+      expect(e_.errors[0]).toBeInstanceOf(validationErrors.ErrorParse);
+      expect(e_.errors[0].keyPath).toStrictEqual(['arr', '0', 'a']);
+      expect(e_.errors[0].value).toBe('123');
+      expect(e_.errors[0].context).toStrictEqual({ a: '123', b: 'foo bar' });
+      expect(e_.errors[1]).toBeInstanceOf(validationErrors.ErrorParse);
+      expect(e_.errors[1].keyPath).toStrictEqual(['arr', '0', 'b']);
+      expect(e_.errors[1].value).toBe('foo bar');
+      expect(e_.errors[1].context).toStrictEqual({ a: '123', b: 'foo bar' });
+      expect(e_.errors[2]).toBeInstanceOf(validationErrors.ErrorParse);
+      expect(e_.errors[2].keyPath).toStrictEqual(['obj', 'arr', '0']);
+      expect(e_.errors[2].value).toBe('123');
+      expect(e_.errors[2].context).toStrictEqual(['123', 'foo bar']);
+      expect(e_.errors[3]).toBeInstanceOf(validationErrors.ErrorParse);
+      expect(e_.errors[3].keyPath).toStrictEqual(['obj', 'arr', '1']);
+      expect(e_.errors[3].value).toBe('foo bar');
+      expect(e_.errors[3].context).toStrictEqual(['123', 'foo bar']);
+    }
+  });
+  test('manipulate `this` when using function expressions', async () => {
+    await validate((_, value) => {
+      expect(this).toEqual({});
+      return value;
+    }, 'hello world');
+    await validate(function (_, value) {
+      expect(this[undefined!]).toBe(value);
+      return value;
+    }, 'hello world');
+    // Mutating the root context
+    expect(
+      await validate(function (_, value) {
+        // This has no effect because the same value is still returned
+        this[undefined!] = 'foo bar';
+        return value;
+      }, 'hello world'),
+    ).toBe('hello world');
+    // Mutating nested context
+    expect(
+      await validate(
+        async function (keyPath, value) {
+          if (keyPath[0] === 'a' && keyPath[1] === 'b') {
+            expect(this).toEqual({ b: 'c' });
+            this['d'] = 'e';
+            return 'c2';
+          }
+          return value;
+        },
+        {
+          a: {
+            b: 'c',
+          },
+        },
+      ),
+    ).toEqual({
+      a: {
+        b: 'c2',
+        d: 'e',
+      },
+    });
+  });
+});


### PR DESCRIPTION
### Description

Boundary validation seems like a general problem that people are hitting over and over. It's best to fix this once and for all across all domains to ensure that we always have a consistent way of doing boundary validation.

#318 was merged with problems involving general data validation.

It's come to attention that data validation is not consistently applied across all of the IO boundaries that PK does.

Data validation is a very crucial task that we've missed, I originally thought that the combination of GRPC protobuf and the domain types would be enough. But it appears it is not, and our IO boundaries require a general validation system.

I've used general validation systems/libraries in the past for many different applications, mostly web SaaS, and I've never liked any of them.

After working with `JSON.parse`, I got some inspiration that combines the ideas from `JSON.parse`'s `reviver` parameter and the usage of recursion schemes used in functional languages, and the boundary issue mentioned in the Yesod framework https://www.yesodweb.com/book/introduction to create a `parse` function that do triple duty:

1. Be capable of validating nested data structure without any static constraints
2. Be capable of doing IO during validation, in order to validate complex dynamic data relationships
3. Be capable of sanitisation and type-marshalling and any other transformations that could occur

The lack of tuple structures, tuple-based pattern matching in JS means the composition of graph-operating function fragments is less syntactically nice, however the general principle of recursion schemes is followed.

Example prototype:

<details>

```ts
import { CustomError } from 'ts-custom-error';

class ErrorParse extends CustomError {
  public readonly errors: Array<ErrorRule>;
  constructor(errors: Array<ErrorRule>) {
    const message = errors.map((e) => e.message).join('; ');
    super(message);
    this.errors = errors;
  }
}

class ErrorRule extends CustomError {
  public keyPath: Array<string>;
  public value: any;
  public context: object;
  constructor(message?: string) {
    super(message);
  }
}

/**
 * Functional data-validation, inspired by recursion schemes and `JSON.parse` reviver
 * Post-fix depth first traversal on the data structure tree
 * Capable of modifying the data structure during traversal
 * Works like `JSON.parse` but on POJOs rather than JSON strings
 * Compose validation rules into the `rules` function
 */
async function parse(
  rules: (keyPath: Array<string>, value: any) => Promise<any>,
  data: any,
  options: { mode: 'greedy' | 'lazy' } = { mode: 'lazy' }
): Promise<any> {
  const errors: Array<ErrorRule> = [];
  const parse_ = async (keyPath: Array<string>, value: any, context: object) => {
    if (typeof value === 'object' && value != null) {
      for (const key in value) {
        value[key] = await parse_([...keyPath, key], value[key], value);
      }
    }
    try {
      value = await rules.bind(context)(keyPath, value);
    } catch (e) {
      if (e instanceof ErrorRule) {
        e.keyPath = keyPath;
        e.value = value;
        e.context = context;
        errors.push(e);
        // If lazy mode, short circuit evaluation
        // And throw the error up
        if (options.mode === 'lazy') {
          throw e;
        }
      } else {
        throw e;
      }
    }
    return value;
  };
  try {
    // The root context is an object containing the root data but keyed with undefined
    data = await parse_([], data, { undefined: data });
  } catch (e) {
    if (e instanceof ErrorRule) {
      throw new ErrorParse(errors);
    } else {
      throw e;
    }
  }
  if (errors.length > 0) {
    throw new ErrorParse(errors);
  }
  return data;
}

export { parse };
```

</details>

The `rules` parameter is a generic function that operates over every element of the data structure graph "bottom-up" using a post-fix depth first search traversal order, this allows one to operate any point in the graph, and the rules are meant to be composed of pattern-matched fragments doing a flexible mix of validation, sanitisation and marshalling.

The exact implementation may change as I encounter problems.

### Tasks

1. [x] The `decodeNodeId` should be returning `undefined` and the exception for invalid node id should be thrown on the boundaries, not inside the `decodeNodeId` function. The decoding function needs to match the behaviour that other utilities work with.
2. ~[ ] `ErrorNodeIdInvalid` over `ErrorInvalidNodeId` to keep it consistent with the rest of the code as well as changing the error message to remove `.`.~
3. [x] Implement `validation` domain with `validate` and `validateSync` and the usage of `ErrorParse` for generically throwing validation exceptions
4. [x] Change all validation functions to type predicates so that they assert the resulting type:
   - `isValidHost` - `isHost`
   - `isValidHostname` - `isHostname`
   - `isPort`
   - `isGestaltAction`
   - `isVaultAction`
5. [x] Ensure that all relevant encoded ids are done in their domains like `nodes/utils.ts` - `encodeNodeId`, `decodeNodeId`, `vaults/utils.ts` - `encodeVaultId`, `decodeVaultId`. Any Id that requires an encoded form and a decoded form should do this.
   - What about `NotificationId` and `Claimid` and `Permid`?
     * `NotificationId` and `ClaimId` are internal only
     * `ClaimId` is exposed externally as `ClaimIdString`, this will become `ClaimIdEncoded`, and encoded as `base32hex` instead of `base58btc` to preserve lexicographic order
     * Both `NotificationId` and `PermissionId` may have a "binary string" type `NotificationIdString` and `PermissionIdString`, this is different from any encoded form which would be `NotifcationIdEncoded` and `PermissionIdEncoded`, and there's no encoding/decoding functions, the string from happens during POJO keys usually.
     * Only `PermissionId` needs `PermissionIdString` for now. In the future `NotificationId` can have `NotificationIdString` if is being used.
   - Make sure all decoding functions are functional in that they return `IdType | undefined`, they are not supposed to throw exceptions, and for domains where the id is being extracted from a "trusted source of truth", then the decoding is expected to succeed, then using `!` can be used
     * `NodeManager` - from the node graph
     * `GestaltGraph` - from the graph db
     * `NotificationManager` - from the notifications db
   - CLI bin parsers may require a refactoring to apply validation consistently to arguments and options, and argument should then have the relevant types afterwards. It's important to resolve any default values must be the value that would be parsed.
6. [x] Service handlers are IO boundaries, all service handlers (client and agent) must apply the new `validate` or `validateSync` from `validation` domain and validate their input data. Remember `validate` and `validateSync` represent the 2nd line of defense. The first line for API is protobuf decoding. And for CLI, that would be commander's arg parsing logic.
7. [x] Ensure that `ErrorValidation` that is thrown by `validate` or `validateSync` can be serialised over GRPC and deserialised on the client side to see all parse errors. The list of errors during validation should be available under the `data` property as `data.errors = [ { message, keyPath, value }]`
8. [x] Ensure that `ErrorValidation` can be pretty printed to the STDERR by our root exception handlers, we want to be able to show a multitude of errors, however most uses of `validate` and `validateSync` will be `lazy` and not `greedy` in order to avoid Denial of Service.
   - This is pretty enough for now, but further prettying to be done in #323
9. [x] See if this applies to CLI bin commands too
   - The validation utilities don't apply to CLI bin parsers, because they sit in their own context of being used as arg parsers, however they do use the encoding/decoding and type guards provided by the domains
   - Some parsers are moved into `validation/utils.ts` like `parseGestaltId`, this was changed to actually return the `GestaltId`. Future parsing utilities to be shared between service handlers and CLI parsers should be delegated to `validation/utils.ts`, the main thing is to catch the `ErrorParse` and rethrow as a commander error.
10. [x] See if this applies to file interactions like Status or elsewhere
    - For `Status`, it uses the `decodeNodeId` directly because it already has a general error for failure to parse which is `ErrorStatusParse`, so it doesn't use the validation utility
    - Other files in the future may end up using the validation system as well, but for now, no other files are being read have sophisticated validation requirements, I imagine for some files it will just be done in the CLI bin commands when it gets read, so future data processing will use the general validation system
11. [x] Apply tests to validation domain, and new tests for expecting `ErrorValidation`.
12. [x] Check if we need to rework our imports to prevent cycles when imports from the index vs directly importing. We know this causes problems when some modules are broken. But does this actually cause cycles during imports too? If so, we have to change to direct imports.
    - Resolve to progressively change our imports to selective imports to avoid problems from index imports for internal code: https://github.com/MatrixAI/js-polykey/pull/321#issuecomment-1029631104

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
