### PR TITLE
fix: bug with GPRC client call through proxy

### DIFF
--- a/src/network/ConnectionReverse.ts
+++ b/src/network/ConnectionReverse.ts
@@ -295,7 +295,9 @@ class ConnectionReverse extends Connection {
         await this.stop();
       });
       this.tlsSocket.pipe(this.serverSocket, { end: false });
-      this.serverSocket.pipe(this.tlsSocket, { end: false });
+      this.tlsSocket.once('data', () => {
+        this.serverSocket.pipe(this.tlsSocket as TLSSocket, { end: false });
+      });
       this.clientCertChain = clientCertChain;
       this.logger.info('Composed Connection Reverse');
     } catch (e) {

--- a/src/network/utils.ts
+++ b/src/network/utils.ts
@@ -29,6 +29,10 @@ function isHost(host: any): host is Host {
   return isIPv4 || isIPv6;
 }
 
+function isHostWildcard(host: Host): boolean {
+  return host === '0.0.0.0' || host === '::';
+}
+
 /**
  * Validates hostname as per RFC 1123
  */
@@ -353,6 +357,7 @@ export {
   pingBuffer,
   pongBuffer,
   isHost,
+  isHostWildcard,
   isHostname,
   isPort,
   toAuthToken,

--- a/src/nodes/NodeConnection.ts
+++ b/src/nodes/NodeConnection.ts
@@ -59,6 +59,10 @@ class NodeConnection<T extends GRPCClient> {
     logger?: Logger;
   }): Promise<NodeConnection<T>> {
     logger.info(`Creating ${this.name}`);
+    // Checking if attempting to connect to a wildcard IP
+    if (networkUtils.isHostWildcard(targetHost)) {
+      throw new nodesErrors.ErrorNodeConnectionHostWildcard();
+    }
     const proxyConfig = {
       host: proxy.getForwardHost(),
       port: proxy.getForwardPort(),

--- a/src/nodes/errors.ts
+++ b/src/nodes/errors.ts
@@ -62,6 +62,11 @@ class ErrorNodeConnectionManagerNotRunning extends ErrorNodes {
   exitCode = sysexits.USAGE;
 }
 
+class ErrorNodeConnectionHostWildcard extends ErrorNodes {
+  description = 'An IP wildcard was provided for the target host';
+  exitCode = sysexits.USAGE;
+}
+
 export {
   ErrorNodes,
   ErrorNodeGraphRunning,
@@ -76,4 +81,5 @@ export {
   ErrorNodeConnectionInfoNotExist,
   ErrorNodeConnectionPublicKeyNotFound,
   ErrorNodeConnectionManagerNotRunning,
+  ErrorNodeConnectionHostWildcard,
 };

--- a/tests/agent/service/nodesCrossSignClaim.test.ts
+++ b/tests/agent/service/nodesCrossSignClaim.test.ts
@@ -52,6 +52,9 @@ describe('nodesCrossSignClaim', () => {
         rootKeyPairBits: 2048,
       },
       seedNodes: {}, // Explicitly no seed nodes on startup
+      networkConfig: {
+        proxyHost: '127.0.0.1' as Host,
+      },
       logger,
     });
     localId = pkAgent.keyManager.getNodeId();
@@ -63,6 +66,9 @@ describe('nodesCrossSignClaim', () => {
         rootKeyPairBits: 2048,
       },
       seedNodes: {}, // Explicitly no seed nodes on startup
+      networkConfig: {
+        proxyHost: '127.0.0.1' as Host,
+      },
       logger,
     });
     remoteId = remoteNode.keyManager.getNodeId();

--- a/tests/bin/vaults/vaults.test.ts
+++ b/tests/bin/vaults/vaults.test.ts
@@ -1,5 +1,6 @@
 import type { NodeIdEncoded, NodeAddress, NodeInfo } from '@/nodes/types';
 import type { VaultId, VaultName } from '@/vaults/types';
+import type { Host } from '@/network/types';
 import os from 'os';
 import path from 'path';
 import fs from 'fs';
@@ -207,6 +208,9 @@ describe('CLI vaults', () => {
       const targetPolykeyAgent = await PolykeyAgent.createPolykeyAgent({
         password,
         nodePath: dataDir2,
+        networkConfig: {
+          proxyHost: '127.0.0.1' as Host,
+        },
         logger: logger,
       });
       const vaultId = await targetPolykeyAgent.vaultManager.createVault(
@@ -701,6 +705,9 @@ describe('CLI vaults', () => {
             password,
             logger,
             nodePath: path.join(dataDir, 'remoteOnline'),
+            networkConfig: {
+              proxyHost: '127.0.0.1' as Host,
+            },
           });
           const remoteOnlineNodeId = remoteOnline.keyManager.getNodeId();
           const remoteOnlineNodeIdEncoded =

--- a/tests/network/Proxy.test.ts
+++ b/tests/network/Proxy.test.ts
@@ -208,6 +208,15 @@ describe(Proxy.name, () => {
         `127.0.0.1:80?nodeId=${encodeURIComponent(nodeIdSomeEncoded)}`,
       ),
     ).rejects.toThrow('407');
+    // Wildcard as host
+    await expect(() =>
+      httpConnect(
+        proxy.getForwardHost(),
+        proxy.getForwardPort(),
+        authToken,
+        `0.0.0.0:80?nodeId=${encodeURIComponent(nodeIdSomeEncoded)}`,
+      ),
+    ).rejects.toThrow('400');
     // No node id
     await expect(() =>
       httpConnect(

--- a/tests/nodes/NodeConnectionManager.general.test.ts
+++ b/tests/nodes/NodeConnectionManager.general.test.ts
@@ -139,12 +139,18 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     remoteNode1 = await PolykeyAgent.createPolykeyAgent({
       password,
       nodePath: path.join(dataDir2, 'remoteNode1'),
+      networkConfig: {
+        proxyHost: '127.0.0.1' as Host,
+      },
       logger: logger.getChild('remoteNode1'),
     });
     remoteNodeId1 = remoteNode1.keyManager.getNodeId();
     remoteNode2 = await PolykeyAgent.createPolykeyAgent({
       password,
       nodePath: path.join(dataDir2, 'remoteNode2'),
+      networkConfig: {
+        proxyHost: '127.0.0.1' as Host,
+      },
       logger: logger.getChild('remoteNode2'),
     });
     remoteNodeId2 = remoteNode2.keyManager.getNodeId();
@@ -266,6 +272,9 @@ describe(`${NodeConnectionManager.name} general test`, () => {
         const server = await PolykeyAgent.createPolykeyAgent({
           nodePath: path.join(dataDir, 'node2'),
           password,
+          networkConfig: {
+            proxyHost: '127.0.0.1' as Host,
+          },
           logger: nodeConnectionManagerLogger,
         });
         await nodeGraph.setNode(server.keyManager.getNodeId(), {
@@ -300,6 +309,9 @@ describe(`${NodeConnectionManager.name} general test`, () => {
         const server = await PolykeyAgent.createPolykeyAgent({
           nodePath: path.join(dataDir, 'node3'),
           password,
+          networkConfig: {
+            proxyHost: '127.0.0.1' as Host,
+          },
           logger: nodeConnectionManagerLogger,
         });
         await nodeGraph.setNode(server.keyManager.getNodeId(), {
@@ -456,6 +468,9 @@ describe(`${NodeConnectionManager.name} general test`, () => {
         password,
         logger: logger.getChild('serverPKAgent'),
         nodePath: path.join(dataDir, 'serverPKAgent'),
+        networkConfig: {
+          proxyHost: '127.0.0.1' as Host,
+        },
       });
       nodeConnectionManager = new NodeConnectionManager({
         keyManager,

--- a/tests/nodes/NodeConnectionManager.lifecycle.test.ts
+++ b/tests/nodes/NodeConnectionManager.lifecycle.test.ts
@@ -97,12 +97,18 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     remoteNode1 = await PolykeyAgent.createPolykeyAgent({
       password,
       nodePath: path.join(dataDir2, 'remoteNode1'),
+      networkConfig: {
+        proxyHost: '127.0.0.1' as Host,
+      },
       logger: logger.getChild('remoteNode1'),
     });
     remoteNodeId1 = remoteNode1.keyManager.getNodeId();
     remoteNode2 = await PolykeyAgent.createPolykeyAgent({
       password,
       nodePath: path.join(dataDir2, 'remoteNode2'),
+      networkConfig: {
+        proxyHost: '127.0.0.1' as Host,
+      },
       logger: logger.getChild('remoteNode2'),
     });
     remoteNodeId2 = remoteNode2.keyManager.getNodeId();

--- a/tests/nodes/NodeConnectionManager.seednodes.test.ts
+++ b/tests/nodes/NodeConnectionManager.seednodes.test.ts
@@ -90,12 +90,18 @@ describe(`${NodeConnectionManager.name} seed nodes test`, () => {
     remoteNode1 = await PolykeyAgent.createPolykeyAgent({
       password,
       nodePath: path.join(dataDir2, 'remoteNode1'),
+      networkConfig: {
+        proxyHost: '127.0.0.1' as Host,
+      },
       logger: logger.getChild('remoteNode1'),
     });
     remoteNodeId1 = remoteNode1.keyManager.getNodeId();
     remoteNode2 = await PolykeyAgent.createPolykeyAgent({
       password,
       nodePath: path.join(dataDir2, 'remoteNode2'),
+      networkConfig: {
+        proxyHost: '127.0.0.1' as Host,
+      },
       logger: logger.getChild('remoteNode2'),
     });
     remoteNodeId2 = remoteNode2.keyManager.getNodeId();

--- a/tests/nodes/NodeConnectionManager.termination.test.ts
+++ b/tests/nodes/NodeConnectionManager.termination.test.ts
@@ -355,6 +355,9 @@ describe(`${NodeConnectionManager.name} termination test`, () => {
       polykeyAgent = await PolykeyAgent.createPolykeyAgent({
         password,
         nodePath: nodePath,
+        networkConfig: {
+          proxyHost: '127.0.0.1' as Host,
+        },
         logger: logger,
       });
 
@@ -408,6 +411,9 @@ describe(`${NodeConnectionManager.name} termination test`, () => {
       polykeyAgent = await PolykeyAgent.createPolykeyAgent({
         password,
         nodePath: nodePath,
+        networkConfig: {
+          proxyHost: '127.0.0.1' as Host,
+        },
         logger: logger,
       });
       const agentNodeId = polykeyAgent.keyManager.getNodeId();
@@ -483,6 +489,9 @@ describe(`${NodeConnectionManager.name} termination test`, () => {
       polykeyAgent = await PolykeyAgent.createPolykeyAgent({
         password,
         nodePath: nodePath,
+        networkConfig: {
+          proxyHost: '127.0.0.1' as Host,
+        },
         logger: logger,
       });
 
@@ -551,6 +560,9 @@ describe(`${NodeConnectionManager.name} termination test`, () => {
       polykeyAgent = await PolykeyAgent.createPolykeyAgent({
         password,
         nodePath: nodePath,
+        networkConfig: {
+          proxyHost: '127.0.0.1' as Host,
+        },
         logger: logger,
       });
 
@@ -624,6 +636,9 @@ describe(`${NodeConnectionManager.name} termination test`, () => {
       polykeyAgent = await PolykeyAgent.createPolykeyAgent({
         password,
         nodePath: nodePath,
+        networkConfig: {
+          proxyHost: '127.0.0.1' as Host,
+        },
         logger: logger,
       });
 
@@ -697,6 +712,9 @@ describe(`${NodeConnectionManager.name} termination test`, () => {
       polykeyAgent = await PolykeyAgent.createPolykeyAgent({
         password,
         nodePath: nodePath,
+        networkConfig: {
+          proxyHost: '127.0.0.1' as Host,
+        },
         logger: logger,
       });
 

--- a/tests/nodes/NodeConnectionManager.timeout.test.ts
+++ b/tests/nodes/NodeConnectionManager.timeout.test.ts
@@ -92,12 +92,18 @@ describe(`${NodeConnectionManager.name} timeout test`, () => {
       password,
       nodePath: path.join(dataDir2, 'remoteNode1'),
       logger: logger.getChild('remoteNode1'),
+      networkConfig: {
+        proxyHost: '127.0.0.1' as Host,
+      },
     });
     remoteNodeId1 = remoteNode1.keyManager.getNodeId();
     remoteNode2 = await PolykeyAgent.createPolykeyAgent({
       password,
       nodePath: path.join(dataDir2, 'remoteNode2'),
       logger: logger.getChild('remoteNode2'),
+      networkConfig: {
+        proxyHost: '127.0.0.1' as Host,
+      },
     });
     remoteNodeId2 = remoteNode2.keyManager.getNodeId();
   });

--- a/tests/nodes/NodeManager.test.ts
+++ b/tests/nodes/NodeManager.test.ts
@@ -136,6 +136,9 @@ describe(`${NodeManager.name} test`, () => {
           keysConfig: {
             rootKeyPairBits: 2048,
           },
+          networkConfig: {
+            proxyHost: '127.0.0.1' as Host,
+          },
           logger: logger,
         });
         const serverNodeId = server.keyManager.getNodeId();
@@ -161,7 +164,12 @@ describe(`${NodeManager.name} test`, () => {
         const active1 = await nodeManager.pingNode(serverNodeId);
         expect(active1).toBe(false);
         // Bring server node online
-        await server.start({ password: 'password' });
+        await server.start({
+          password: 'password',
+          networkConfig: {
+            proxyHost: '127.0.0.1' as Host,
+          },
+        });
         // Update the node address (only changes because we start and stop)
         serverNodeAddress = {
           host: server.proxy.getProxyHost(),
@@ -198,6 +206,9 @@ describe(`${NodeManager.name} test`, () => {
         nodePath: path.join(dataDir, 'server'),
         keysConfig: {
           rootKeyPairBits: 2048,
+        },
+        networkConfig: {
+          proxyHost: '127.0.0.1' as Host,
         },
         logger: logger,
       });
@@ -258,6 +269,9 @@ describe(`${NodeManager.name} test`, () => {
         keysConfig: {
           rootKeyPairBits: 2048,
         },
+        networkConfig: {
+          proxyHost: '127.0.0.1' as Host,
+        },
         logger,
       });
 
@@ -276,6 +290,9 @@ describe(`${NodeManager.name} test`, () => {
         nodePath: yDataDir,
         keysConfig: {
           rootKeyPairBits: 2048,
+        },
+        networkConfig: {
+          proxyHost: '127.0.0.1' as Host,
         },
         logger,
       });

--- a/tests/notifications/NotificationsManager.test.ts
+++ b/tests/notifications/NotificationsManager.test.ts
@@ -134,6 +134,9 @@ describe('NotificationsManager', () => {
       keysConfig: {
         rootKeyPairBits: 1024,
       },
+      networkConfig: {
+        proxyHost: '127.0.0.1' as Host,
+      },
       logger,
     });
     await nodeGraph.setNode(receiver.keyManager.getNodeId(), {

--- a/tests/vaults/VaultManager.test.ts
+++ b/tests/vaults/VaultManager.test.ts
@@ -484,6 +484,9 @@ describe('VaultManager', () => {
         password,
         logger: logger.getChild('Remote Keynode 1'),
         nodePath: path.join(allDataDir, 'remoteKeynode1'),
+        networkConfig: {
+          proxyHost: '127.0.0.1' as Host,
+        },
       });
       remoteKeynode1Id = remoteKeynode1.keyManager.getNodeId();
       remoteKeynode1IdEncoded = nodesUtils.encodeNodeId(remoteKeynode1Id);
@@ -491,6 +494,9 @@ describe('VaultManager', () => {
         password,
         logger: logger.getChild('Remote Keynode 2'),
         nodePath: path.join(allDataDir, 'remoteKeynode2'),
+        networkConfig: {
+          proxyHost: '127.0.0.1' as Host,
+        },
       });
       remoteKeynode2Id = remoteKeynode2.keyManager.getNodeId();
       remoteKeynode2IdEncoded = nodesUtils.encodeNodeId(remoteKeynode2Id);
@@ -1424,6 +1430,9 @@ describe('VaultManager', () => {
     const remoteAgent = await PolykeyAgent.createPolykeyAgent({
       password: 'password',
       nodePath: path.join(dataDir, 'remoteNode'),
+      networkConfig: {
+        proxyHost: '127.0.0.1' as Host,
+      },
       logger,
     });
     const acl = await ACL.createACL({


### PR DESCRIPTION
### Description
This PR is to address the issue with #369 and other small fixes.

This is basically the fix:

```
      this.tlsSocket.once('data', () => {
        this.serverSocket.pipe(this.tlsSocket as TLSSocket, { end: false });
      });
```

We couldn't get `pause` or `cork` to work. So now we only start piping the server socket to the tls socket on the reverse side upon first receiving data.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #369 

### Tasks
1. [X] fix the `RST_stream`  GRPC bug. Do this by delaying any response through the proxy till after we receive the MAGIC frame.
1. [X] Add in a check for `handleConnectForward` for the wild card addresses since they should not be connectable. - this could be done in `Proxy.establishConnectionForward` because it is used by both `handleConnectForward` and `openConnectionForward`, and it would throw a specific exception for this. Have a look at `src/network/errors.ts` to see what is acceptable.
2. [X] Add additional tests for this in `Proxy.test.ts`
3. [X] Ensure that `NodeConnection.name` is embedded in the `NodeConnection` logger.
4. [X] update logging in `NodeConnectionManager` to be less confusing when creating and using connections.
6. [x] test for if the proxy connections are established first and then client connects.

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
