### PR TITLE
Fixing the GRPC `toError()` bug with `ErrorValidation`

### DIFF
--- a/src/validation/errors.ts
+++ b/src/validation/errors.ts
@@ -2,24 +2,45 @@ import { CustomError } from 'ts-custom-error';
 import { ErrorPolykey, sysexits } from '../errors';
 
 /**
- * This packages the `ErrorParse` array into the `data` property
- * This is to allow encoding to and decoding from GRPC errors
+ * Generic error containing all parsing errors that occurred during
+ * execution.
  */
 class ErrorValidation extends ErrorPolykey {
-  public readonly errors: Array<ErrorParse>;
-  constructor(errors: Array<ErrorParse>) {
+  description = 'Input data failed validation';
+  exitCode = sysexits.DATAERR;
+  public errors: Array<ErrorParse>;
+  constructor(message, data) {
+    super(message, data);
+    if (data.errors != null) {
+      const errors: Array<ErrorParse> = [];
+      for (const eData of data.errors) {
+        const errorParse = new ErrorParse(eData.message);
+        errorParse.keyPath = eData.keyPath;
+        errorParse.value = eData.value;
+        errorParse.context = eData.context;
+        errors.push(errorParse);
+      }
+      this.errors = errors;
+    }
+  }
+
+  /**
+   * This packages an `ErrorParse` array into the `data` property
+   * This is to allow encoding to and decoding from GRPC errors
+   */
+  static createFromErrors(errors: Array<ErrorParse>): ErrorValidation {
     const message = errors.map((e) => e.message).join('; ');
     const data = {
       errors: errors.map((e) => ({
         message: e.message,
         keyPath: e.keyPath,
         value: e.value.valueOf(),
+        context: e.context,
       })),
     };
-    super(message, data);
-    this.description = 'Input data failed validation';
-    this.exitCode = sysexits.DATAERR;
-    this.errors = errors;
+    const e = new ErrorValidation(message, data);
+    e.errors = errors;
+    return e;
   }
 }
 

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -41,13 +41,13 @@ async function validate(
     data = await parse_([], data, { undefined: data });
   } catch (e) {
     if (e instanceof validationErrors.ErrorParse) {
-      throw new validationErrors.ErrorValidation(errors);
+      throw validationErrors.ErrorValidation.createFromErrors(errors);
     } else {
       throw e;
     }
   }
   if (errors.length > 0) {
-    throw new validationErrors.ErrorValidation(errors);
+    throw validationErrors.ErrorValidation.createFromErrors(errors);
   }
   return data;
 }
@@ -88,13 +88,13 @@ function validateSync(
     data = parse_([], data, { undefined: data });
   } catch (e) {
     if (e instanceof validationErrors.ErrorParse) {
-      throw new validationErrors.ErrorValidation(errors);
+      throw validationErrors.ErrorValidation.createFromErrors(errors);
     } else {
       throw e;
     }
   }
   if (errors.length > 0) {
-    throw new validationErrors.ErrorValidation(errors);
+    throw validationErrors.ErrorValidation.createFromErrors(errors);
   }
   return data;
 }

