### PR TITLE
CLI Retry Options due to Intermittent Network

### DIFF
--- a/src/bin/errors.ts
+++ b/src/bin/errors.ts
@@ -51,28 +51,12 @@ class ErrorCLIFileRead extends ErrorCLI {
   exitCode = sysexits.NOINPUT;
 }
 
-class ErrorSecretPathFormat extends ErrorCLI {
-  description = "Secret name needs to be of format: '<vaultName>:<secretPath>'";
-  exitCode = 64;
-}
-
-class ErrorVaultNameAmbiguous extends ErrorCLI {
-  description =
-    'There is more than 1 Vault with this name. Please specify a Vault ID';
-  exitCode = 1;
-}
-
-class ErrorSecretsUndefined extends ErrorCLI {
-  description = 'At least one secret must be specified as an argument';
-  exitCode = 64;
-}
-
-class ErrorNodeFindFailed extends ErrorCLI {
+class ErrorCLINodeFindFailed extends ErrorCLI {
   description = 'Failed to find the node in the DHT';
   exitCode = 1;
 }
 
-class ErrorNodePingFailed extends ErrorCLI {
+class ErrorCLINodePingFailed extends ErrorCLI {
   description = 'Node was not online or not found.';
   exitCode = 1;
 }
@@ -88,9 +72,6 @@ export {
   ErrorCLIPasswordFileRead,
   ErrorCLIRecoveryCodeFileRead,
   ErrorCLIFileRead,
-  ErrorSecretPathFormat,
-  ErrorVaultNameAmbiguous,
-  ErrorSecretsUndefined,
-  ErrorNodeFindFailed,
-  ErrorNodePingFailed,
+  ErrorCLINodeFindFailed,
+  ErrorCLINodePingFailed,
 };

--- a/src/bin/utils/options.ts
+++ b/src/bin/utils/options.ts
@@ -155,6 +155,19 @@ const workers = new commander.Option(
   .argParser(binParsers.parseCoreCount)
   .default(undefined);
 
+
+const retryCount = new commander.Option(
+  '-rc --retry-count <retryCount>',
+  'Number of attempts before failing',
+).argParser(binParsers.parseNumber);
+
+const retryInterval = new commander.Option(
+  '-ri --retry-interval <retryInterval>',
+  'Number of milliseconds between each attempt',
+)
+  .argParser(binParsers.parseNumber)
+  .default(5000);
+
 export {
   nodePath,
   format,
@@ -176,4 +189,6 @@ export {
   seedNodes,
   network,
   workers,
+  retryCount,
+  retryInterval,
 };

--- a/tests/bin/nodes/find.test.ts
+++ b/tests/bin/nodes/find.test.ts
@@ -181,6 +181,10 @@ describe('find', () => {
       const commands = genCommands([
         'find',
         nodesUtils.encodeNodeId(unknownNodeId),
+        '-c',
+        '3',
+        '-ad',
+        '100',
       ]);
       const result = await testBinUtils.pkStdio(commands, {}, dataDir);
       expect(result.exitCode).toBe(1);

--- a/tests/bin/nodes/ping.test.ts
+++ b/tests/bin/nodes/ping.test.ts
@@ -101,6 +101,10 @@ describe('ping', () => {
       const commands = genCommands([
         'ping',
         nodesUtils.encodeNodeId(remoteOfflineNodeId),
+        '-c',
+        '1',
+        '-ad',
+        '100',
       ]);
       const result = await testBinUtils.pkStdio(commands, {}, dataDir);
       expect(result.exitCode).toBe(1); // Should fail with no response. for automation purposes.


### PR DESCRIPTION
### Description

This introduces retry options to `CommandFind` and `CommandPing`.

This was extracted out of #266 because it wasn't related to vaults functionality.

Still trying to find what the reason for these options are for, and perhaps this should be considered in light of the CLI over-all design.

### Issues Fixed
<!-- List all issues fixed by this PR. -->

### Tasks
<!-- List all tasks to be done by this PR. -->

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [ ] Domain specific tests
* [ ] Full tests
* [ ] Updated inline-comment documentation
* [ ] Lint fixed
* [ ] Squash and rebased
* [ ] Sanity check the final build
