### PR TITLE
Fixing `swc` specific bug with decorators and constructors

### DIFF
--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -383,7 +383,7 @@ class PolykeyAgent {
       await status?.stop({});
       throw e;
     }
-    const pkAgent = new PolykeyAgent({
+    const pkAgent = new this({
       nodePath,
       status,
       schema,

--- a/src/PolykeyClient.ts
+++ b/src/PolykeyClient.ts
@@ -69,7 +69,7 @@ class PolykeyClient {
         timer,
         logger: logger.getChild(GRPCClientClient.name),
       }));
-    const pkClient = new PolykeyClient({
+    const pkClient = new this({
       nodePath,
       grpcClient,
       session,

--- a/src/acl/ACL.ts
+++ b/src/acl/ACL.ts
@@ -36,7 +36,7 @@ class ACL {
     fresh?: boolean;
   }): Promise<ACL> {
     logger.info(`Creating ${this.name}`);
-    const acl = new ACL({ db, logger });
+    const acl = new this({ db, logger });
     await acl.start({ fresh });
     logger.info(`Created ${this.name}`);
     return acl;

--- a/src/agent/GRPCClientAgent.ts
+++ b/src/agent/GRPCClientAgent.ts
@@ -57,7 +57,7 @@ class GRPCClientAgent extends GRPCClient<AgentServiceClient> {
         timer,
         logger,
       });
-    const grpcClientAgent = new GRPCClientAgent({
+    const grpcClientAgent = new this({
       client,
       nodeId,
       host,

--- a/src/client/GRPCClientClient.ts
+++ b/src/client/GRPCClientClient.ts
@@ -69,7 +69,7 @@ class GRPCClientClient extends GRPCClient<ClientServiceClient> {
         interceptors,
         logger,
       });
-    return new GRPCClientClient({
+    return new this({
       client,
       nodeId,
       host,

--- a/src/discovery/Discovery.ts
+++ b/src/discovery/Discovery.ts
@@ -61,7 +61,7 @@ class Discovery {
     fresh?: boolean;
   }): Promise<Discovery> {
     logger.info(`Creating ${this.name}`);
-    const discovery = new Discovery({
+    const discovery = new this({
       db,
       keyManager,
       gestaltGraph,

--- a/src/gestalts/GestaltGraph.ts
+++ b/src/gestalts/GestaltGraph.ts
@@ -42,7 +42,7 @@ class GestaltGraph {
     fresh?: boolean;
   }): Promise<GestaltGraph> {
     logger.info(`Creating ${this.name}`);
-    const gestaltGraph = new GestaltGraph({ acl, db, logger });
+    const gestaltGraph = new this({ acl, db, logger });
     await gestaltGraph.start({ fresh });
     logger.info(`Created ${this.name}`);
     return gestaltGraph;

--- a/src/grpc/utils/utils.ts
+++ b/src/grpc/utils/utils.ts
@@ -125,10 +125,10 @@ function getClientSession(
   if (channel.getConnectivityState(false) !== grpc.connectivityState.READY) {
     throw grpcErrors.ErrorGRPCClientChannelNotReady;
   }
-  // @ts-ignore
+  // @ts-ignore: accessing private property
   const channelTarget = channel.target;
   const subchannelTarget = { host, port };
-  // @ts-ignore
+  // @ts-ignore: accessing private property
   const subchannelPool = channel.subchannelPool;
   // This must acquire the first channel in the subchannel pool
   // Only the first channel is in ready state and therefore has the session property
@@ -155,7 +155,7 @@ function getClientSession(
  * It will contain `stream` property, which will contain the `session` property
  */
 function getServerSession(call: ServerSurfaceCall): Http2Session {
-  // @ts-ignore
+  // @ts-ignore: accessing private property
   return call.stream.session;
 }
 

--- a/src/identities/IdentitiesManager.ts
+++ b/src/identities/IdentitiesManager.ts
@@ -30,7 +30,7 @@ class IdentitiesManager {
     fresh?: boolean;
   }): Promise<IdentitiesManager> {
     logger.info(`Creating ${this.name}`);
-    const identitiesManager = new IdentitiesManager({ db, logger });
+    const identitiesManager = new this({ db, logger });
     await identitiesManager.start({ fresh });
     logger.info(`Created ${this.name}`);
     return identitiesManager;

--- a/src/keys/KeyManager.ts
+++ b/src/keys/KeyManager.ts
@@ -55,7 +55,7 @@ class KeyManager {
   }): Promise<KeyManager> {
     logger.info(`Creating ${this.name}`);
     logger.info(`Setting keys path to ${keysPath}`);
-    const keyManager = new KeyManager({
+    const keyManager = new this({
       keysPath,
       rootCertDuration,
       rootKeyPairBits,

--- a/src/keys/utils.ts
+++ b/src/keys/utils.ts
@@ -384,7 +384,7 @@ function certVerified(cert1: Certificate, cert2: Certificate): boolean {
 
 function certVerifiedNode(cert: Certificate): boolean {
   const certNodeSignatureExt = cert.getExtension({
-    // @ts-ignore
+    // @ts-ignore: ignoring type mismatch
     id: config.oids.extensions.nodeSignature,
   }) as any;
   if (certNodeSignatureExt == null) {
@@ -403,7 +403,7 @@ function certVerifiedNode(cert: Certificate): boolean {
   let verified;
   try {
     cert.setExtensions(extensionsFiltered);
-    // @ts-ignore
+    // @ts-ignore: accessing private property
     const certTBS = pki.getTBSCertificate(cert);
     const certTBSDer = asn1.toDer(certTBS);
     certDigest.update(certTBSDer.getBytes());

--- a/src/nodes/NodeConnection.ts
+++ b/src/nodes/NodeConnection.ts
@@ -83,7 +83,7 @@ class NodeConnection<T extends GRPCClient> {
     // 3. Relay the proxy port to the broker/s (such that they can inform the other node)
     // 4. Start sending hole-punching packets to other node (done in openConnection())
     // Done in parallel
-    const nodeConnection = new NodeConnection<T>({
+    const nodeConnection = new this<T>({
       host: targetHost,
       port: targetPort,
       hostname: targetHostname,

--- a/src/nodes/NodeGraph.ts
+++ b/src/nodes/NodeGraph.ts
@@ -43,7 +43,7 @@ class NodeGraph {
     fresh?: boolean;
   }): Promise<NodeGraph> {
     logger.info(`Creating ${this.name}`);
-    const nodeGraph = new NodeGraph({
+    const nodeGraph = new this({
       db,
       keyManager,
       nodeIdBits,
@@ -368,7 +368,6 @@ class NodeGraph {
         )) {
           const nodeId = IdInternal.fromBuffer<NodeId>(nodeIdBuffer);
           bucketDbIterator.seek(nodeIdBuffer);
-          // @ts-ignore
           // eslint-disable-next-line
           const iteratorResult = await bucketDbIterator.next();
           if (iteratorResult == null) never();
@@ -376,7 +375,6 @@ class NodeGraph {
           bucket.push([nodeId, nodeData]);
         }
       } finally {
-        // @ts-ignore
         await bucketDbIterator.end();
       }
     }
@@ -467,7 +465,6 @@ class NodeGraph {
           const { bucketIndex: bucketIndex_, nodeId } =
             nodesUtils.parseLastUpdatedBucketsDbKey(key);
           bucketsDbIterator.seek([key[0], key[2]]);
-          // @ts-ignore
           // eslint-disable-next-line
           const iteratorResult = await bucketsDbIterator.next();
           if (iteratorResult == null) never();
@@ -491,7 +488,6 @@ class NodeGraph {
           yield [bucketIndex, bucket];
         }
       } finally {
-        // @ts-ignore
         await bucketsDbIterator.end();
       }
     }

--- a/src/notifications/NotificationsManager.ts
+++ b/src/notifications/NotificationsManager.ts
@@ -56,7 +56,7 @@ class NotificationsManager {
     fresh?: boolean;
   }): Promise<NotificationsManager> {
     logger.info(`Creating ${this.name}`);
-    const notificationsManager = new NotificationsManager({
+    const notificationsManager = new this({
       acl,
       db,
       keyManager,

--- a/src/schema/Schema.ts
+++ b/src/schema/Schema.ts
@@ -28,7 +28,7 @@ class Schema {
     fresh?: boolean;
   }): Promise<Schema> {
     logger.info(`Creating ${this.name}`);
-    const schema = new Schema({
+    const schema = new this({
       statePath,
       stateVersion,
       fs,

--- a/src/sessions/Session.ts
+++ b/src/sessions/Session.ts
@@ -28,7 +28,7 @@ class Session {
   }): Promise<Session> {
     logger.info(`Creating ${this.name}`);
     logger.info(`Setting session token path to ${sessionTokenPath}`);
-    const session = new Session({
+    const session = new this({
       sessionTokenPath,
       fs,
       logger,

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -34,7 +34,7 @@ class SessionManager {
     fresh?: boolean;
   }): Promise<SessionManager> {
     logger.info(`Creating ${this.name}`);
-    const sessionManager = new SessionManager({
+    const sessionManager = new this({
       db,
       keyManager,
       expiry,

--- a/src/sigchain/Sigchain.ts
+++ b/src/sigchain/Sigchain.ts
@@ -59,7 +59,7 @@ class Sigchain {
     fresh?: boolean;
   }): Promise<Sigchain> {
     logger.info(`Creating ${this.name}`);
-    const sigchain = new Sigchain({ db, keyManager, logger });
+    const sigchain = new this({ db, keyManager, logger });
     await sigchain.start({ fresh });
     logger.info(`Created ${this.name}`);
     return sigchain;

--- a/src/vaults/VaultInternal.ts
+++ b/src/vaults/VaultInternal.ts
@@ -85,7 +85,7 @@ class VaultInternal {
 
     const vaultIdEncoded = vaultsUtils.encodeVaultId(vaultId);
     logger.info(`Creating ${this.name} - ${vaultIdEncoded}`);
-    const vault = new VaultInternal({
+    const vault = new this({
       vaultId,
       db,
       vaultsDbPath,

--- a/src/vaults/VaultManager.ts
+++ b/src/vaults/VaultManager.ts
@@ -85,7 +85,7 @@ class VaultManager {
   }) {
     logger.info(`Creating ${this.name}`);
     logger.info(`Setting vaults path to ${vaultsPath}`);
-    const vaultManager = new VaultManager({
+    const vaultManager = new this({
       vaultsPath,
       db,
       acl,

--- a/tests/bin/utils.ts
+++ b/tests/bin/utils.ts
@@ -203,12 +203,7 @@ async function pkExec(
   return new Promise((resolve, reject) => {
     child_process.execFile(
       'ts-node',
-      [
-        '--project',
-        tsConfigPath,
-        polykeyPath,
-        ...args,
-      ],
+      ['--project', tsConfigPath, polykeyPath, ...args],
       {
         env,
         cwd,
@@ -266,13 +261,7 @@ async function pkSpawn(
       ? path.resolve(path.join(global.projectDir, global.testCmd))
       : 'ts-node';
   const tsNodeArgs =
-    global.testCmd != null
-      ? []
-      : [
-          '--project',
-          tsConfigPath,
-          polykeyPath,
-        ];
+    global.testCmd != null ? [] : ['--project', tsConfigPath, polykeyPath];
   const subprocess = child_process.spawn(command, [...tsNodeArgs, ...args], {
     env,
     cwd,
@@ -326,12 +315,7 @@ async function pkExpect({
   // Expect chain runs against stdout and stderr
   let expectChain = nexpect.spawn(
     'ts-node',
-    [
-      '--project',
-      tsConfigPath,
-      polykeyPath,
-      ...args,
-    ],
+    ['--project', tsConfigPath, polykeyPath, ...args],
     {
       env,
       cwd,

--- a/tests/grpc/utils.test.ts
+++ b/tests/grpc/utils.test.ts
@@ -449,13 +449,11 @@ describe('GRPC utils', () => {
     expect(deserialisedError).toBeInstanceOf(grpcErrors.ErrorPolykeyRemote);
     expect(deserialisedError.message).toBe('test error');
     // @ts-ignore - already checked above that error is ErrorPolykeyRemote
-    expect(deserialisedError.metadata.nodeId).toBe(nodeId);
-    // @ts-ignore
-    expect(deserialisedError.metadata.host).toBe(host);
-    // @ts-ignore
-    expect(deserialisedError.metadata.port).toBe(port);
-    // @ts-ignore
-    expect(deserialisedError.metadata.command).toBe('testCall');
+    const metadata = deserialisedError.metadata;
+    expect(metadata.nodeId).toBe(nodeId);
+    expect(metadata.host).toBe(host);
+    expect(metadata.port).toBe(port);
+    expect(metadata.command).toBe('testCall');
     expect(deserialisedError.cause).toBeInstanceOf(errors.ErrorPolykey);
     expect(deserialisedError.cause.message).toBe('test error');
     expect(deserialisedError.cause.exitCode).toBe(255);
@@ -490,13 +488,11 @@ describe('GRPC utils', () => {
     expect(deserialisedError).toBeInstanceOf(grpcErrors.ErrorPolykeyRemote);
     expect(deserialisedError.message).toBe('test error');
     // @ts-ignore - already checked above that error is ErrorPolykeyRemote
-    expect(deserialisedError.metadata.nodeId).toBe(nodeId);
-    // @ts-ignore
-    expect(deserialisedError.metadata.host).toBe(host);
-    // @ts-ignore
-    expect(deserialisedError.metadata.port).toBe(port);
-    // @ts-ignore
-    expect(deserialisedError.metadata.command).toBe('testCall');
+    const metadata = deserialisedError.metadata;
+    expect(metadata.nodeId).toBe(nodeId);
+    expect(metadata.host).toBe(host);
+    expect(metadata.port).toBe(port);
+    expect(metadata.command).toBe('testCall');
     expect(deserialisedError.cause).toBeInstanceOf(TypeError);
     expect(deserialisedError.cause.message).toBe('test error');
     expect(deserialisedError.cause.stack).toBe(error.stack);
@@ -524,13 +520,11 @@ describe('GRPC utils', () => {
     );
     expect(deserialisedError).toBeInstanceOf(grpcErrors.ErrorPolykeyRemote);
     // @ts-ignore - already checked above that error is ErrorPolykeyRemote
-    expect(deserialisedError.metadata.nodeId).toBe(nodeId);
-    // @ts-ignore
-    expect(deserialisedError.metadata.host).toBe(host);
-    // @ts-ignore
-    expect(deserialisedError.metadata.port).toBe(port);
-    // @ts-ignore
-    expect(deserialisedError.metadata.command).toBe('testCall');
+    const metadata = deserialisedError.metadata;
+    expect(metadata.nodeId).toBe(nodeId);
+    expect(metadata.host).toBe(host);
+    expect(metadata.port).toBe(port);
+    expect(metadata.command).toBe('testCall');
     expect(deserialisedError.cause).toBeInstanceOf(errors.ErrorPolykeyUnknown);
     // This is slightly brittle because it's based on what we choose to do
     // with unknown data in our grpc reviver
@@ -578,13 +572,11 @@ describe('GRPC utils', () => {
     expect(deserialisedError).toBeInstanceOf(grpcErrors.ErrorPolykeyRemote);
     expect(deserialisedError.message).toBe('test error');
     // @ts-ignore - already checked above that error is ErrorPolykeyRemote
-    expect(deserialisedError.metadata.nodeId).toBe(nodeId);
-    // @ts-ignore
-    expect(deserialisedError.metadata.host).toBe(host);
-    // @ts-ignore
-    expect(deserialisedError.metadata.port).toBe(port);
-    // @ts-ignore
-    expect(deserialisedError.metadata.command).toBe('testCall');
+    const metadata = deserialisedError.metadata;
+    expect(metadata.nodeId).toBe(nodeId);
+    expect(metadata.host).toBe(host);
+    expect(metadata.port).toBe(port);
+    expect(metadata.command).toBe('testCall');
     expect(deserialisedError.cause).toBeInstanceOf(errors.ErrorPolykey);
     expect(deserialisedError.cause.message).toBe('test error');
     expect(deserialisedError.cause.exitCode).toBe(255);

--- a/tests/vaults/VaultInternal.test.ts
+++ b/tests/vaults/VaultInternal.test.ts
@@ -720,7 +720,7 @@ describe('VaultInternal', () => {
       for (const logElement of log) {
         refs.push(await quickCommit(logElement.commitId, `secret-${num++}`));
       }
-      // @ts-ignore
+      // @ts-ignore: private method
       await vault.garbageCollectGitObjects();
 
       for (const ref of refs) {


### PR DESCRIPTION
### Description

Due to a difference with swc on how decorators are handled. Classes were constructed without decorators applied when called inside of `createX` static functions. This was solved by using `new this()` to construct instead.

Fixed up some linting errors as well. Some  `// @ts-ignore` lines were added without descriptions.

### Tasks

- [x] 1. Use `new this()` to construct the class inside of `createX` static methods.

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [ ] Domain specific tests
* [ ] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [ ] Sanity check the final build