--- a/tests/client/service/identitiesAuthenticate.test.ts
+++ b/tests/client/service/identitiesAuthenticate.test.ts
@@ -16,6 +16,7 @@ import {
 import identitiesAuthenticate from '@/client/service/identitiesAuthenticate';
 import * as identitiesPB from '@/proto/js/polykey/v1/identities/identities_pb';
 import { utils as nodesUtils } from '@/nodes';
+import * as validationErrors from '@/validation/errors';
 import TestProvider from '../../identities/TestProvider';
 
 describe('identitiesAuthenticate', () => {
@@ -87,7 +88,6 @@ describe('identitiesAuthenticate', () => {
   test('authenticates identity', async () => {
     const request = new identitiesPB.Provider();
     request.setProviderId(testToken.providerId);
-    request.setIdentityId(testToken.identityId);
     const response = grpcClient.identitiesAuthenticate(
       request,
       clientUtils.encodeAuthFromPassword(password),
@@ -122,5 +122,17 @@ describe('identitiesAuthenticate', () => {
       testToken.providerId,
       testToken.identityId,
     );
+  });
+  test('cannot authenticate invalid provider', async () => {
+    const request = new identitiesPB.Provider();
+    request.setProviderId('');
+    await expect(
+      grpcClient
+        .identitiesAuthenticate(
+          request,
+          clientUtils.encodeAuthFromPassword(password),
+        )
+        .next(),
+    ).rejects.toThrow(validationErrors.ErrorValidation);
   });
 });

--- a/tests/client/service/identitiesClaim.test.ts
+++ b/tests/client/service/identitiesClaim.test.ts
@@ -22,6 +22,7 @@ import {
 import identitiesClaim from '@/client/service/identitiesClaim';
 import * as identitiesPB from '@/proto/js/polykey/v1/identities/identities_pb';
 import * as claimsUtils from '@/claims/utils';
+import * as validationErrors from '@/validation/errors';
 import TestProvider from '../../identities/TestProvider';
 import * as testUtils from '../../utils';
 
@@ -198,5 +199,32 @@ describe('identitiesClaim', () => {
       testToken.providerId,
       testToken.identityId,
     );
+  });
+  test('cannot claim invalid identity', async () => {
+    const request = new identitiesPB.Provider();
+    request.setIdentityId('');
+    request.setProviderId(testToken.providerId);
+    await expect(
+      grpcClient.identitiesClaim(
+        request,
+        clientUtils.encodeAuthFromPassword(password),
+      ),
+    ).rejects.toThrow(validationErrors.ErrorValidation);
+    request.setIdentityId(testToken.identityId);
+    request.setProviderId('');
+    await expect(
+      grpcClient.identitiesClaim(
+        request,
+        clientUtils.encodeAuthFromPassword(password),
+      ),
+    ).rejects.toThrow(validationErrors.ErrorValidation);
+    request.setIdentityId('');
+    request.setProviderId('');
+    await expect(
+      grpcClient.identitiesClaim(
+        request,
+        clientUtils.encodeAuthFromPassword(password),
+      ),
+    ).rejects.toThrow(validationErrors.ErrorValidation);
   });
 });

--- a/tests/client/service/nodesAdd.test.ts
+++ b/tests/client/service/nodesAdd.test.ts
@@ -19,6 +19,7 @@ import nodesAdd from '@/client/service/nodesAdd';
 import * as nodesPB from '@/proto/js/polykey/v1/nodes/nodes_pb';
 import * as utilsPB from '@/proto/js/polykey/v1/utils/utils_pb';
 import { utils as nodesUtils } from '@/nodes';
+import * as validationErrors from '@/validation/errors';
 import * as testUtils from '../../utils';
 
 describe('nodesAdd', () => {
@@ -154,5 +155,38 @@ describe('nodesAdd', () => {
     expect(result).toBeDefined();
     expect(result!.host).toBe('127.0.0.1');
     expect(result!.port).toBe(11111);
+  });
+  test('cannot add invalid node', async () => {
+    // Invalid host
+    const addressMessage = new nodesPB.Address();
+    addressMessage.setHost('');
+    addressMessage.setPort(11111);
+    const request = new nodesPB.NodeAddress();
+    request.setNodeId('vrsc24a1er424epq77dtoveo93meij0pc8ig4uvs9jbeld78n9nl0');
+    request.setAddress(addressMessage);
+    await expect(
+      grpcClient.nodesAdd(
+        request,
+        clientUtils.encodeAuthFromPassword(password),
+      ),
+    ).rejects.toThrow(validationErrors.ErrorValidation);
+    // Invalid port
+    addressMessage.setHost('127.0.0.1');
+    addressMessage.setPort(111111);
+    await expect(
+      grpcClient.nodesAdd(
+        request,
+        clientUtils.encodeAuthFromPassword(password),
+      ),
+    ).rejects.toThrow(validationErrors.ErrorValidation);
+    // Invalid nodeid
+    addressMessage.setPort(11111);
+    request.setNodeId('nodeId');
+    await expect(
+      grpcClient.nodesAdd(
+        request,
+        clientUtils.encodeAuthFromPassword(password),
+      ),
+    ).rejects.toThrow(validationErrors.ErrorValidation);
   });
 });

--- a/tests/client/service/nodesClaim.test.ts
+++ b/tests/client/service/nodesClaim.test.ts
@@ -22,6 +22,7 @@ import {
 import nodesClaim from '@/client/service/nodesClaim';
 import * as nodesPB from '@/proto/js/polykey/v1/nodes/nodes_pb';
 import * as utilsPB from '@/proto/js/polykey/v1/utils/utils_pb';
+import * as validationErrors from '@/validation/errors';
 import * as testUtils from '../../utils';
 
 describe('nodesClaim', () => {
@@ -211,5 +212,15 @@ describe('nodesClaim', () => {
     );
     expect(response).toBeInstanceOf(utilsPB.StatusMessage);
     expect(response.getSuccess()).toBeTruthy();
+  });
+  test('cannot claim an invalid node', async () => {
+    const request = new nodesPB.Claim();
+    request.setNodeId('nodeId');
+    await expect(
+      grpcClient.nodesClaim(
+        request,
+        clientUtils.encodeAuthFromPassword(password),
+      ),
+    ).rejects.toThrow(validationErrors.ErrorValidation);
   });
 });

--- a/tests/client/service/nodesFind.test.ts
+++ b/tests/client/service/nodesFind.test.ts
@@ -17,6 +17,7 @@ import {
 } from '@/client';
 import nodesFind from '@/client/service/nodesFind';
 import * as nodesPB from '@/proto/js/polykey/v1/nodes/nodes_pb';
+import * as validationErrors from '@/validation/errors';
 import * as testUtils from '../../utils';
 
 describe('nodesFind', () => {
@@ -152,5 +153,15 @@ describe('nodesFind', () => {
     );
     expect(response.getAddress()!.getHost()).toBe('127.0.0.1');
     expect(response.getAddress()!.getPort()).toBe(11111);
+  });
+  test('cannot find an invalid node', async () => {
+    const request = new nodesPB.Node();
+    request.setNodeId('nodeId');
+    await expect(
+      grpcClient.nodesFind(
+        request,
+        clientUtils.encodeAuthFromPassword(password),
+      ),
+    ).rejects.toThrow(validationErrors.ErrorValidation);
   });
 });

--- a/tests/client/service/nodesPing.test.ts
+++ b/tests/client/service/nodesPing.test.ts
@@ -18,6 +18,7 @@ import {
 import nodesPing from '@/client/service/nodesPing';
 import * as nodesPB from '@/proto/js/polykey/v1/nodes/nodes_pb';
 import * as utilsPB from '@/proto/js/polykey/v1/utils/utils_pb';
+import * as validationErrors from '@/validation/errors';
 import * as testUtils from '../../utils';
 
 describe('nodesPing', () => {
@@ -157,5 +158,15 @@ describe('nodesPing', () => {
     );
     expect(response).toBeInstanceOf(utilsPB.StatusMessage);
     expect(response.getSuccess()).toBeTruthy();
+  });
+  test('cannot ping an invalid node', async () => {
+    const request = new nodesPB.Node();
+    request.setNodeId('nodeId');
+    await expect(
+      grpcClient.nodesPing(
+        request,
+        clientUtils.encodeAuthFromPassword(password),
+      ),
+    ).rejects.toThrow(validationErrors.ErrorValidation);
   });
 });


### PR DESCRIPTION
### Description
There is currently a bug with the new `ErrorValidation`, which was brought in as part of the new validation system in #321. Since `ErrorValidation` extends `ErrorPolykey`, but also uses a different constructor, `toError()` is unable to properly construct `ErrorValidation`s when throwing errors. Since we want `ErrorValidation` to be able to be used as both a standard `ErrorPolykey`, but also as a way of joining together multiple `ErrorParse`s into a single error, we need to do something like this:
```
class ErrorValidation extends ErrorPolykey {
  description = '...';
  exitCode = sysexits.DATAERR;
  public errors: Array<ErrorParse>;

  constructor(message, data) {

    if (data.errors != null) {
      let errors = [];
      for (const eData of data.errors) {
        const errorParse = new ErrorParse(eData.message);
        errorParse.keyPath = ...eData.keyPath;
        errors.push(errorParse);
      }
      this.errors = errors;
    }


  }

  static createFromErrors(errors: Array<ErrorParse>): ErrorValidation {
    const message = errors.map((e) => e.message).join('; ');
    const data = {
      errors: errors.map((e) => ({
        message: e.message,
        keyPath: e.keyPath,
        value: e.value.valueOf(),
      })),
    };
    const e = new ErrorValidation(message, data);
    e.errors = errors;
    return e;
    // super(message, data);
    // this.description = 'Input data failed validation';
    // this.exitCode = sysexits.DATAERR;
    // this.errors = errors;
  }
}
```

### Issues Fixed
* Fixes https://github.com/MatrixAI/js-polykey/pull/321#issuecomment-1033215131

### Tasks
1. [x] Fix the constructor inside `ErrorValidation` to match `ErrorPolykey`
2. [x] Add a static method to `ErrorValidation` to deconstruct an array of `ErrorParse`s
3. [x] Tests for both usages of `ErrorValidation`, including with `toError()`

### Final checklist
* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
