### PR TITLE
`getClosestGlobalNodes`, `findNode` error fix

### DIFF
--- a/src/nodes/NodeConnectionManager.ts
+++ b/src/nodes/NodeConnectionManager.ts
@@ -449,9 +449,10 @@ class NodeConnectionManager {
       this.initialClosestNodes,
     );
     // If we have no nodes at all in our database (even after synchronising),
-    // then we should throw an eor. We aren't going to find any others
+    // then we should return nothing. We aren't going to find any others
     if (shortlist.length === 0) {
-      throw new nodesErrors.ErrorNodeGraphEmptyDatabase();
+      this.logger.warn('Node graph was empty, No nodes to query');
+      return;
     }
     // Need to keep track of the nodes that have been contacted
     // Not sufficient to simply check if there's already a pre-existing connection

--- a/src/nodes/errors.ts
+++ b/src/nodes/errors.ts
@@ -37,11 +37,6 @@ class ErrorNodeGraphNodeIdNotFound<T> extends ErrorNodes<T> {
   exitCode = sysexits.NOUSER;
 }
 
-class ErrorNodeGraphEmptyDatabase<T> extends ErrorNodes<T> {
-  static description = 'NodeGraph database was empty';
-  exitCode = sysexits.USAGE;
-}
-
 class ErrorNodeGraphOversizedBucket<T> extends ErrorNodes<T> {
   static description: 'Bucket invalidly contains more nodes than capacity';
   exitCode = sysexits.USAGE;
@@ -101,7 +96,6 @@ export {
   ErrorNodeGraphNotRunning,
   ErrorNodeGraphDestroyed,
   ErrorNodeGraphNodeIdNotFound,
-  ErrorNodeGraphEmptyDatabase,
   ErrorNodeGraphOversizedBucket,
   ErrorNodeGraphSameNodeId,
   ErrorNodeGraphBucketIndex,

--- a/tests/bin/bootstrap.test.ts
+++ b/tests/bin/bootstrap.test.ts
@@ -219,8 +219,8 @@ describe('bootstrap', () => {
         });
       });
       await new Promise((res) => {
-        bootstrapProcess1.once('exit', () => res(null))
-      })
+        bootstrapProcess1.once('exit', () => res(null));
+      });
       // Attempting to bootstrap should fail with existing state
       const bootstrapProcess2 = await testBinUtils.pkStdio(
         [

--- a/tests/nodes/NodeManager.test.ts
+++ b/tests/nodes/NodeManager.test.ts
@@ -1104,7 +1104,7 @@ describe(`${NodeManager.name} test`, () => {
       'refreshBucket',
     );
     try {
-      logger.setLevel(LogLevel.DEBUG);
+      logger.setLevel(LogLevel.WARN);
       await queue.start();
       await nodeManager.start();
       await nodeConnectionManager.start({ nodeManager });
@@ -1143,6 +1143,24 @@ describe(`${NodeManager.name} test`, () => {
       mockRefreshBucket.mockRestore();
       await nodeManager.stop();
       await queue.stop();
+    }
+  });
+  test('refreshBucket should not throw errors when network is empty', async () => {
+    const nodeManager = new NodeManager({
+      db,
+      sigchain: {} as Sigchain,
+      keyManager,
+      nodeGraph,
+      nodeConnectionManager,
+      queue,
+      refreshBucketTimerDefault: 10000000,
+      logger,
+    });
+    await nodeConnectionManager.start({ nodeManager });
+    try {
+      await expect(nodeManager.refreshBucket(100)).resolves.not.toThrow();
+    } finally {
+      await nodeManager.stop();
     }
   });
 });


### PR DESCRIPTION
### Description

This PR addresses...

#398 Was a problem with `NodeConnectionManager.getClosestGlobalNodes` throwing an error if the `nodeGraph` was empty. This shouldn't happen in usual operation unless said node is a seed node with no nodes in the network. Here it's not strictly an error since having no nodes in the graph just means we can't find any other nodes or the target node for that matter. `getClosestGlobalNodes` should've just returned undefined.

### Issues Fixed

* Fixes #398 

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
