### PR TITLE
feat: adding `workerManager` parameter to `createPolykeyAgent` and `createKeyManager`

### DIFF
--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -97,6 +97,7 @@ class PolykeyAgent {
     sessionManager,
     grpcServerClient,
     grpcServerAgent,
+    workerManager,
     fs = require('fs'),
     logger = new Logger(this.name),
     fresh = false,
@@ -143,6 +144,7 @@ class PolykeyAgent {
     sessionManager?: SessionManager;
     grpcServerClient?: GRPCServer;
     grpcServerAgent?: GRPCServer;
+    workerManager?: PolykeyWorkerManagerInterface;
     fs?: FileSystem;
     logger?: Logger;
     fresh?: boolean;
@@ -204,6 +206,7 @@ class PolykeyAgent {
           keysPath,
           password,
           fs,
+          workerManager,
           changeCallback: (data) =>
             events.emitAsync(PolykeyAgent.eventSymbols.KeyManager, data),
           logger: logger.getChild(KeyManager.name),
@@ -232,6 +235,7 @@ class PolykeyAgent {
           logger: logger.getChild(DB.name),
           fresh,
         }));
+      if (workerManager != null) db.setWorkerManager(workerManager);
       identitiesManager =
         identitiesManager ??
         (await IdentitiesManager.createIdentitiesManager({
@@ -348,6 +352,7 @@ class PolykeyAgent {
           logger: logger.getChild(VaultManager.name),
           fresh,
         }));
+      if (workerManager != null) vaultManager.setWorkerManager(workerManager);
       sessionManager =
         sessionManager ??
         (await SessionManager.createSessionManager({

--- a/src/bin/agent/CommandStart.ts
+++ b/src/bin/agent/CommandStart.ts
@@ -205,24 +205,24 @@ class CommandStart extends CommandPolykey {
         // eslint-disable-next-line prefer-const
         let pkAgent: PolykeyAgent;
         // eslint-disable-next-line prefer-const
-        let workerManager: PolykeyWorkerManagerInterface;
         this.exitHandlers.handlers.push(async () => {
           pkAgent?.unsetWorkerManager();
           await workerManager?.destroy();
           await pkAgent?.stop();
         });
+        const workerManager: PolykeyWorkerManagerInterface | undefined =
+          options.workers === 0
+            ? undefined
+            : await workersUtils.createWorkerManager({
+                cores: options.workers,
+                logger: this.logger.getChild(WorkerManager.name),
+              });
         pkAgent = await PolykeyAgent.createPolykeyAgent({
           fs: this.fs,
           logger: this.logger.getChild(PolykeyAgent.name),
+          workerManager,
           ...agentConfig,
         });
-        if (options.workers !== 0) {
-          workerManager = await workersUtils.createWorkerManager({
-            cores: options.workers,
-            logger: this.logger.getChild(WorkerManager.name),
-          });
-          pkAgent.setWorkerManager(workerManager);
-        }
         recoveryCodeOut = pkAgent.keyManager.getRecoveryCode();
         statusLiveData = {
           pid: process.pid,

--- a/src/keys/KeyManager.ts
+++ b/src/keys/KeyManager.ts
@@ -36,6 +36,7 @@ class KeyManager {
     rootKeyPairBits = 4096,
     rootCertDuration = 31536000,
     dbKeyBits = 256,
+    workerManager,
     changeCallback = () => {},
     fs = require('fs'),
     logger = new Logger(this.name),
@@ -47,6 +48,7 @@ class KeyManager {
     rootKeyPairBits?: number;
     rootCertDuration?: number;
     dbKeyBits?: number;
+    workerManager?: PolykeyWorkerManagerInterface;
     changeCallback?: (data: KeyManagerChangeData) => any;
     fs?: FileSystem;
     logger?: Logger;
@@ -64,6 +66,7 @@ class KeyManager {
       fs,
       logger,
     });
+    if (workerManager != null) keyManager.setWorkerManager(workerManager);
     await keyManager.start({
       password,
       recoveryCode,

--- a/tests/bin/bootstrap.test.ts
+++ b/tests/bin/bootstrap.test.ts
@@ -219,8 +219,8 @@ describe('bootstrap', () => {
         });
       });
       await new Promise((res) => {
-        bootstrapProcess1.once('exit', () => res(null))
-      })
+        bootstrapProcess1.once('exit', () => res(null));
+      });
       // Attempting to bootstrap should fail with existing state
       const bootstrapProcess2 = await testBinUtils.pkStdio(
         [

--- a/tests/keys/KeyManager.test.ts
+++ b/tests/keys/KeyManager.test.ts
@@ -167,8 +167,8 @@ describe('KeyManager', () => {
       password,
       keysPath,
       logger,
+      workerManager,
     });
-    keyManager.setWorkerManager(workerManager);
     const keysPathContents = await fs.promises.readdir(keysPath);
     expect(keysPathContents).toContain('root.pub');
     expect(keysPathContents).toContain('root.key');


### PR DESCRIPTION
### Description

#399 was not actually a problem, just a race condition in the logs since the two outputs were on `stdout` and `stderr` at exactly the same time. I checked and there was no issue. However I did discover that the `WorkerManager` was only set after starting up polykey. So anything such as `KeyManager` that used it during startup never had it. I've made some modifications to fix this. `workerManager` can be provided to `createPolykeyAgent` and propagated to the relevant domains. Ultimately the `WorkerManager` is started before `PolykeyAgent` now when doing `polykey agent start`. This should fix the order of the logs too.

### Issues Fixed

* Fixes #399

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [ ] Domain specific tests
* [ ] Full tests
* [ ] Updated inline-comment documentation
* [ ] Lint fixed
* [ ] Squash and rebased
* [ ] Sanity check the final build
