### PR TITLE
Standardise process execution for tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,6 +33,10 @@
       {
         "name": "global",
         "message": "Use `globalThis` instead"
+      },
+      {
+        "name": "window",
+        "message": "Use `globalThis` instead"
       }
     ],
     "require-yield": 0,

--- a/jest.config.js
+++ b/jest.config.js
@@ -64,7 +64,7 @@ module.exports = {
       reportTestSuiteErrors: 'true',
     }],
   ],
-  collectCoverageFrom: ['src/**/*.{ts,tsx,js,jsx}', '!src/**/*.d.ts'],
+  collectCoverageFrom: ['src/**/*.{ts,tsx,js,jsx}', '!src/**/*.d.ts', '!src/proto/*'],
   coverageReporters: ['text', 'cobertura'],
   globals,
   // Global setup script executed once before all test files

--- a/src/bin/agent/CommandStart.ts
+++ b/src/bin/agent/CommandStart.ts
@@ -8,7 +8,7 @@ import type PolykeyAgent from '../../PolykeyAgent';
 import type { RecoveryCode } from '../../keys/types';
 import type { PolykeyWorkerManagerInterface } from '../../workers/types';
 import path from 'path';
-import child_process from 'child_process';
+import childProcess from 'child_process';
 import process from 'process';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
@@ -130,7 +130,7 @@ class CommandStart extends CommandPolykey {
           );
           stdio[2] = agentErrFile.fd;
         }
-        const agentProcess = child_process.fork(
+        const agentProcess = childProcess.fork(
           path.join(__dirname, '../polykey-agent'),
           [],
           {

--- a/tests/agent/service/notificationsSend.test.ts
+++ b/tests/agent/service/notificationsSend.test.ts
@@ -26,7 +26,7 @@ import * as utilsPB from '@/proto/js/polykey/v1/utils/utils_pb';
 import * as notificationsPB from '@/proto/js/polykey/v1/notifications/notifications_pb';
 import * as nodesUtils from '@/nodes/utils';
 import * as notificationsUtils from '@/notifications/utils';
-import { expectRemoteError } from '../../utils';
+import * as testUtils from '../../utils';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 
 describe('notificationsSend', () => {
@@ -225,7 +225,7 @@ describe('notificationsSend', () => {
     };
     const request1 = new notificationsPB.AgentNotification();
     request1.setContent(notification1.toString());
-    await expectRemoteError(
+    await testUtils.expectRemoteError(
       grpcClient.notificationsSend(request1),
       notificationsErrors.ErrorNotificationsParse,
     );
@@ -253,7 +253,7 @@ describe('notificationsSend', () => {
       .sign(privateKey);
     const request2 = new notificationsPB.AgentNotification();
     request2.setContent(signedNotification);
-    await expectRemoteError(
+    await testUtils.expectRemoteError(
       grpcClient.notificationsSend(request2),
       notificationsErrors.ErrorNotificationsValidationFailed,
     );
@@ -279,7 +279,7 @@ describe('notificationsSend', () => {
     );
     const request = new notificationsPB.AgentNotification();
     request.setContent(signedNotification);
-    await expectRemoteError(
+    await testUtils.expectRemoteError(
       grpcClient.notificationsSend(request),
       notificationsErrors.ErrorNotificationsPermissionsNotFound,
     );

--- a/tests/bin/agent/start.test.ts
+++ b/tests/bin/agent/start.test.ts
@@ -12,7 +12,6 @@ import Status from '@/status/Status';
 import * as statusErrors from '@/status/errors';
 import config from '@/config';
 import * as keysUtils from '@/keys/utils';
-import * as execUtils from '../../utils/exec';
 import * as testUtils from '../../utils';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 
@@ -38,7 +37,7 @@ describe('start', () => {
       const password = 'abc123';
       const polykeyPath = path.join(dataDir, 'polykey');
       await fs.promises.mkdir(polykeyPath);
-      const agentProcess = await execUtils.pkSpawn(
+      const agentProcess = await testUtils.pkSpawn(
         [
           'agent',
           'start',
@@ -57,9 +56,11 @@ describe('start', () => {
           'json',
         ],
         {
-          PK_PASSWORD: password,
+          env: {
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
         logger,
       );
       const rlOut = readline.createInterface(agentProcess.stdout!);
@@ -107,7 +108,7 @@ describe('start', () => {
       const password = 'abc123';
       const passwordPath = path.join(dataDir, 'password');
       await fs.promises.writeFile(passwordPath, password);
-      const agentProcess = await execUtils.pkSpawn(
+      const agentProcess = await testUtils.pkSpawn(
         [
           'agent',
           'start',
@@ -131,9 +132,11 @@ describe('start', () => {
           'json',
         ],
         {
-          PK_NODE_PATH: path.join(dataDir, 'polykey'),
+          env: {
+            PK_NODE_PATH: path.join(dataDir, 'polykey'),
+          },
+          cwd: dataDir,
         },
-        dataDir,
         logger,
       );
       const agentProcessExit = new Promise<void>((resolve, reject) => {
@@ -210,7 +213,7 @@ describe('start', () => {
       const password = 'abc123';
       // One of these processes is blocked
       const [agentProcess1, agentProcess2] = await Promise.all([
-        execUtils.pkSpawn(
+        testUtils.pkSpawn(
           [
             'agent',
             'start',
@@ -227,13 +230,15 @@ describe('start', () => {
             'json',
           ],
           {
-            PK_NODE_PATH: path.join(dataDir, 'polykey'),
-            PK_PASSWORD: password,
+            env: {
+              PK_NODE_PATH: path.join(dataDir, 'polykey'),
+              PK_PASSWORD: password,
+            },
+            cwd: dataDir,
           },
-          dataDir,
           logger.getChild('agentProcess1'),
         ),
-        execUtils.pkSpawn(
+        testUtils.pkSpawn(
           [
             'agent',
             'start',
@@ -250,10 +255,12 @@ describe('start', () => {
             'json',
           ],
           {
-            PK_NODE_PATH: path.join(dataDir, 'polykey'),
-            PK_PASSWORD: password,
+            env: {
+              PK_NODE_PATH: path.join(dataDir, 'polykey'),
+              PK_PASSWORD: password,
+            },
+            cwd: dataDir,
           },
-          dataDir,
           logger.getChild('agentProcess2'),
         ),
       ]);
@@ -283,12 +290,12 @@ describe('start', () => {
       const errorStatusLocked = new statusErrors.ErrorStatusLocked();
       // It's either the first or second process
       if (index === 0) {
-        execUtils.expectProcessError(exitCode!, stdErrLine1, [
+        testUtils.expectProcessError(exitCode!, stdErrLine1, [
           errorStatusLocked,
         ]);
         agentProcess2.kill('SIGQUIT');
       } else if (index === 1) {
-        execUtils.expectProcessError(exitCode!, stdErrLine2, [
+        testUtils.expectProcessError(exitCode!, stdErrLine2, [
           errorStatusLocked,
         ]);
         agentProcess1.kill('SIGQUIT');
@@ -304,7 +311,7 @@ describe('start', () => {
       const password = 'abc123';
       // One of these processes is blocked
       const [agentProcess, bootstrapProcess] = await Promise.all([
-        execUtils.pkSpawn(
+        testUtils.pkSpawn(
           [
             'agent',
             'start',
@@ -321,13 +328,15 @@ describe('start', () => {
             'json',
           ],
           {
-            PK_NODE_PATH: path.join(dataDir, 'polykey'),
-            PK_PASSWORD: password,
+            env: {
+              PK_NODE_PATH: path.join(dataDir, 'polykey'),
+              PK_PASSWORD: password,
+            },
+            cwd: dataDir,
           },
-          dataDir,
           logger.getChild('agentProcess'),
         ),
-        execUtils.pkSpawn(
+        testUtils.pkSpawn(
           [
             'bootstrap',
             '--fresh',
@@ -338,10 +347,12 @@ describe('start', () => {
             'json',
           ],
           {
-            PK_NODE_PATH: path.join(dataDir, 'polykey'),
-            PK_PASSWORD: password,
+            env: {
+              PK_NODE_PATH: path.join(dataDir, 'polykey'),
+              PK_PASSWORD: password,
+            },
+            cwd: dataDir,
           },
-          dataDir,
           logger.getChild('bootstrapProcess'),
         ),
       ]);
@@ -371,12 +382,12 @@ describe('start', () => {
       const errorStatusLocked = new statusErrors.ErrorStatusLocked();
       // It's either the first or second process
       if (index === 0) {
-        execUtils.expectProcessError(exitCode!, stdErrLine1, [
+        testUtils.expectProcessError(exitCode!, stdErrLine1, [
           errorStatusLocked,
         ]);
         bootstrapProcess.kill('SIGTERM');
       } else if (index === 1) {
-        execUtils.expectProcessError(exitCode!, stdErrLine2, [
+        testUtils.expectProcessError(exitCode!, stdErrLine2, [
           errorStatusLocked,
         ]);
         agentProcess.kill('SIGTERM');
@@ -390,7 +401,7 @@ describe('start', () => {
     'start with existing state',
     async () => {
       const password = 'abc123';
-      const agentProcess1 = await execUtils.pkSpawn(
+      const agentProcess1 = await testUtils.pkSpawn(
         [
           'agent',
           'start',
@@ -405,10 +416,12 @@ describe('start', () => {
           '--verbose',
         ],
         {
-          PK_NODE_PATH: path.join(dataDir, 'polykey'),
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: path.join(dataDir, 'polykey'),
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
         logger,
       );
       const rlOut = readline.createInterface(agentProcess1.stdout!);
@@ -417,7 +430,7 @@ describe('start', () => {
         rlOut.once('close', reject);
       });
       agentProcess1.kill('SIGHUP');
-      const agentProcess2 = await execUtils.pkSpawn(
+      const agentProcess2 = await testUtils.pkSpawn(
         [
           'agent',
           'start',
@@ -432,10 +445,12 @@ describe('start', () => {
           '--verbose',
         ],
         {
-          PK_NODE_PATH: path.join(dataDir, 'polykey'),
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: path.join(dataDir, 'polykey'),
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
         logger,
       );
       const status = new Status({
@@ -462,7 +477,7 @@ describe('start', () => {
     'start when interrupted, requires fresh on next start',
     async () => {
       const password = 'password';
-      const agentProcess1 = await execUtils.pkSpawn(
+      const agentProcess1 = await testUtils.pkSpawn(
         [
           'agent',
           'start',
@@ -477,10 +492,12 @@ describe('start', () => {
           '--verbose',
         ],
         {
-          PK_NODE_PATH: path.join(dataDir, 'polykey'),
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: path.join(dataDir, 'polykey'),
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
         logger.getChild('agentProcess1'),
       );
       const rlErr = readline.createInterface(agentProcess1.stderr!);
@@ -500,7 +517,7 @@ describe('start', () => {
       // Unlike bootstrapping, agent start can succeed under certain compatible partial state
       // However in some cases, state will conflict, and the start will fail with various errors
       // In such cases, the `--fresh` option must be used
-      const agentProcess2 = await execUtils.pkSpawn(
+      const agentProcess2 = await testUtils.pkSpawn(
         [
           'agent',
           'start',
@@ -518,10 +535,12 @@ describe('start', () => {
           'json',
         ],
         {
-          PK_NODE_PATH: path.join(dataDir, 'polykey'),
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: path.join(dataDir, 'polykey'),
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
         logger.getChild('agentProcess2'),
       );
       const rlOut = readline.createInterface(agentProcess2.stdout!);
@@ -548,7 +567,7 @@ describe('start', () => {
           statusLiveData.recoveryCode.split(' ').length === 24,
       ).toBe(true);
       agentProcess2.kill('SIGQUIT');
-      await execUtils.processExit(agentProcess2);
+      await testUtils.processExit(agentProcess2);
       // Check for graceful exit
       const status = new Status({
         statusPath: path.join(dataDir, 'polykey', config.defaults.statusBase),
@@ -582,7 +601,7 @@ describe('start', () => {
         fs,
         logger,
       });
-      const agentProcess1 = await execUtils.pkSpawn(
+      const agentProcess1 = await testUtils.pkSpawn(
         [
           'agent',
           'start',
@@ -601,9 +620,11 @@ describe('start', () => {
           'json',
         ],
         {
-          PK_PASSWORD: password1,
+          env: {
+            PK_PASSWORD: password1,
+          },
+          cwd: dataDir,
         },
-        dataDir,
         logger.getChild('agentProcess1'),
       );
       const rlOut = readline.createInterface(agentProcess1.stdout!);
@@ -615,11 +636,11 @@ describe('start', () => {
       const recoveryCode = statusLiveData.recoveryCode;
       const statusInfo1 = (await status.readStatus())!;
       agentProcess1.kill('SIGTERM');
-      await execUtils.processExit(agentProcess1);
+      await testUtils.processExit(agentProcess1);
       const recoveryCodePath = path.join(dataDir, 'recovery-code');
       await fs.promises.writeFile(recoveryCodePath, recoveryCode + '\n');
       // When recovering, having the wrong bit size is not a problem
-      const agentProcess2 = await execUtils.pkSpawn(
+      const agentProcess2 = await testUtils.pkSpawn(
         [
           'agent',
           'start',
@@ -636,10 +657,12 @@ describe('start', () => {
           '--verbose',
         ],
         {
-          PK_NODE_PATH: path.join(dataDir, 'polykey'),
-          PK_PASSWORD: password2,
+          env: {
+            PK_NODE_PATH: path.join(dataDir, 'polykey'),
+            PK_PASSWORD: password2,
+          },
+          cwd: dataDir,
         },
-        dataDir,
         logger.getChild('agentProcess2'),
       );
       const statusInfo2 = await status.waitFor('LIVE');
@@ -647,15 +670,17 @@ describe('start', () => {
       // Node Id hasn't changed
       expect(statusInfo1.data.nodeId).toStrictEqual(statusInfo2.data.nodeId);
       agentProcess2.kill('SIGTERM');
-      await execUtils.processExit(agentProcess2);
+      await testUtils.processExit(agentProcess2);
       // Check that the password has changed
-      const agentProcess3 = await execUtils.pkSpawn(
+      const agentProcess3 = await testUtils.pkSpawn(
         ['agent', 'start', '--workers', '0', '--verbose'],
         {
-          PK_NODE_PATH: path.join(dataDir, 'polykey'),
-          PK_PASSWORD: password2,
+          env: {
+            PK_NODE_PATH: path.join(dataDir, 'polykey'),
+            PK_PASSWORD: password2,
+          },
+          cwd: dataDir,
         },
-        dataDir,
         logger.getChild('agentProcess3'),
       );
       const statusInfo3 = await status.waitFor('LIVE');
@@ -663,14 +688,14 @@ describe('start', () => {
       // Node ID hasn't changed
       expect(statusInfo1.data.nodeId).toStrictEqual(statusInfo3.data.nodeId);
       agentProcess3.kill('SIGTERM');
-      await execUtils.processExit(agentProcess3);
+      await testUtils.processExit(agentProcess3);
       // Checks deterministic generation using the same recovery code
       // First by deleting the polykey state
       await fs.promises.rm(path.join(dataDir, 'polykey'), {
         force: true,
         recursive: true,
       });
-      const agentProcess4 = await execUtils.pkSpawn(
+      const agentProcess4 = await testUtils.pkSpawn(
         [
           'agent',
           'start',
@@ -685,11 +710,13 @@ describe('start', () => {
           '--verbose',
         ],
         {
-          PK_NODE_PATH: path.join(dataDir, 'polykey'),
-          PK_PASSWORD: password2,
-          PK_RECOVERY_CODE: recoveryCode,
+          env: {
+            PK_NODE_PATH: path.join(dataDir, 'polykey'),
+            PK_PASSWORD: password2,
+            PK_RECOVERY_CODE: recoveryCode,
+          },
+          cwd: dataDir,
         },
-        dataDir,
         logger.getChild('agentProcess4'),
       );
       const statusInfo4 = await status.waitFor('LIVE');
@@ -697,7 +724,7 @@ describe('start', () => {
       // Same Node ID as before
       expect(statusInfo1.data.nodeId).toStrictEqual(statusInfo4.data.nodeId);
       agentProcess4.kill('SIGTERM');
-      await execUtils.processExit(agentProcess4);
+      await testUtils.processExit(agentProcess4);
     },
     globalThis.defaultTimeout * 3,
   );
@@ -722,7 +749,7 @@ describe('start', () => {
       const clientPort = 55555;
       const proxyHost = '127.0.0.3';
       const proxyPort = 55556;
-      const agentProcess = await execUtils.pkSpawn(
+      const agentProcess = await testUtils.pkSpawn(
         [
           'agent',
           'start',
@@ -741,10 +768,12 @@ describe('start', () => {
           '--verbose',
         ],
         {
-          PK_NODE_PATH: path.join(dataDir, 'polykey'),
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: path.join(dataDir, 'polykey'),
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
         logger.getChild('agentProcess'),
       );
       const statusInfo = await status.waitFor('LIVE');
@@ -778,14 +807,16 @@ describe('start', () => {
           keysUtils.privateKeyFromPem(privateKeyPem),
         ),
       );
-      const agentProcess = await execUtils.pkSpawn(
+      const agentProcess = await testUtils.pkSpawn(
         ['agent', 'start', '--workers', '0', '--verbose'],
         {
-          PK_NODE_PATH: path.join(dataDir, 'polykey'),
-          PK_PASSWORD: password,
-          PK_ROOT_KEY: privateKeyPem,
+          env: {
+            PK_NODE_PATH: path.join(dataDir, 'polykey'),
+            PK_PASSWORD: password,
+            PK_ROOT_KEY: privateKeyPem,
+          },
+          cwd: dataDir,
         },
-        dataDir,
         logger,
       );
       const statusInfo = await status.waitFor('LIVE');
@@ -822,7 +853,7 @@ describe('start', () => {
       await fs.promises.writeFile(privateKeyPath, privateKeyPem, {
         encoding: 'utf-8',
       });
-      const agentProcess = await execUtils.pkSpawn(
+      const agentProcess = await testUtils.pkSpawn(
         [
           'agent',
           'start',
@@ -833,10 +864,12 @@ describe('start', () => {
           privateKeyPath,
         ],
         {
-          PK_NODE_PATH: path.join(dataDir, 'polykey'),
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: path.join(dataDir, 'polykey'),
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
         logger,
       );
       const statusInfo = await status.waitFor('LIVE');
@@ -867,9 +900,9 @@ describe('start', () => {
           path.join(globalThis.tmpDir, 'polykey-test-'),
         );
         ({ agentStatus: agent1Status, agentClose: agent1Close } =
-          await execUtils.setupTestAgent(globalRootKeyPems[0], logger));
+          await testUtils.setupTestAgent(globalRootKeyPems[0], logger));
         ({ agentStatus: agent2Status, agentClose: agent2Close } =
-          await execUtils.setupTestAgent(globalRootKeyPems[1], logger));
+          await testUtils.setupTestAgent(globalRootKeyPems[1], logger));
         seedNodeId1 = agent1Status.data.nodeId;
         seedNodeHost1 = agent1Status.data.proxyHost;
         seedNodePort1 = agent1Status.data.proxyPort;
@@ -912,7 +945,7 @@ describe('start', () => {
               },
               testnet: {},
             });
-          await execUtils.pkStdio(
+          await testUtils.pkStdio(
             [
               'agent',
               'start',
@@ -931,19 +964,20 @@ describe('start', () => {
               '--verbose',
             ],
             {
+              env: {
+                PK_NODE_PATH: nodePath,
+                PK_PASSWORD: password,
+              },
+              cwd: dataDir,
+            },
+          );
+          await testUtils.pkStdio(['agent', 'stop'], {
+            env: {
               PK_NODE_PATH: nodePath,
               PK_PASSWORD: password,
             },
-            dataDir,
-          );
-          await execUtils.pkStdio(
-            ['agent', 'stop'],
-            {
-              PK_NODE_PATH: nodePath,
-              PK_PASSWORD: password,
-            },
-            dataDir,
-          );
+            cwd: dataDir,
+          });
           mockedConfigDefaultsNetwork.mockRestore();
           await status.waitFor('DEAD');
         },
@@ -976,7 +1010,7 @@ describe('start', () => {
                 },
               },
             });
-          await execUtils.pkStdio(
+          await testUtils.pkStdio(
             [
               'agent',
               'start',
@@ -991,21 +1025,22 @@ describe('start', () => {
               '--verbose',
             ],
             {
+              env: {
+                PK_NODE_PATH: nodePath,
+                PK_PASSWORD: password,
+                PK_SEED_NODES: `<defaults>;${seedNodeId1}@${seedNodeHost1}:${seedNodePort1}`,
+                PK_NETWORK: 'testnet',
+              },
+              cwd: dataDir,
+            },
+          );
+          await testUtils.pkStdio(['agent', 'stop'], {
+            env: {
               PK_NODE_PATH: nodePath,
               PK_PASSWORD: password,
-              PK_SEED_NODES: `<defaults>;${seedNodeId1}@${seedNodeHost1}:${seedNodePort1}`,
-              PK_NETWORK: 'testnet',
             },
-            dataDir,
-          );
-          await execUtils.pkStdio(
-            ['agent', 'stop'],
-            {
-              PK_NODE_PATH: nodePath,
-              PK_PASSWORD: password,
-            },
-            dataDir,
-          );
+            cwd: dataDir,
+          });
           mockedConfigDefaultsNetwork.mockRestore();
           await status.waitFor('DEAD');
         },

--- a/tests/bin/agent/unlock.test.ts
+++ b/tests/bin/agent/unlock.test.ts
@@ -3,7 +3,6 @@ import fs from 'fs';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import Session from '@/sessions/Session';
 import config from '@/config';
-import * as execUtils from '../../utils/exec';
 import * as testUtils from '../../utils';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 
@@ -15,7 +14,7 @@ describe('unlock', () => {
   let agentPassword;
   let agentClose;
   beforeEach(async () => {
-    ({ agentDir, agentPassword, agentClose } = await execUtils.setupTestAgent(
+    ({ agentDir, agentPassword, agentClose } = await testUtils.setupTestAgent(
       globalRootKeyPems[0],
       logger,
     ));
@@ -34,33 +33,36 @@ describe('unlock', () => {
       fresh: true,
     });
     let exitCode, stdout;
-    ({ exitCode } = await execUtils.pkStdio(
-      ['agent', 'unlock'],
-      {
+    ({ exitCode } = await testUtils.pkExec(['agent', 'unlock'], {
+      env: {
         PK_NODE_PATH: agentDir,
         PK_PASSWORD: agentPassword,
       },
-      agentDir,
-    ));
+      cwd: agentDir,
+    }));
     expect(exitCode).toBe(0);
     // Run command without password
-    ({ exitCode, stdout } = await execUtils.pkStdio(
+    ({ exitCode, stdout } = await testUtils.pkExec(
       ['agent', 'status', '--format', 'json'],
       {
-        PK_NODE_PATH: agentDir,
+        env: {
+          PK_NODE_PATH: agentDir,
+        },
+        cwd: agentDir,
       },
-      agentDir,
     ));
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout)).toMatchObject({ status: 'LIVE' });
     // Run command with PK_TOKEN
-    ({ exitCode, stdout } = await execUtils.pkStdio(
+    ({ exitCode, stdout } = await testUtils.pkExec(
       ['agent', 'status', '--format', 'json'],
       {
-        PK_NODE_PATH: agentDir,
-        PK_TOKEN: await session.readToken(),
+        env: {
+          PK_NODE_PATH: agentDir,
+          PK_TOKEN: await session.readToken(),
+        },
+        cwd: agentDir,
       },
-      agentDir,
     ));
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout)).toMatchObject({ status: 'LIVE' });

--- a/tests/bin/identities/authenticateAuthenticated.test.ts
+++ b/tests/bin/identities/authenticateAuthenticated.test.ts
@@ -6,7 +6,6 @@ import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import PolykeyAgent from '@/PolykeyAgent';
 import { sysexits } from '@/utils';
 import * as identitiesUtils from '@/identities/utils';
-import * as execUtils from '../../utils/exec';
 import TestProvider from '../../identities/TestProvider';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 import * as testUtils from '../../utils';
@@ -63,7 +62,7 @@ describe('authenticate/authenticated', () => {
         .spyOn(identitiesUtils, 'browser')
         .mockImplementation(() => {});
       // Authenticate an identity
-      ({ exitCode, stdout } = await execUtils.pkStdio(
+      ({ exitCode, stdout } = await testUtils.pkStdio(
         [
           'identities',
           'authenticate',
@@ -71,21 +70,25 @@ describe('authenticate/authenticated', () => {
           testToken.identityId,
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       expect(stdout).toContain('randomtestcode');
       // Check that the identity was authenticated
-      ({ exitCode, stdout } = await execUtils.pkStdio(
+      ({ exitCode, stdout } = await testUtils.pkStdio(
         ['identities', 'authenticated', '--format', 'json'],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toEqual({
@@ -93,7 +96,7 @@ describe('authenticate/authenticated', () => {
         identityId: testToken.identityId,
       });
       // Check using providerId flag
-      ({ exitCode, stdout } = await execUtils.pkStdio(
+      ({ exitCode, stdout } = await testUtils.pkStdio(
         [
           'identities',
           'authenticated',
@@ -103,10 +106,12 @@ describe('authenticate/authenticated', () => {
           'json',
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toEqual({
@@ -122,34 +127,40 @@ describe('authenticate/authenticated', () => {
       let exitCode;
       // Authenticate
       // Invalid provider
-      ({ exitCode } = await execUtils.pkStdio(
+      ({ exitCode } = await testUtils.pkStdio(
         ['identities', 'authenticate', '', testToken.identityId],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(sysexits.USAGE);
       // Invalid identity
-      ({ exitCode } = await execUtils.pkStdio(
+      ({ exitCode } = await testUtils.pkStdio(
         ['identities', 'authenticate', testToken.providerId, ''],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(sysexits.USAGE);
       // Authenticated
       // Invalid provider
-      ({ exitCode } = await execUtils.pkStdio(
+      ({ exitCode } = await testUtils.pkStdio(
         ['identities', 'authenticate', '--provider-id', ''],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(sysexits.USAGE);
     },

--- a/tests/bin/identities/claim.test.ts
+++ b/tests/bin/identities/claim.test.ts
@@ -10,7 +10,6 @@ import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import PolykeyAgent from '@/PolykeyAgent';
 import { sysexits } from '@/utils';
 import * as identitiesUtils from '@/identities/utils';
-import * as execUtils from '../../utils/exec';
 import TestProvider from '../../identities/TestProvider';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 import * as testUtils from '../../utils';
@@ -63,7 +62,7 @@ describe('claim', () => {
       const mockedBrowser = jest
         .spyOn(identitiesUtils, 'browser')
         .mockImplementation(() => {});
-      await execUtils.pkStdio(
+      await testUtils.pkStdio(
         [
           'identities',
           'authenticate',
@@ -71,13 +70,15 @@ describe('claim', () => {
           testToken.identityId,
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       // Claim identity
-      const { exitCode, stdout } = await execUtils.pkStdio(
+      const { exitCode, stdout } = await testUtils.pkStdio(
         [
           'identities',
           'claim',
@@ -87,10 +88,12 @@ describe('claim', () => {
           'json',
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toEqual(['Claim Id: 0', 'Url: test.com']);
@@ -108,13 +111,15 @@ describe('claim', () => {
   testUtils.testIf(testUtils.isTestPlatformEmpty)(
     'cannot claim unauthenticated identities',
     async () => {
-      const { exitCode } = await execUtils.pkStdio(
+      const { exitCode } = await testUtils.pkStdio(
         ['identities', 'claim', testToken.providerId, testToken.identityId],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       expect(exitCode).toBe(sysexits.NOPERM);
     },
@@ -124,23 +129,27 @@ describe('claim', () => {
     async () => {
       let exitCode;
       // Invalid provider
-      ({ exitCode } = await execUtils.pkStdio(
+      ({ exitCode } = await testUtils.pkStdio(
         ['identities', 'claim', '', testToken.identityId],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(sysexits.USAGE);
       // Invalid identity
-      ({ exitCode } = await execUtils.pkStdio(
+      ({ exitCode } = await testUtils.pkStdio(
         ['identities', 'claim', testToken.providerId, ''],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(sysexits.USAGE);
     },

--- a/tests/bin/identities/discoverGet.test.ts
+++ b/tests/bin/identities/discoverGet.test.ts
@@ -11,7 +11,6 @@ import { poll, sysexits } from '@/utils';
 import * as identitiesUtils from '@/identities/utils';
 import * as claimsUtils from '@/claims/utils';
 import * as nodesUtils from '@/nodes/utils';
-import * as execUtils from '../../utils/exec';
 import * as testNodesUtils from '../../nodes/utils';
 import TestProvider from '../../identities/TestProvider';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
@@ -128,7 +127,7 @@ describe('discover/get', () => {
       const mockedBrowser = jest
         .spyOn(identitiesUtils, 'browser')
         .mockImplementation(() => {});
-      await execUtils.pkStdio(
+      await testUtils.pkStdio(
         [
           'identities',
           'authenticate',
@@ -136,14 +135,16 @@ describe('discover/get', () => {
           testToken.identityId,
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       // Add one of the nodes to our gestalt graph so that we'll be able to
       // contact the gestalt during discovery
-      await execUtils.pkStdio(
+      await testUtils.pkStdio(
         [
           'nodes',
           'add',
@@ -152,19 +153,23 @@ describe('discover/get', () => {
           `${nodeAPort}`,
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       // Discover gestalt by node
-      const discoverResponse = await execUtils.pkStdio(
+      const discoverResponse = await testUtils.pkStdio(
         ['identities', 'discover', nodesUtils.encodeNodeId(nodeAId)],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       expect(discoverResponse.exitCode).toBe(0);
       // Since discovery is a background process we need to wait for the
@@ -191,13 +196,15 @@ describe('discover/get', () => {
         100,
       );
       // Now we can get the gestalt
-      const getResponse = await execUtils.pkStdio(
+      const getResponse = await testUtils.pkStdio(
         ['identities', 'get', nodesUtils.encodeNodeId(nodeAId)],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       expect(getResponse.exitCode).toBe(0);
       expect(getResponse.stdout).toContain(nodesUtils.encodeNodeId(nodeAId));
@@ -224,7 +231,7 @@ describe('discover/get', () => {
       const mockedBrowser = jest
         .spyOn(identitiesUtils, 'browser')
         .mockImplementation(() => {});
-      await execUtils.pkStdio(
+      await testUtils.pkStdio(
         [
           'identities',
           'authenticate',
@@ -232,14 +239,16 @@ describe('discover/get', () => {
           testToken.identityId,
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       // Add one of the nodes to our gestalt graph so that we'll be able to
       // contact the gestalt during discovery
-      await execUtils.pkStdio(
+      await testUtils.pkStdio(
         [
           'nodes',
           'add',
@@ -248,19 +257,23 @@ describe('discover/get', () => {
           `${nodeAPort}`,
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       // Discover gestalt by node
-      const discoverResponse = await execUtils.pkStdio(
+      const discoverResponse = await testUtils.pkStdio(
         ['identities', 'discover', providerString],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       expect(discoverResponse.exitCode).toBe(0);
       // Since discovery is a background process we need to wait for the
@@ -287,13 +300,15 @@ describe('discover/get', () => {
         100,
       );
       // Now we can get the gestalt
-      const getResponse = await execUtils.pkStdio(
+      const getResponse = await testUtils.pkStdio(
         ['identities', 'get', providerString],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       expect(getResponse.exitCode).toBe(0);
       expect(getResponse.stdout).toContain(nodesUtils.encodeNodeId(nodeAId));
@@ -318,23 +333,27 @@ describe('discover/get', () => {
     async () => {
       let exitCode;
       // Discover
-      ({ exitCode } = await execUtils.pkStdio(
+      ({ exitCode } = await testUtils.pkStdio(
         ['identities', 'discover', 'invalid'],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(sysexits.USAGE);
       // Get
-      ({ exitCode } = await execUtils.pkStdio(
+      ({ exitCode } = await testUtils.pkStdio(
         ['identities', 'get', 'invalid'],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
     },
   );

--- a/tests/bin/identities/search.test.ts
+++ b/tests/bin/identities/search.test.ts
@@ -6,7 +6,6 @@ import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import PolykeyAgent from '@/PolykeyAgent';
 import { sysexits } from '@/utils';
 import * as identitiesUtils from '@/identities/utils';
-import * as execUtils from '../../utils/exec';
 import TestProvider from '../../identities/TestProvider';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 import * as testUtils from '../../utils';
@@ -150,33 +149,39 @@ describe('search', () => {
         .mockImplementation(() => {});
       // Search with no authenticated identities
       // Should return nothing
-      ({ exitCode, stdout } = await execUtils.pkStdio(
+      ({ exitCode, stdout } = await testUtils.pkStdio(
         ['identities', 'search', '--format', 'json'],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       expect(stdout).toBe('');
       // Authenticate an identity for provider1
-      await execUtils.pkStdio(
+      await testUtils.pkStdio(
         ['identities', 'authenticate', provider1.id, identityId],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       // Now our search should include the identities from provider1
-      ({ exitCode, stdout } = await execUtils.pkStdio(
+      ({ exitCode, stdout } = await testUtils.pkStdio(
         ['identities', 'search', '--format', 'json'],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       searchResults = stdout.split('\n').slice(undefined, -1).map(JSON.parse);
@@ -185,23 +190,27 @@ describe('search', () => {
       expect(searchResults).toContainEqual(user2);
       expect(searchResults).toContainEqual(user3);
       // Authenticate an identity for provider2
-      await execUtils.pkStdio(
+      await testUtils.pkStdio(
         ['identities', 'authenticate', provider2.id, identityId],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       // Now our search should include the identities from provider1 and
       // provider2
-      ({ exitCode, stdout } = await execUtils.pkStdio(
+      ({ exitCode, stdout } = await testUtils.pkStdio(
         ['identities', 'search', '--format', 'json'],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       searchResults = stdout.split('\n').slice(undefined, -1).map(JSON.parse);
@@ -213,13 +222,15 @@ describe('search', () => {
       expect(searchResults).toContainEqual(user5);
       expect(searchResults).toContainEqual(user6);
       // We can narrow this search by providing search terms
-      ({ exitCode, stdout } = await execUtils.pkStdio(
+      ({ exitCode, stdout } = await testUtils.pkStdio(
         ['identities', 'search', '4', '5', '--format', 'json'],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       searchResults = stdout.split('\n').slice(undefined, -1).map(JSON.parse);
@@ -227,17 +238,19 @@ describe('search', () => {
       expect(searchResults).toContainEqual(user4);
       expect(searchResults).toContainEqual(user5);
       // Authenticate an identity for provider3
-      await execUtils.pkStdio(
+      await testUtils.pkStdio(
         ['identities', 'authenticate', provider3.id, identityId],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       // We can get results from only some providers using the --provider-id
       // option
-      ({ exitCode, stdout } = await execUtils.pkStdio(
+      ({ exitCode, stdout } = await testUtils.pkStdio(
         [
           'identities',
           'search',
@@ -248,10 +261,12 @@ describe('search', () => {
           'json',
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       searchResults = stdout.split('\n').slice(undefined, -1).map(JSON.parse);
@@ -261,7 +276,7 @@ describe('search', () => {
       expect(searchResults).toContainEqual(user6);
       expect(searchResults).toContainEqual(user7);
       expect(searchResults).toContainEqual(user8);
-      ({ exitCode, stdout } = await execUtils.pkStdio(
+      ({ exitCode, stdout } = await testUtils.pkStdio(
         [
           'identities',
           'search',
@@ -273,10 +288,12 @@ describe('search', () => {
           'json',
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       searchResults = stdout.split('\n').slice(undefined, -1).map(JSON.parse);
@@ -288,13 +305,15 @@ describe('search', () => {
       expect(searchResults).toContainEqual(user8);
       // We can search for a specific identity id across providers
       // This will find identities even if they're disconnected
-      ({ exitCode, stdout } = await execUtils.pkStdio(
+      ({ exitCode, stdout } = await testUtils.pkStdio(
         ['identities', 'search', '--identity-id', 'user3', '--format', 'json'],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       searchResults = stdout.split('\n').slice(undefined, -1).map(JSON.parse);
@@ -303,13 +322,15 @@ describe('search', () => {
       expect(searchResults).toContainEqual(user6);
       expect(searchResults).toContainEqual(user9);
       // We can limit the number of search results to display
-      ({ exitCode, stdout } = await execUtils.pkStdio(
+      ({ exitCode, stdout } = await testUtils.pkStdio(
         ['identities', 'search', '--limit', '2', '--format', 'json'],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       searchResults = stdout.split('\n').slice(undefined, -1).map(JSON.parse);
@@ -322,33 +343,39 @@ describe('search', () => {
     async () => {
       let exitCode;
       // Invalid identity id
-      ({ exitCode } = await execUtils.pkStdio(
+      ({ exitCode } = await testUtils.pkStdio(
         ['identities', 'search', '--identity-id', ''],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(sysexits.USAGE);
       // Invalid auth identity id
-      ({ exitCode } = await execUtils.pkStdio(
+      ({ exitCode } = await testUtils.pkStdio(
         ['identities', 'search', '--auth-identity-id', ''],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(sysexits.USAGE);
       // Invalid value for limit
-      ({ exitCode } = await execUtils.pkStdio(
+      ({ exitCode } = await testUtils.pkStdio(
         ['identities', 'search', '--limit', 'NaN'],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(sysexits.USAGE);
     },

--- a/tests/bin/identities/trustUntrustList.test.ts
+++ b/tests/bin/identities/trustUntrustList.test.ts
@@ -10,7 +10,6 @@ import { sysexits } from '@/utils';
 import * as nodesUtils from '@/nodes/utils';
 import * as claimsUtils from '@/claims/utils';
 import * as identitiesUtils from '@/identities/utils';
-import * as execUtils from '../../utils/exec';
 import TestProvider from '../../identities/TestProvider';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 import * as testUtils from '../../utils';
@@ -103,7 +102,7 @@ describe('trust/untrust/list', () => {
       // Add the node to our node graph and authenticate an identity on the
       // provider
       // This allows us to contact the members of the gestalt we want to trust
-      await execUtils.pkStdio(
+      await testUtils.pkStdio(
         [
           'nodes',
           'add',
@@ -112,15 +111,17 @@ describe('trust/untrust/list', () => {
           `${nodePort}`,
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       const mockedBrowser = jest
         .spyOn(identitiesUtils, 'browser')
         .mockImplementation(() => {});
-      await execUtils.pkStdio(
+      await testUtils.pkStdio(
         [
           'identities',
           'authenticate',
@@ -128,34 +129,40 @@ describe('trust/untrust/list', () => {
           testToken.identityId,
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       mockedBrowser.mockRestore();
       // Trust node - this should trigger discovery on the gestalt the node
       // belongs to and add it to our gestalt graph
-      ({ exitCode } = await execUtils.pkStdio(
+      ({ exitCode } = await testUtils.pkStdio(
         ['identities', 'trust', nodesUtils.encodeNodeId(nodeId)],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       // Since discovery is a background process we need to wait for the
       // gestalt to be discovered
       await pkAgent.discovery.waitForDrained();
       // Check that gestalt was discovered and permission was set
-      ({ exitCode, stdout } = await execUtils.pkStdio(
+      ({ exitCode, stdout } = await testUtils.pkStdio(
         ['identities', 'list', '--format', 'json'],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toHaveLength(1);
@@ -172,23 +179,27 @@ describe('trust/untrust/list', () => {
       // Untrust the gestalt by node
       // This should remove the permission, but not the gestalt (from the gestalt
       // graph)
-      ({ exitCode } = await execUtils.pkStdio(
+      ({ exitCode } = await testUtils.pkStdio(
         ['identities', 'untrust', nodesUtils.encodeNodeId(nodeId)],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       // Check that gestalt still exists but has no permissions
-      ({ exitCode, stdout } = await execUtils.pkStdio(
+      ({ exitCode, stdout } = await testUtils.pkStdio(
         ['identities', 'list', '--format', 'json'],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toHaveLength(1);
@@ -222,7 +233,7 @@ describe('trust/untrust/list', () => {
       // Add the node to our node graph and authenticate an identity on the
       // provider
       // This allows us to contact the members of the gestalt we want to trust
-      await execUtils.pkStdio(
+      await testUtils.pkStdio(
         [
           'nodes',
           'add',
@@ -231,15 +242,17 @@ describe('trust/untrust/list', () => {
           `${nodePort}`,
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       const mockedBrowser = jest
         .spyOn(identitiesUtils, 'browser')
         .mockImplementation(() => {});
-      await execUtils.pkStdio(
+      await testUtils.pkStdio(
         [
           'identities',
           'authenticate',
@@ -247,46 +260,54 @@ describe('trust/untrust/list', () => {
           testToken.identityId,
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       mockedBrowser.mockRestore();
       // Trust identity - this should trigger discovery on the gestalt the node
       // belongs to and add it to our gestalt graph
       // This command should fail first time as we need to allow time for the
       // identity to be linked to a node in the node graph
-      ({ exitCode } = await execUtils.pkStdio(
+      ({ exitCode } = await testUtils.pkStdio(
         ['identities', 'trust', providerString],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(sysexits.NOUSER);
       // Since discovery is a background process we need to wait for the
       // gestalt to be discovered
       await pkAgent.discovery.waitForDrained();
       // This time the command should succeed
-      ({ exitCode } = await execUtils.pkStdio(
+      ({ exitCode } = await testUtils.pkStdio(
         ['identities', 'trust', providerString],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       // Check that gestalt was discovered and permission was set
-      ({ exitCode, stdout } = await execUtils.pkStdio(
+      ({ exitCode, stdout } = await testUtils.pkStdio(
         ['identities', 'list', '--format', 'json'],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toHaveLength(1);
@@ -303,23 +324,27 @@ describe('trust/untrust/list', () => {
       // Untrust the gestalt by node
       // This should remove the permission, but not the gestalt (from the gestalt
       // graph)
-      ({ exitCode } = await execUtils.pkStdio(
+      ({ exitCode } = await testUtils.pkStdio(
         ['identities', 'untrust', providerString],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       // Check that gestalt still exists but has no permissions
-      ({ exitCode, stdout } = await execUtils.pkStdio(
+      ({ exitCode, stdout } = await testUtils.pkStdio(
         ['identities', 'list', '--format', 'json'],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toHaveLength(1);
@@ -351,23 +376,27 @@ describe('trust/untrust/list', () => {
     async () => {
       let exitCode;
       // Trust
-      ({ exitCode } = await execUtils.pkStdio(
+      ({ exitCode } = await testUtils.pkStdio(
         ['identities', 'trust', 'invalid'],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(sysexits.USAGE);
       // Untrust
-      ({ exitCode } = await execUtils.pkStdio(
+      ({ exitCode } = await testUtils.pkStdio(
         ['identities', 'untrust', 'invalid'],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(sysexits.USAGE);
     },

--- a/tests/bin/keys/cert.test.ts
+++ b/tests/bin/keys/cert.test.ts
@@ -1,5 +1,4 @@
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
-import * as execUtils from '../../utils/exec';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 import * as testUtils from '../../utils';
 
@@ -9,7 +8,7 @@ describe('cert', () => {
   let agentPassword;
   let agentClose;
   beforeEach(async () => {
-    ({ agentDir, agentPassword, agentClose } = await execUtils.setupTestAgent(
+    ({ agentDir, agentPassword, agentClose } = await testUtils.setupTestAgent(
       globalRootKeyPems[0],
       logger,
     ));
@@ -20,26 +19,30 @@ describe('cert', () => {
   testUtils.testIf(
     testUtils.isTestPlatformEmpty || testUtils.isTestPlatformDocker,
   )('cert gets the certificate', async () => {
-    let { exitCode, stdout } = await execUtils.pkStdio(
+    let { exitCode, stdout } = await testUtils.pkExec(
       ['keys', 'cert', '--format', 'json'],
       {
-        PK_NODE_PATH: agentDir,
-        PK_PASSWORD: agentPassword,
+        env: {
+          PK_NODE_PATH: agentDir,
+          PK_PASSWORD: agentPassword,
+        },
+        cwd: agentDir,
       },
-      agentDir,
     );
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout)).toEqual({
       cert: expect.any(String),
     });
     const certCommand = JSON.parse(stdout).cert;
-    ({ exitCode, stdout } = await execUtils.pkStdio(
+    ({ exitCode, stdout } = await testUtils.pkExec(
       ['agent', 'status', '--format', 'json'],
       {
-        PK_NODE_PATH: agentDir,
-        PK_PASSWORD: agentPassword,
+        env: {
+          PK_NODE_PATH: agentDir,
+          PK_PASSWORD: agentPassword,
+        },
+        cwd: agentDir,
       },
-      agentDir,
     ));
     expect(exitCode).toBe(0);
     const certStatus = JSON.parse(stdout).rootCertPem;

--- a/tests/bin/keys/certchain.test.ts
+++ b/tests/bin/keys/certchain.test.ts
@@ -1,5 +1,4 @@
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
-import * as execUtils from '../../utils/exec';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 import * as testUtils from '../../utils';
 
@@ -11,7 +10,7 @@ describe('certchain', () => {
   let agentPassword;
   let agentClose;
   beforeEach(async () => {
-    ({ agentDir, agentPassword, agentClose } = await execUtils.setupTestAgent(
+    ({ agentDir, agentPassword, agentClose } = await testUtils.setupTestAgent(
       globalRootKeyPems[0],
       logger,
     ));
@@ -22,26 +21,30 @@ describe('certchain', () => {
   testUtils.testIf(
     testUtils.isTestPlatformEmpty || testUtils.isTestPlatformDocker,
   )('certchain gets the certificate chain', async () => {
-    let { exitCode, stdout } = await execUtils.pkStdio(
+    let { exitCode, stdout } = await testUtils.pkExec(
       ['keys', 'certchain', '--format', 'json'],
       {
-        PK_NODE_PATH: agentDir,
-        PK_PASSWORD: agentPassword,
+        env: {
+          PK_NODE_PATH: agentDir,
+          PK_PASSWORD: agentPassword,
+        },
+        cwd: agentDir,
       },
-      agentDir,
     );
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout)).toEqual({
       certchain: expect.any(Array),
     });
     const certChainCommand = JSON.parse(stdout).certchain.join('\n');
-    ({ exitCode, stdout } = await execUtils.pkStdio(
+    ({ exitCode, stdout } = await testUtils.pkExec(
       ['agent', 'status', '--format', 'json'],
       {
-        PK_NODE_PATH: agentDir,
-        PK_PASSWORD: agentPassword,
+        env: {
+          PK_NODE_PATH: agentDir,
+          PK_PASSWORD: agentPassword,
+        },
+        cwd: agentDir,
       },
-      agentDir,
     ));
     expect(exitCode).toBe(0);
     const certChainStatus = JSON.parse(stdout).rootCertChainPem;

--- a/tests/bin/keys/encryptDecrypt.test.ts
+++ b/tests/bin/keys/encryptDecrypt.test.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import fs from 'fs';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
-import * as execUtils from '../../utils/exec';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 import * as testUtils from '../../utils';
 
@@ -13,7 +12,7 @@ describe('encrypt-decrypt', () => {
   let agentPassword;
   let agentClose;
   beforeEach(async () => {
-    ({ agentDir, agentPassword, agentClose } = await execUtils.setupTestAgent(
+    ({ agentDir, agentPassword, agentClose } = await testUtils.setupTestAgent(
       globalRootKeyPems[0],
       logger,
     ));
@@ -21,42 +20,45 @@ describe('encrypt-decrypt', () => {
   afterEach(async () => {
     await agentClose();
   });
-  testUtils.testIf(testUtils.isTestPlatformDocker)(
-    'encrypts and decrypts data',
-    async () => {
-      let exitCode, stdout;
-      const dataPath = path.join(agentDir, 'data');
-      await fs.promises.writeFile(dataPath, 'abc', {
-        encoding: 'binary',
-      });
-      ({ exitCode, stdout } = await execUtils.pkStdio(
-        ['keys', 'encrypt', dataPath, '--format', 'json'],
-        {
+  testUtils.testIf(
+    testUtils.isTestPlatformEmpty || testUtils.isTestPlatformDocker,
+  )('encrypts and decrypts data', async () => {
+    let exitCode, stdout;
+    const dataPath = path.join(agentDir, 'data');
+    await fs.promises.writeFile(dataPath, 'abc', {
+      encoding: 'binary',
+    });
+    ({ exitCode, stdout } = await testUtils.pkExec(
+      ['keys', 'encrypt', dataPath, '--format', 'json'],
+      {
+        env: {
           PK_NODE_PATH: agentDir,
           PK_PASSWORD: agentPassword,
         },
-        agentDir,
-      ));
-      expect(exitCode).toBe(0);
-      expect(JSON.parse(stdout)).toEqual({
-        encryptedData: expect.any(String),
-      });
-      const encrypted = JSON.parse(stdout).encryptedData;
-      await fs.promises.writeFile(dataPath, encrypted, {
-        encoding: 'binary',
-      });
-      ({ exitCode, stdout } = await execUtils.pkStdio(
-        ['keys', 'decrypt', dataPath, '--format', 'json'],
-        {
+        cwd: agentDir,
+      },
+    ));
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout)).toEqual({
+      encryptedData: expect.any(String),
+    });
+    const encrypted = JSON.parse(stdout).encryptedData;
+    await fs.promises.writeFile(dataPath, encrypted, {
+      encoding: 'binary',
+    });
+    ({ exitCode, stdout } = await testUtils.pkExec(
+      ['keys', 'decrypt', dataPath, '--format', 'json'],
+      {
+        env: {
           PK_NODE_PATH: agentDir,
           PK_PASSWORD: agentPassword,
         },
-        agentDir,
-      ));
-      expect(exitCode).toBe(0);
-      expect(JSON.parse(stdout)).toEqual({
-        decryptedData: 'abc',
-      });
-    },
-  );
+        cwd: agentDir,
+      },
+    ));
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout)).toEqual({
+      decryptedData: 'abc',
+    });
+  });
 });

--- a/tests/bin/keys/reset.test.ts
+++ b/tests/bin/keys/reset.test.ts
@@ -5,7 +5,6 @@ import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import PolykeyAgent from '@/PolykeyAgent';
 import * as keysUtils from '@/keys/utils';
 import * as testUtils from '../../utils';
-import * as execUtils from '../../utils/exec';
 
 describe('reset', () => {
   const logger = new Logger('reset test', LogLevel.WARN, [new StreamHandler()]);
@@ -56,58 +55,68 @@ describe('reset', () => {
     async () => {
       // Can't test with target executable due to mocking
       // Get previous keypair and nodeId
-      let { exitCode, stdout } = await execUtils.pkStdio(
+      let { exitCode, stdout } = await testUtils.pkStdio(
         ['keys', 'root', '--private-key', '--format', 'json'],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       expect(exitCode).toBe(0);
       const prevPublicKey = JSON.parse(stdout).publicKey;
       const prevPrivateKey = JSON.parse(stdout).privateKey;
-      ({ exitCode, stdout } = await execUtils.pkStdio(
+      ({ exitCode, stdout } = await testUtils.pkStdio(
         ['agent', 'status', '--format', 'json'],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       const prevNodeId = JSON.parse(stdout).nodeId;
       // Reset keypair
       const passPath = path.join(dataDir, 'reset-password');
       await fs.promises.writeFile(passPath, 'password-new');
-      ({ exitCode } = await execUtils.pkStdio(
+      ({ exitCode } = await testUtils.pkStdio(
         ['keys', 'reset', '--password-new-file', passPath],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       // Get new keypair and nodeId and compare against old
-      ({ exitCode, stdout } = await execUtils.pkStdio(
+      ({ exitCode, stdout } = await testUtils.pkStdio(
         ['keys', 'root', '--private-key', '--format', 'json'],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: 'password-new',
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: 'password-new',
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       const newPublicKey = JSON.parse(stdout).publicKey;
       const newPrivateKey = JSON.parse(stdout).privateKey;
-      ({ exitCode, stdout } = await execUtils.pkStdio(
+      ({ exitCode, stdout } = await testUtils.pkStdio(
         ['agent', 'status', '--format', 'json'],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: 'password-new',
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: 'password-new',
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       const newNodeId = JSON.parse(stdout).nodeId;
@@ -116,13 +125,15 @@ describe('reset', () => {
       expect(newNodeId).not.toBe(prevNodeId);
       // Revert side effects
       await fs.promises.writeFile(passPath, password);
-      ({ exitCode } = await execUtils.pkStdio(
+      ({ exitCode } = await testUtils.pkStdio(
         ['keys', 'password', '--password-new-file', passPath],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: 'password-new',
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: 'password-new',
+          },
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
     },

--- a/tests/bin/keys/root.test.ts
+++ b/tests/bin/keys/root.test.ts
@@ -1,5 +1,4 @@
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
-import * as execUtils from '../../utils/exec';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 import * as testUtils from '../../utils';
 
@@ -9,7 +8,7 @@ describe('root', () => {
   let agentPassword;
   let agentClose;
   beforeEach(async () => {
-    ({ agentDir, agentPassword, agentClose } = await execUtils.setupTestAgent(
+    ({ agentDir, agentPassword, agentClose } = await testUtils.setupTestAgent(
       globalRootKeyPems[0],
       logger,
     ));
@@ -20,13 +19,15 @@ describe('root', () => {
   testUtils.testIf(
     testUtils.isTestPlatformEmpty || testUtils.isTestPlatformDocker,
   )('root gets the public key', async () => {
-    const { exitCode, stdout } = await execUtils.pkStdio(
+    const { exitCode, stdout } = await testUtils.pkExec(
       ['keys', 'root', '--format', 'json'],
       {
-        PK_NODE_PATH: agentDir,
-        PK_PASSWORD: agentPassword,
+        env: {
+          PK_NODE_PATH: agentDir,
+          PK_PASSWORD: agentPassword,
+        },
+        cwd: agentDir,
       },
-      agentDir,
     );
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout)).toEqual({
@@ -36,13 +37,15 @@ describe('root', () => {
   testUtils.testIf(
     testUtils.isTestPlatformEmpty || testUtils.isTestPlatformDocker,
   )('root gets public and private keys', async () => {
-    const { exitCode, stdout } = await execUtils.pkStdio(
+    const { exitCode, stdout } = await testUtils.pkExec(
       ['keys', 'root', '--private-key', '--format', 'json'],
       {
-        PK_NODE_PATH: agentDir,
-        PK_PASSWORD: agentPassword,
+        env: {
+          PK_NODE_PATH: agentDir,
+          PK_PASSWORD: agentPassword,
+        },
+        cwd: agentDir,
       },
-      agentDir,
     );
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout)).toEqual({

--- a/tests/bin/keys/signVerify.test.ts
+++ b/tests/bin/keys/signVerify.test.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import fs from 'fs';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
-import * as execUtils from '../../utils/exec';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 import * as testUtils from '../../utils';
 
@@ -13,7 +12,7 @@ describe('sign-verify', () => {
   let agentPassword;
   let agentClose;
   beforeEach(async () => {
-    ({ agentDir, agentPassword, agentClose } = await execUtils.setupTestAgent(
+    ({ agentDir, agentPassword, agentClose } = await testUtils.setupTestAgent(
       globalRootKeyPems[0],
       logger,
     ));
@@ -29,13 +28,15 @@ describe('sign-verify', () => {
     await fs.promises.writeFile(dataPath, 'sign-me', {
       encoding: 'binary',
     });
-    ({ exitCode, stdout } = await execUtils.pkStdio(
+    ({ exitCode, stdout } = await testUtils.pkExec(
       ['keys', 'sign', dataPath, '--format', 'json'],
       {
-        PK_NODE_PATH: agentDir,
-        PK_PASSWORD: agentPassword,
+        env: {
+          PK_NODE_PATH: agentDir,
+          PK_PASSWORD: agentPassword,
+        },
+        cwd: agentDir,
       },
-      agentDir,
     ));
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout)).toEqual({
@@ -46,13 +47,15 @@ describe('sign-verify', () => {
     await fs.promises.writeFile(signaturePath, signed, {
       encoding: 'binary',
     });
-    ({ exitCode, stdout } = await execUtils.pkStdio(
+    ({ exitCode, stdout } = await testUtils.pkExec(
       ['keys', 'verify', dataPath, signaturePath, '--format', 'json'],
       {
-        PK_NODE_PATH: agentDir,
-        PK_PASSWORD: agentPassword,
+        env: {
+          PK_NODE_PATH: agentDir,
+          PK_PASSWORD: agentPassword,
+        },
+        cwd: agentDir,
       },
-      agentDir,
     ));
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout)).toEqual({

--- a/tests/bin/nodes/add.test.ts
+++ b/tests/bin/nodes/add.test.ts
@@ -8,7 +8,6 @@ import { sysexits } from '@/utils';
 import PolykeyAgent from '@/PolykeyAgent';
 import * as nodesUtils from '@/nodes/utils';
 import NodeManager from '@/nodes/NodeManager';
-import * as execUtils from '../../utils/exec';
 import * as testNodesUtils from '../../nodes/utils';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 import * as testUtils from '../../utils';
@@ -60,7 +59,7 @@ describe('add', () => {
     mockedPingNode.mockRestore();
   });
   testUtils.testIf(testUtils.isTestPlatformEmpty)('adds a node', async () => {
-    const { exitCode } = await execUtils.pkStdio(
+    const { exitCode } = await testUtils.pkStdio(
       [
         'nodes',
         'add',
@@ -69,20 +68,24 @@ describe('add', () => {
         `${port}`,
       ],
       {
-        PK_NODE_PATH: nodePath,
-        PK_PASSWORD: password,
+        env: {
+          PK_NODE_PATH: nodePath,
+          PK_PASSWORD: password,
+        },
+        cwd: dataDir,
       },
-      dataDir,
     );
     expect(exitCode).toBe(0);
     // Checking if node was added.
-    const { stdout } = await execUtils.pkStdio(
+    const { stdout } = await testUtils.pkStdio(
       ['nodes', 'find', nodesUtils.encodeNodeId(validNodeId)],
       {
-        PK_NODE_PATH: nodePath,
-        PK_PASSWORD: password,
+        env: {
+          PK_NODE_PATH: nodePath,
+          PK_PASSWORD: password,
+        },
+        cwd: dataDir,
       },
-      dataDir,
     );
     expect(stdout).toContain(validHost);
     expect(stdout).toContain(`${port}`);
@@ -90,7 +93,7 @@ describe('add', () => {
   testUtils.testIf(testUtils.isTestPlatformEmpty)(
     'fails to add a node (invalid node ID)',
     async () => {
-      const { exitCode } = await execUtils.pkStdio(
+      const { exitCode } = await testUtils.pkStdio(
         [
           'nodes',
           'add',
@@ -99,10 +102,12 @@ describe('add', () => {
           `${port}`,
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       expect(exitCode).toBe(sysexits.USAGE);
     },
@@ -110,7 +115,7 @@ describe('add', () => {
   testUtils.testIf(testUtils.isTestPlatformEmpty)(
     'fails to add a node (invalid IP address)',
     async () => {
-      const { exitCode } = await execUtils.pkStdio(
+      const { exitCode } = await testUtils.pkStdio(
         [
           'nodes',
           'add',
@@ -119,10 +124,12 @@ describe('add', () => {
           `${port}`,
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       expect(exitCode).toBe(sysexits.USAGE);
     },
@@ -130,7 +137,7 @@ describe('add', () => {
   testUtils.testIf(testUtils.isTestPlatformEmpty)(
     'adds a node with --force flag',
     async () => {
-      const { exitCode } = await execUtils.pkStdio(
+      const { exitCode } = await testUtils.pkStdio(
         [
           'nodes',
           'add',
@@ -140,10 +147,12 @@ describe('add', () => {
           `${port}`,
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       expect(exitCode).toBe(0);
       // Checking if node was added.
@@ -155,7 +164,7 @@ describe('add', () => {
     'fails to add node when ping fails',
     async () => {
       mockedPingNode.mockImplementation(() => false);
-      const { exitCode } = await execUtils.pkStdio(
+      const { exitCode } = await testUtils.pkStdio(
         [
           'nodes',
           'add',
@@ -164,10 +173,12 @@ describe('add', () => {
           `${port}`,
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       expect(exitCode).toBe(sysexits.NOHOST);
     },
@@ -176,7 +187,7 @@ describe('add', () => {
     'adds a node with --no-ping flag',
     async () => {
       mockedPingNode.mockImplementation(() => false);
-      const { exitCode } = await execUtils.pkStdio(
+      const { exitCode } = await testUtils.pkStdio(
         [
           'nodes',
           'add',
@@ -186,10 +197,12 @@ describe('add', () => {
           `${port}`,
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       expect(exitCode).toBe(0);
       // Checking if node was added.

--- a/tests/bin/nodes/claim.test.ts
+++ b/tests/bin/nodes/claim.test.ts
@@ -5,7 +5,6 @@ import fs from 'fs';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import PolykeyAgent from '@/PolykeyAgent';
 import * as nodesUtils from '@/nodes/utils';
-import * as execUtils from '../../utils/exec';
 import * as testNodesUtils from '../../nodes/utils';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 import * as testUtils from '../../utils';
@@ -86,13 +85,15 @@ describe('claim', () => {
   testUtils.testIf(testUtils.isTestPlatformEmpty)(
     'sends a gestalt invite',
     async () => {
-      const { exitCode, stdout } = await execUtils.pkStdio(
+      const { exitCode, stdout } = await testUtils.pkStdio(
         ['nodes', 'claim', remoteIdEncoded],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       expect(exitCode).toBe(0);
       expect(stdout).toContain('Gestalt Invite');
@@ -105,13 +106,15 @@ describe('claim', () => {
       await remoteNode.notificationsManager.sendNotification(localId, {
         type: 'GestaltInvite',
       });
-      const { exitCode, stdout } = await execUtils.pkStdio(
+      const { exitCode, stdout } = await testUtils.pkStdio(
         ['nodes', 'claim', remoteIdEncoded, '--force-invite'],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       expect(exitCode).toBe(0);
       expect(stdout).toContain('Gestalt Invite');
@@ -122,13 +125,15 @@ describe('claim', () => {
     await remoteNode.notificationsManager.sendNotification(localId, {
       type: 'GestaltInvite',
     });
-    const { exitCode, stdout } = await execUtils.pkStdio(
+    const { exitCode, stdout } = await testUtils.pkStdio(
       ['nodes', 'claim', remoteIdEncoded],
       {
-        PK_NODE_PATH: nodePath,
-        PK_PASSWORD: password,
+        env: {
+          PK_NODE_PATH: nodePath,
+          PK_PASSWORD: password,
+        },
+        cwd: dataDir,
       },
-      dataDir,
     );
     expect(exitCode).toBe(0);
     expect(stdout).toContain('cryptolink claim');

--- a/tests/bin/nodes/find.test.ts
+++ b/tests/bin/nodes/find.test.ts
@@ -6,7 +6,6 @@ import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import PolykeyAgent from '@/PolykeyAgent';
 import * as nodesUtils from '@/nodes/utils';
 import { sysexits } from '@/errors';
-import * as execUtils from '../../utils/exec';
 import * as testNodesUtils from '../../nodes/utils';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 import * as testUtils from '../../utils';
@@ -104,7 +103,7 @@ describe('find', () => {
   testUtils.testIf(testUtils.isTestPlatformEmpty)(
     'finds an online node',
     async () => {
-      const { exitCode, stdout } = await execUtils.pkStdio(
+      const { exitCode, stdout } = await testUtils.pkStdio(
         [
           'nodes',
           'find',
@@ -113,10 +112,12 @@ describe('find', () => {
           'json',
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toEqual({
@@ -131,7 +132,7 @@ describe('find', () => {
   testUtils.testIf(testUtils.isTestPlatformEmpty)(
     'finds an offline node',
     async () => {
-      const { exitCode, stdout } = await execUtils.pkStdio(
+      const { exitCode, stdout } = await testUtils.pkStdio(
         [
           'nodes',
           'find',
@@ -140,10 +141,12 @@ describe('find', () => {
           'json',
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toEqual({
@@ -161,7 +164,7 @@ describe('find', () => {
       const unknownNodeId = nodesUtils.decodeNodeId(
         'vrcacp9vsb4ht25hds6s4lpp2abfaso0mptcfnh499n35vfcn2gkg',
       );
-      const { exitCode, stdout } = await execUtils.pkStdio(
+      const { exitCode, stdout } = await testUtils.pkStdio(
         [
           'nodes',
           'find',
@@ -170,10 +173,12 @@ describe('find', () => {
           'json',
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       expect(exitCode).toBe(sysexits.GENERAL);
       expect(JSON.parse(stdout)).toEqual({

--- a/tests/bin/nodes/ping.test.ts
+++ b/tests/bin/nodes/ping.test.ts
@@ -6,7 +6,6 @@ import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import PolykeyAgent from '@/PolykeyAgent';
 import * as nodesUtils from '@/nodes/utils';
 import { sysexits } from '@/errors';
-import * as execUtils from '../../utils/exec';
 import * as testNodesUtils from '../../nodes/utils';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 import * as testUtils from '../../utils';
@@ -99,7 +98,7 @@ describe('ping', () => {
   testUtils.testIf(testUtils.isTestPlatformEmpty)(
     'fails when pinging an offline node',
     async () => {
-      const { exitCode, stdout, stderr } = await execUtils.pkStdio(
+      const { exitCode, stdout, stderr } = await testUtils.pkStdio(
         [
           'nodes',
           'ping',
@@ -108,10 +107,12 @@ describe('ping', () => {
           'json',
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       expect(exitCode).toBe(sysexits.GENERAL); // Should fail with no response. for automation purposes.
       expect(stderr).toContain('No response received');
@@ -127,7 +128,7 @@ describe('ping', () => {
       const fakeNodeId = nodesUtils.decodeNodeId(
         'vrsc24a1er424epq77dtoveo93meij0pc8ig4uvs9jbeld78n9nl0',
       );
-      const { exitCode, stdout } = await execUtils.pkStdio(
+      const { exitCode, stdout } = await testUtils.pkStdio(
         [
           'nodes',
           'ping',
@@ -136,10 +137,12 @@ describe('ping', () => {
           'json',
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       expect(exitCode).not.toBe(0); // Should fail if node doesn't exist.
       expect(JSON.parse(stdout)).toEqual({
@@ -153,7 +156,7 @@ describe('ping', () => {
   testUtils.testIf(testUtils.isTestPlatformEmpty)(
     'succeed when pinging a live node',
     async () => {
-      const { exitCode, stdout } = await execUtils.pkStdio(
+      const { exitCode, stdout } = await testUtils.pkStdio(
         [
           'nodes',
           'ping',
@@ -162,10 +165,12 @@ describe('ping', () => {
           'json',
         ],
         {
-          PK_NODE_PATH: nodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: nodePath,
+            PK_PASSWORD: password,
+          },
+          cwd: dataDir,
         },
-        dataDir,
       );
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toEqual({

--- a/tests/bin/polykey.test.ts
+++ b/tests/bin/polykey.test.ts
@@ -3,7 +3,6 @@ import path from 'path';
 import os from 'os';
 import readline from 'readline';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
-import * as execUtils from '../utils/exec';
 import * as testUtils from '../utils';
 
 describe('polykey', () => {
@@ -12,7 +11,7 @@ describe('polykey', () => {
       testUtils.isTestPlatformLinux ||
       testUtils.isTestPlatformDocker,
   )('default help display', async () => {
-    const result = await execUtils.pkStdio([]);
+    const result = await testUtils.pkExec([]);
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe('');
     expect(result.stderr.length > 0).toBe(true);
@@ -29,7 +28,7 @@ describe('polykey', () => {
     const password = 'abc123';
     const polykeyPath = path.join(dataDir, 'polykey');
     await fs.promises.mkdir(polykeyPath);
-    const agentProcess = await execUtils.pkSpawn(
+    const agentProcess = await testUtils.pkSpawn(
       [
         'agent',
         'start',
@@ -48,10 +47,12 @@ describe('polykey', () => {
         'json',
       ],
       {
-        PK_TEST_DATA_PATH: dataDir,
-        PK_PASSWORD: password,
+        env: {
+          PK_TEST_DATA_PATH: dataDir,
+          PK_PASSWORD: password,
+        },
+        cwd: dataDir,
       },
-      dataDir,
       logger,
     );
     const rlErr = readline.createInterface(agentProcess.stderr!);

--- a/tests/bin/secrets/secrets.test.ts
+++ b/tests/bin/secrets/secrets.test.ts
@@ -4,7 +4,6 @@ import fs from 'fs';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import PolykeyAgent from '@/PolykeyAgent';
 import { vaultOps } from '@/vaults';
-import * as execUtils from '../../utils/exec';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 import * as testUtils from '../../utils';
 
@@ -31,10 +30,12 @@ describe('CLI secrets', () => {
       },
     });
     // Authorize session
-    await execUtils.pkStdio(
+    await testUtils.pkStdio(
       ['agent', 'unlock', '-np', dataDir, '--password-file', passwordFile],
-      {},
-      dataDir,
+      {
+        env: {},
+        cwd: dataDir,
+      },
     );
   });
   afterEach(async () => {
@@ -64,7 +65,10 @@ describe('CLI secrets', () => {
           `${vaultName}:MySecret`,
         ];
 
-        const result = await execUtils.pkStdio([...command], {}, dataDir);
+        const result = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result.exitCode).toBe(0);
 
         await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
@@ -99,7 +103,10 @@ describe('CLI secrets', () => {
           `${vaultName}:MySecret`,
         ];
 
-        const result = await execUtils.pkStdio([...command], {}, dataDir);
+        const result = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result.exitCode).toBe(0);
 
         await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
@@ -122,7 +129,10 @@ describe('CLI secrets', () => {
 
         command = ['secrets', 'get', '-np', dataDir, `${vaultName}:MySecret`];
 
-        const result = await execUtils.pkStdio([...command], {}, dataDir);
+        const result = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result.exitCode).toBe(0);
       },
     );
@@ -142,7 +152,10 @@ describe('CLI secrets', () => {
 
         command = ['secrets', 'list', '-np', dataDir, vaultName];
 
-        const result = await execUtils.pkStdio([...command], {}, dataDir);
+        const result = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result.exitCode).toBe(0);
       },
       globalThis.defaultTimeout * 2,
@@ -164,7 +177,10 @@ describe('CLI secrets', () => {
           '-r',
         ];
 
-        const result = await execUtils.pkStdio([...command], {}, dataDir);
+        const result = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result.exitCode).toBe(0);
 
         await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
@@ -207,7 +223,10 @@ describe('CLI secrets', () => {
           'MyRenamedSecret',
         ];
 
-        const result = await execUtils.pkStdio([...command], {}, dataDir);
+        const result = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result.exitCode).toBe(0);
 
         await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
@@ -243,7 +262,10 @@ describe('CLI secrets', () => {
           `${vaultName}:MySecret`,
         ];
 
-        const result2 = await execUtils.pkStdio([...command], {}, dataDir);
+        const result2 = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result2.exitCode).toBe(0);
 
         await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
@@ -285,7 +307,10 @@ describe('CLI secrets', () => {
 
         command = ['secrets', 'dir', '-np', dataDir, secretDir, vaultName];
 
-        const result2 = await execUtils.pkStdio([...command], {}, dataDir);
+        const result2 = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result2.exitCode).toBe(0);
 
         await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
@@ -312,7 +337,10 @@ describe('CLI secrets', () => {
 
         command = ['secrets', 'stat', '-np', dataDir, `${vaultName}:MySecret`];
 
-        const result = await execUtils.pkStdio([...command], {}, dataDir);
+        const result = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain('nlink: 1');
         expect(result.stdout).toContain('blocks: 1');

--- a/tests/bin/vaults/vaults.test.ts
+++ b/tests/bin/vaults/vaults.test.ts
@@ -9,7 +9,6 @@ import * as nodesUtils from '@/nodes/utils';
 import * as vaultsUtils from '@/vaults/utils';
 import sysexits from '@/utils/sysexits';
 import NotificationsManager from '@/notifications/NotificationsManager';
-import * as execUtils from '../../utils/exec';
 import * as testNodesUtils from '../../nodes/utils';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 import * as testUtils from '../../utils';
@@ -71,10 +70,12 @@ describe('CLI vaults', () => {
     vaultNumber = 0;
 
     // Authorize session
-    await execUtils.pkStdio(
+    await testUtils.pkStdio(
       ['agent', 'unlock', '-np', dataDir, '--password-file', passwordFile],
-      {},
-      dataDir,
+      {
+        env: {},
+        cwd: dataDir,
+      },
     );
     vaultName = genVaultName();
     command = [];
@@ -96,7 +97,10 @@ describe('CLI vaults', () => {
         await polykeyAgent.vaultManager.createVault('Vault1' as VaultName);
         await polykeyAgent.vaultManager.createVault('Vault2' as VaultName);
 
-        const result = await execUtils.pkStdio([...command], {}, dataDir);
+        const result = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result.exitCode).toBe(0);
       },
     );
@@ -106,12 +110,17 @@ describe('CLI vaults', () => {
       'should create vaults',
       async () => {
         command = ['vaults', 'create', '-np', dataDir, 'MyTestVault'];
-        const result = await execUtils.pkStdio([...command], {}, dataDir);
+        const result = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result.exitCode).toBe(0);
-        const result2 = await execUtils.pkStdio(
+        const result2 = await testUtils.pkStdio(
           ['vaults', 'touch', '-np', dataDir, 'MyTestVault2'],
-          {},
-          dataDir,
+          {
+            env: {},
+            cwd: dataDir,
+          },
         );
         expect(result2.exitCode).toBe(0);
 
@@ -141,7 +150,10 @@ describe('CLI vaults', () => {
         const id = polykeyAgent.vaultManager.getVaultId(vaultName);
         expect(id).toBeTruthy();
 
-        const result = await execUtils.pkStdio([...command], {}, dataDir);
+        const result = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result.exitCode).toBe(0);
 
         const list = (await polykeyAgent.vaultManager.listVaults()).keys();
@@ -167,7 +179,10 @@ describe('CLI vaults', () => {
         const id = polykeyAgent.vaultManager.getVaultId(vaultName);
         expect(id).toBeTruthy();
 
-        const result = await execUtils.pkStdio([...command], {}, dataDir);
+        const result = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         // Exit code of the exception
         expect(result.exitCode).toBe(sysexits.USAGE);
 
@@ -192,7 +207,10 @@ describe('CLI vaults', () => {
         id = polykeyAgent.vaultManager.getVaultId(vaultName);
         expect(id).toBeTruthy();
 
-        const result2 = await execUtils.pkStdio([...command], {}, dataDir);
+        const result2 = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result2.exitCode).toBe(0);
 
         const list = (await polykeyAgent.vaultManager.listVaults()).keys();
@@ -274,7 +292,10 @@ describe('CLI vaults', () => {
         targetNodeIdEncoded,
       ];
 
-      let result = await execUtils.pkStdio([...command], {}, dataDir);
+      let result = await testUtils.pkStdio([...command], {
+        env: {},
+        cwd: dataDir,
+      });
       expect(result.exitCode).toBe(0);
 
       const clonedVaultId = await polykeyAgent.vaultManager.getVaultId(
@@ -300,7 +321,7 @@ describe('CLI vaults', () => {
         vaultName,
         nodesUtils.encodeNodeId(targetNodeId),
       ];
-      result = await execUtils.pkStdio([...command], {}, dataDir);
+      result = await testUtils.pkStdio([...command], { env: {}, cwd: dataDir });
       expect(result.exitCode).toBe(0);
 
       const secondClonedVaultId = (await polykeyAgent.vaultManager.getVaultId(
@@ -326,7 +347,7 @@ describe('CLI vaults', () => {
       );
 
       command = ['vaults', 'pull', '-np', dataDir, vaultName];
-      result = await execUtils.pkStdio([...command], {}, dataDir);
+      result = await testUtils.pkStdio([...command], { env: {}, cwd: dataDir });
       expect(result.exitCode).toBe(0);
 
       await polykeyAgent.vaultManager.withVaults(
@@ -349,7 +370,7 @@ describe('CLI vaults', () => {
         vaultsUtils.encodeVaultId(secondClonedVaultId),
         targetNodeIdEncoded,
       ];
-      result = await execUtils.pkStdio([...command], {}, dataDir);
+      result = await testUtils.pkStdio([...command], { env: {}, cwd: dataDir });
       expect(result.exitCode).toBe(sysexits.USAGE);
       expect(result.stderr).toContain('ErrorVaultsVaultUndefined');
 
@@ -363,7 +384,7 @@ describe('CLI vaults', () => {
         vaultsUtils.encodeVaultId(secondClonedVaultId),
         'InvalidNodeId',
       ];
-      result = await execUtils.pkStdio([...command], {}, dataDir);
+      result = await testUtils.pkStdio([...command], { env: {}, cwd: dataDir });
       expect(result.exitCode).toBe(sysexits.USAGE);
 
       await targetPolykeyAgent.stop();
@@ -408,7 +429,10 @@ describe('CLI vaults', () => {
             vaultIdEncoded,
             targetNodeIdEncoded,
           ];
-          const result = await execUtils.pkStdio([...command], {}, dataDir);
+          const result = await testUtils.pkStdio([...command], {
+            env: {},
+            cwd: dataDir,
+          });
           expect(result.exitCode).toBe(0);
 
           // Check permission
@@ -459,7 +483,10 @@ describe('CLI vaults', () => {
           vaultIdEncoded1,
           targetNodeIdEncoded,
         ];
-        const result = await execUtils.pkStdio([...command], {}, dataDir);
+        const result = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result.exitCode).toBe(0);
 
         // Check permission
@@ -481,7 +508,10 @@ describe('CLI vaults', () => {
           vaultIdEncoded2,
           targetNodeIdEncoded,
         ];
-        const result2 = await execUtils.pkStdio([...command], {}, dataDir);
+        const result2 = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result2.exitCode).toBe(0);
 
         // Check permission
@@ -525,14 +555,20 @@ describe('CLI vaults', () => {
         await polykeyAgent.acl.setVaultAction(vaultId2, targetNodeId, 'pull');
 
         command = ['vaults', 'permissions', '-np', dataDir, vaultIdEncoded1];
-        const result = await execUtils.pkStdio([...command], {}, dataDir);
+        const result = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain(targetNodeIdEncoded);
         expect(result.stdout).toContain('clone');
         expect(result.stdout).toContain('pull');
 
         command = ['vaults', 'permissions', '-np', dataDir, vaultIdEncoded2];
-        const result2 = await execUtils.pkStdio([...command], {}, dataDir);
+        const result2 = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result2.exitCode).toBe(0);
         expect(result2.stdout).toContain(targetNodeIdEncoded);
         expect(result2.stdout).not.toContain('clone');
@@ -575,7 +611,10 @@ describe('CLI vaults', () => {
           ver1Oid,
         ];
 
-        const result = await execUtils.pkStdio([...command], {}, dataDir);
+        const result = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result.exitCode).toBe(0);
 
         await polykeyAgent.vaultManager.withVaults([vaultId], async (vault) => {
@@ -620,7 +659,10 @@ describe('CLI vaults', () => {
           ver1Oid,
         ];
 
-        const result = await execUtils.pkStdio([...command], {}, dataDir);
+        const result = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result.exitCode).toBe(0);
 
         const command2 = [
@@ -632,7 +674,10 @@ describe('CLI vaults', () => {
           'last',
         ];
 
-        const result2 = await execUtils.pkStdio([...command2], {}, dataDir);
+        const result2 = await testUtils.pkStdio([...command2], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result2.exitCode).toBe(0);
       },
     );
@@ -652,7 +697,10 @@ describe('CLI vaults', () => {
           'NOT_A_VALID_CHECKOUT_ID',
         ];
 
-        const result = await execUtils.pkStdio([...command], {}, dataDir);
+        const result = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result.exitCode).toBe(sysexits.USAGE);
 
         expect(result.stderr).toContain('ErrorVaultReferenceInvalid');
@@ -670,7 +718,10 @@ describe('CLI vaults', () => {
           'NOT_A_VALID_CHECKOUT_ID',
         ];
 
-        const result = await execUtils.pkStdio([...command], {}, dataDir);
+        const result = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result.exitCode).toBe(sysexits.USAGE);
         expect(result.stderr).toContain('ErrorVaultsVaultUndefined');
       },
@@ -714,7 +765,10 @@ describe('CLI vaults', () => {
       async () => {
         const command = ['vaults', 'log', '-np', dataDir, vaultName];
 
-        const result = await execUtils.pkStdio([...command], {}, dataDir);
+        const result = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result.exitCode).toEqual(0);
         expect(result.stdout).toContain(writeF1Oid);
         expect(result.stdout).toContain(writeF2Oid);
@@ -726,7 +780,10 @@ describe('CLI vaults', () => {
       async () => {
         const command = ['vaults', 'log', '-np', dataDir, '-d', '2', vaultName];
 
-        const result = await execUtils.pkStdio([...command], {}, dataDir);
+        const result = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result.exitCode).toEqual(0);
         expect(result.stdout).not.toContain(writeF1Oid);
         expect(result.stdout).toContain(writeF2Oid);
@@ -748,7 +805,10 @@ describe('CLI vaults', () => {
           writeF2Oid,
         ];
 
-        const result = await execUtils.pkStdio([...command], {}, dataDir);
+        const result = await testUtils.pkStdio([...command], {
+          env: {},
+          cwd: dataDir,
+        });
         expect(result.exitCode).toEqual(0);
         expect(result.stdout).not.toContain(writeF1Oid);
         expect(result.stdout).toContain(writeF2Oid);
@@ -794,11 +854,10 @@ describe('CLI vaults', () => {
             '-np',
             dataDir,
           ];
-          const result1 = await execUtils.pkStdio(
-            commands1,
-            { PK_PASSWORD: 'password' },
-            dataDir,
-          );
+          const result1 = await testUtils.pkStdio(commands1, {
+            env: { PK_PASSWORD: 'password' },
+            cwd: dataDir,
+          });
           expect(result1.exitCode).toEqual(sysexits.NOPERM);
           expect(result1.stderr).toContain(
             'ErrorVaultsPermissionDenied: Permission was denied - Scanning is not allowed for',
@@ -816,11 +875,10 @@ describe('CLI vaults', () => {
             '-np',
             dataDir,
           ];
-          const result2 = await execUtils.pkStdio(
-            commands2,
-            { PK_PASSWORD: 'password' },
-            dataDir,
-          );
+          const result2 = await testUtils.pkStdio(commands2, {
+            env: { PK_PASSWORD: 'password' },
+            cwd: dataDir,
+          });
           expect(result2.exitCode).toEqual(sysexits.NOPERM);
           expect(result2.stderr).toContain(
             'ErrorVaultsPermissionDenied: Permission was denied - Scanning is not allowed for',
@@ -851,11 +909,10 @@ describe('CLI vaults', () => {
             '-np',
             dataDir,
           ];
-          const result3 = await execUtils.pkStdio(
-            commands3,
-            { PK_PASSWORD: 'password' },
-            dataDir,
-          );
+          const result3 = await testUtils.pkStdio(commands3, {
+            env: { PK_PASSWORD: 'password' },
+            cwd: dataDir,
+          });
           expect(result3.exitCode).toBe(0);
           expect(result3.stdout).toContain(
             `Vault1\t\t${vaultsUtils.encodeVaultId(vault1Id)}\t\tclone`,

--- a/tests/client/service/gestaltsGestaltTrustByIdentity.test.ts
+++ b/tests/client/service/gestaltsGestaltTrustByIdentity.test.ts
@@ -32,8 +32,8 @@ import * as gestaltsErrors from '@/gestalts/errors';
 import * as keysUtils from '@/keys/utils';
 import * as clientUtils from '@/client/utils/utils';
 import * as nodesUtils from '@/nodes/utils';
+import * as testUtils from '../../utils';
 import TestProvider from '../../identities/TestProvider';
-import { expectRemoteError } from '../../utils';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 
 describe('gestaltsGestaltTrustByIdentity', () => {
@@ -299,7 +299,7 @@ describe('gestaltsGestaltTrustByIdentity', () => {
     request.setIdentityId(connectedIdentity);
     // Should fail on first attempt - need to allow time for the identity to be
     // linked to a node via discovery
-    await expectRemoteError(
+    await testUtils.expectRemoteError(
       grpcClient.gestaltsGestaltTrustByIdentity(
         request,
         clientUtils.encodeAuthFromPassword(password),
@@ -331,7 +331,7 @@ describe('gestaltsGestaltTrustByIdentity', () => {
     request.setProviderId(testProvider.id);
     request.setIdentityId('disconnected-user');
     // Should fail on first attempt - attempt to find a connected node
-    await expectRemoteError(
+    await testUtils.expectRemoteError(
       grpcClient.gestaltsGestaltTrustByIdentity(
         request,
         clientUtils.encodeAuthFromPassword(password),
@@ -340,7 +340,7 @@ describe('gestaltsGestaltTrustByIdentity', () => {
     );
     // Wait and try again - should fail again because the identity has no
     // linked nodes we can trust
-    await expectRemoteError(
+    await testUtils.expectRemoteError(
       grpcClient.gestaltsGestaltTrustByIdentity(
         request,
         clientUtils.encodeAuthFromPassword(password),
@@ -397,7 +397,7 @@ describe('gestaltsGestaltTrustByIdentity', () => {
     request.setIdentityId(connectedIdentity);
     // Should fail on first attempt - need to allow time for the identity to be
     // linked to a node via discovery
-    await expectRemoteError(
+    await testUtils.expectRemoteError(
       grpcClient.gestaltsGestaltTrustByIdentity(
         request,
         clientUtils.encodeAuthFromPassword(password),

--- a/tests/client/service/identitiesAuthenticate.test.ts
+++ b/tests/client/service/identitiesAuthenticate.test.ts
@@ -16,7 +16,7 @@ import * as validationErrors from '@/validation/errors';
 import * as clientUtils from '@/client/utils/utils';
 import * as nodesUtils from '@/nodes/utils';
 import TestProvider from '../../identities/TestProvider';
-import { expectRemoteError } from '../../utils';
+import * as testUtils from '../../utils';
 
 describe('identitiesAuthenticate', () => {
   const logger = new Logger('identitiesAuthenticate test', LogLevel.WARN, [
@@ -127,7 +127,7 @@ describe('identitiesAuthenticate', () => {
   test('cannot authenticate invalid provider', async () => {
     const request = new identitiesPB.Provider();
     request.setProviderId('');
-    await expectRemoteError(
+    await testUtils.expectRemoteError(
       grpcClient
         .identitiesAuthenticate(
           request,

--- a/tests/client/service/identitiesClaim.test.ts
+++ b/tests/client/service/identitiesClaim.test.ts
@@ -26,7 +26,7 @@ import * as claimsUtils from '@/claims/utils';
 import * as nodesUtils from '@/nodes/utils';
 import * as validationErrors from '@/validation/errors';
 import TestProvider from '../../identities/TestProvider';
-import { expectRemoteError } from '../../utils';
+import * as testUtils from '../../utils';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 
 describe('identitiesClaim', () => {
@@ -210,7 +210,7 @@ describe('identitiesClaim', () => {
     const request = new identitiesPB.Provider();
     request.setIdentityId('');
     request.setProviderId(testToken.providerId);
-    await expectRemoteError(
+    await testUtils.expectRemoteError(
       grpcClient.identitiesClaim(
         request,
         clientUtils.encodeAuthFromPassword(password),
@@ -219,7 +219,7 @@ describe('identitiesClaim', () => {
     );
     request.setIdentityId(testToken.identityId);
     request.setProviderId('');
-    await expectRemoteError(
+    await testUtils.expectRemoteError(
       grpcClient.identitiesClaim(
         request,
         clientUtils.encodeAuthFromPassword(password),
@@ -228,7 +228,7 @@ describe('identitiesClaim', () => {
     );
     request.setIdentityId('');
     request.setProviderId('');
-    await expectRemoteError(
+    await testUtils.expectRemoteError(
       grpcClient.identitiesClaim(
         request,
         clientUtils.encodeAuthFromPassword(password),

--- a/tests/client/service/identitiesInfoConnectedGet.test.ts
+++ b/tests/client/service/identitiesInfoConnectedGet.test.ts
@@ -16,7 +16,7 @@ import * as clientUtils from '@/client/utils/utils';
 import * as nodesUtils from '@/nodes/utils';
 import * as identitiesErrors from '@/identities/errors';
 import TestProvider from '../../identities/TestProvider';
-import { expectRemoteError } from '../../utils';
+import * as testUtils from '../../utils';
 
 describe('identitiesInfoConnectedGet', () => {
   const logger = new Logger('identitiesInfoConnectedGet test', LogLevel.WARN, [
@@ -731,7 +731,7 @@ describe('identitiesInfoConnectedGet', () => {
     // This feature is not implemented yet - should throw error
     const request = new identitiesPB.ProviderSearch();
     request.setDisconnected(true);
-    await expectRemoteError(
+    await testUtils.expectRemoteError(
       grpcClient
         .identitiesInfoConnectedGet(
           request,

--- a/tests/client/service/nodesAdd.test.ts
+++ b/tests/client/service/nodesAdd.test.ts
@@ -21,7 +21,7 @@ import * as utilsPB from '@/proto/js/polykey/v1/utils/utils_pb';
 import * as nodesUtils from '@/nodes/utils';
 import * as clientUtils from '@/client/utils/utils';
 import * as validationErrors from '@/validation/errors';
-import { expectRemoteError } from '../../utils';
+import * as testUtils from '../../utils';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 
 describe('nodesAdd', () => {
@@ -176,7 +176,7 @@ describe('nodesAdd', () => {
     request.setForce(false);
     request.setNodeId('vrsc24a1er424epq77dtoveo93meij0pc8ig4uvs9jbeld78n9nl0');
     request.setAddress(addressMessage);
-    await expectRemoteError(
+    await testUtils.expectRemoteError(
       grpcClient.nodesAdd(
         request,
         clientUtils.encodeAuthFromPassword(password),
@@ -186,7 +186,7 @@ describe('nodesAdd', () => {
     // Invalid port
     addressMessage.setHost('127.0.0.1');
     addressMessage.setPort(111111);
-    await expectRemoteError(
+    await testUtils.expectRemoteError(
       grpcClient.nodesAdd(
         request,
         clientUtils.encodeAuthFromPassword(password),
@@ -196,7 +196,7 @@ describe('nodesAdd', () => {
     // Invalid nodeid
     addressMessage.setPort(11111);
     request.setNodeId('nodeId');
-    await expectRemoteError(
+    await testUtils.expectRemoteError(
       grpcClient.nodesAdd(
         request,
         clientUtils.encodeAuthFromPassword(password),

--- a/tests/client/service/nodesFind.test.ts
+++ b/tests/client/service/nodesFind.test.ts
@@ -19,7 +19,7 @@ import { ClientServiceService } from '@/proto/js/polykey/v1/client_service_grpc_
 import * as nodesPB from '@/proto/js/polykey/v1/nodes/nodes_pb';
 import * as clientUtils from '@/client/utils/utils';
 import * as validationErrors from '@/validation/errors';
-import { expectRemoteError } from '../../utils';
+import * as testUtils from '../../utils';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 
 describe('nodesFind', () => {
@@ -158,7 +158,7 @@ describe('nodesFind', () => {
   test('cannot find an invalid node', async () => {
     const request = new nodesPB.Node();
     request.setNodeId('nodeId');
-    await expectRemoteError(
+    await testUtils.expectRemoteError(
       grpcClient.nodesFind(
         request,
         clientUtils.encodeAuthFromPassword(password),

--- a/tests/client/service/nodesPing.test.ts
+++ b/tests/client/service/nodesPing.test.ts
@@ -20,7 +20,7 @@ import * as utilsPB from '@/proto/js/polykey/v1/utils/utils_pb';
 import * as nodesPB from '@/proto/js/polykey/v1/nodes/nodes_pb';
 import * as clientUtils from '@/client/utils/utils';
 import * as validationErrors from '@/validation/errors';
-import { expectRemoteError } from '../../utils';
+import * as testUtils from '../../utils';
 import { globalRootKeyPems } from '../../fixtures/globalRootKeyPems';
 
 describe('nodesPing', () => {
@@ -173,7 +173,7 @@ describe('nodesPing', () => {
   test('cannot ping an invalid node', async () => {
     const request = new nodesPB.Node();
     request.setNodeId('nodeId');
-    await expectRemoteError(
+    await testUtils.expectRemoteError(
       grpcClient.nodesPing(
         request,
         clientUtils.encodeAuthFromPassword(password),

--- a/tests/grpc/GRPCClient.test.ts
+++ b/tests/grpc/GRPCClient.test.ts
@@ -19,7 +19,7 @@ import * as utilsPB from '@/proto/js/polykey/v1/utils/utils_pb';
 import { timerStart } from '@/utils';
 import * as utils from './utils';
 import * as testNodesUtils from '../nodes/utils';
-import { expectRemoteError } from '../utils';
+import * as testUtils from '../utils';
 
 describe('GRPCClient', () => {
   const logger = new Logger('GRPCClient Test', LogLevel.WARN, [
@@ -176,7 +176,7 @@ describe('GRPCClient', () => {
     const m2 = new utilsPB.EchoMessage();
     m2.setChallenge('error');
     pCall = client.unary(m2);
-    await expectRemoteError(pCall, grpcErrors.ErrorGRPC);
+    await testUtils.expectRemoteError(pCall, grpcErrors.ErrorGRPC);
     meta = await pCall.meta;
     // Expect reflected reflected session token
     expect(clientUtils.decodeAuthToSession(meta)).toBe(

--- a/tests/grpc/utils/testServer.ts
+++ b/tests/grpc/utils/testServer.ts
@@ -1,9 +1,12 @@
 /**
  * This is spawned as a background process for use in some NodeConnection.test.ts tests
+ * This process will not preserve jest testing environment,
+ * any usage of jest globals will result in an error
+ * Beware of propagated usage of jest globals through the script dependencies
  * @module
  */
 import * as grpc from '@grpc/grpc-js';
-import * as utils from './index';
+import * as utils from './utils';
 
 async function main() {
   const authenticate = async (metaClient, metaServer = new grpc.Metadata()) =>

--- a/tests/nat/endpointDependentNAT.test.ts
+++ b/tests/nat/endpointDependentNAT.test.ts
@@ -43,9 +43,7 @@ describe('endpoint dependent NAT traversal', () => {
         tearDownNAT,
       } = await testNatUtils.setupNAT('edm', 'dmz', logger);
       // Since node2 is not behind a NAT can directly add its details
-      await testNatUtils.pkExecNs(
-        userPid!,
-        agent1Pid!,
+      await testUtils.pkExec(
         [
           'nodes',
           'add',
@@ -55,20 +53,32 @@ describe('endpoint dependent NAT traversal', () => {
           '--no-ping',
         ],
         {
-          PK_NODE_PATH: agent1NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent1NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent1Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       );
-      const { exitCode, stdout } = await testNatUtils.pkExecNs(
-        userPid!,
-        agent1Pid!,
+      const { exitCode, stdout } = await testUtils.pkExec(
         ['nodes', 'ping', agent2NodeId, '--format', 'json'],
         {
-          PK_NODE_PATH: agent1NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent1NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent1Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       );
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toEqual({
@@ -97,9 +107,7 @@ describe('endpoint dependent NAT traversal', () => {
         tearDownNAT,
       } = await testNatUtils.setupNAT('dmz', 'edm', logger);
       // Agent 2 must ping Agent 1 first, since Agent 2 is behind a NAT
-      await testNatUtils.pkExecNs(
-        userPid!,
-        agent2Pid!,
+      await testUtils.pkExec(
         [
           'nodes',
           'add',
@@ -109,21 +117,33 @@ describe('endpoint dependent NAT traversal', () => {
           '--no-ping',
         ],
         {
-          PK_NODE_PATH: agent2NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent2NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent2Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       );
       let exitCode, stdout;
-      ({ exitCode, stdout } = await testNatUtils.pkExecNs(
-        userPid!,
-        agent2Pid!,
+      ({ exitCode, stdout } = await testUtils.pkExec(
         ['nodes', 'ping', agent1NodeId, '--format', 'json'],
         {
-          PK_NODE_PATH: agent2NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent2NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent2Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toEqual({
@@ -131,15 +151,20 @@ describe('endpoint dependent NAT traversal', () => {
         message: 'Node is Active.',
       });
       // Can now ping Agent 2 (it will be expecting a response)
-      ({ exitCode, stdout } = await testNatUtils.pkExecNs(
-        userPid!,
-        agent1Pid!,
+      ({ exitCode, stdout } = await testUtils.pkExec(
         ['nodes', 'ping', agent2NodeId, '--format', 'json'],
         {
-          PK_NODE_PATH: agent1NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent1NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent1Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toEqual({
@@ -169,15 +194,20 @@ describe('endpoint dependent NAT traversal', () => {
       // since port mapping changes between targets in EDM mapping
       // Node 2 -> Node 1 ping should fail (Node 1 behind NAT)
       let exitCode, stdout;
-      ({ exitCode, stdout } = await testNatUtils.pkExecNs(
-        userPid!,
-        agent2Pid!,
+      ({ exitCode, stdout } = await testUtils.pkExec(
         ['nodes', 'ping', agent1NodeId, '--format', 'json'],
         {
-          PK_NODE_PATH: agent2NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent2NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent2Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(1);
       expect(JSON.parse(stdout)).toEqual({
@@ -185,15 +215,20 @@ describe('endpoint dependent NAT traversal', () => {
         message: `Failed to resolve node ID ${agent1NodeId} to an address.`,
       });
       // Node 1 -> Node 2 ping should also fail for the same reason
-      ({ exitCode, stdout } = await testNatUtils.pkExecNs(
-        userPid!,
-        agent1Pid!,
+      ({ exitCode, stdout } = await testUtils.pkExec(
         ['nodes', 'ping', agent2NodeId, '--format', 'json'],
         {
-          PK_NODE_PATH: agent1NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent1NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent1Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(1);
       expect(JSON.parse(stdout)).toEqual({
@@ -221,30 +256,40 @@ describe('endpoint dependent NAT traversal', () => {
       } = await testNatUtils.setupNATWithSeedNode('edm', 'eim', logger);
       // Since one of the nodes uses EDM NAT we cannot punch through
       let exitCode, stdout;
-      ({ exitCode, stdout } = await testNatUtils.pkExecNs(
-        userPid!,
-        agent2Pid!,
+      ({ exitCode, stdout } = await testUtils.pkExec(
         ['nodes', 'ping', agent1NodeId, '--format', 'json'],
         {
-          PK_NODE_PATH: agent2NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent2NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent2Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(1);
       expect(JSON.parse(stdout)).toEqual({
         success: false,
         message: `Failed to resolve node ID ${agent1NodeId} to an address.`,
       });
-      ({ exitCode, stdout } = await testNatUtils.pkExecNs(
-        userPid!,
-        agent1Pid!,
+      ({ exitCode, stdout } = await testUtils.pkExec(
         ['nodes', 'ping', agent2NodeId, '--format', 'json'],
         {
-          PK_NODE_PATH: agent1NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent1NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent1Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(1);
       expect(JSON.parse(stdout)).toEqual({

--- a/tests/nat/endpointIndependentNAT.test.ts
+++ b/tests/nat/endpointIndependentNAT.test.ts
@@ -43,9 +43,7 @@ describe('endpoint independent NAT traversal', () => {
         tearDownNAT,
       } = await testNatUtils.setupNAT('eim', 'dmz', logger);
       // Since node2 is not behind a NAT can directly add its details
-      await testNatUtils.pkExecNs(
-        userPid!,
-        agent1Pid!,
+      await testUtils.pkExec(
         [
           'nodes',
           'add',
@@ -55,20 +53,32 @@ describe('endpoint independent NAT traversal', () => {
           '--no-ping',
         ],
         {
-          PK_NODE_PATH: agent1NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent1NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent1Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       );
-      const { exitCode, stdout } = await testNatUtils.pkExecNs(
-        userPid!,
-        agent1Pid!,
+      const { exitCode, stdout } = await testUtils.pkExec(
         ['nodes', 'ping', agent2NodeId, '--format', 'json'],
         {
-          PK_NODE_PATH: agent1NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent1NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent1Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       );
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toEqual({
@@ -98,9 +108,7 @@ describe('endpoint independent NAT traversal', () => {
         agent2ProxyPort,
         tearDownNAT,
       } = await testNatUtils.setupNAT('dmz', 'eim', logger);
-      await testNatUtils.pkExecNs(
-        userPid!,
-        agent2Pid!,
+      await testUtils.pkExec(
         [
           'nodes',
           'add',
@@ -110,14 +118,19 @@ describe('endpoint independent NAT traversal', () => {
           '--no-ping',
         ],
         {
-          PK_NODE_PATH: agent2NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent2NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent2Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       );
-      await testNatUtils.pkExecNs(
-        userPid!,
-        agent1Pid!,
+      await testUtils.pkExec(
         [
           'nodes',
           'add',
@@ -127,22 +140,34 @@ describe('endpoint independent NAT traversal', () => {
           '--no-ping',
         ],
         {
-          PK_NODE_PATH: agent1NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent1NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent1Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       );
       // If we try to ping Agent 2 it will fail
       let exitCode, stdout;
-      ({ exitCode, stdout } = await testNatUtils.pkExecNs(
-        userPid!,
-        agent1Pid!,
+      ({ exitCode, stdout } = await testUtils.pkExec(
         ['nodes', 'ping', agent2NodeId, '--format', 'json'],
         {
-          PK_NODE_PATH: agent1NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent1NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent1Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(1);
       expect(JSON.parse(stdout)).toEqual({
@@ -150,15 +175,20 @@ describe('endpoint independent NAT traversal', () => {
         message: 'No response received',
       });
       // But Agent 2 can ping Agent 1 because Agent 1 is not behind a NAT
-      ({ exitCode, stdout } = await testNatUtils.pkExecNs(
-        userPid!,
-        agent2Pid!,
+      ({ exitCode, stdout } = await testUtils.pkExec(
         ['nodes', 'ping', agent1NodeId, '--format', 'json'],
         {
-          PK_NODE_PATH: agent2NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent2NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent2Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toEqual({
@@ -166,15 +196,20 @@ describe('endpoint independent NAT traversal', () => {
         message: 'Node is Active.',
       });
       // Can now ping Agent 2 (it will be expecting a response)
-      ({ exitCode, stdout } = await testNatUtils.pkExecNs(
-        userPid!,
-        agent1Pid!,
+      ({ exitCode, stdout } = await testUtils.pkExec(
         ['nodes', 'ping', agent2NodeId, '--format', 'json'],
         {
-          PK_NODE_PATH: agent1NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent1NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent1Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toEqual({
@@ -204,9 +239,7 @@ describe('endpoint independent NAT traversal', () => {
         agent2ProxyPort,
         tearDownNAT,
       } = await testNatUtils.setupNAT('dmz', 'eim', logger);
-      await testNatUtils.pkExecNs(
-        userPid!,
-        agent2Pid!,
+      await testUtils.pkExec(
         [
           'nodes',
           'add',
@@ -216,14 +249,19 @@ describe('endpoint independent NAT traversal', () => {
           '--no-ping',
         ],
         {
-          PK_NODE_PATH: agent2NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent2NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent2Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       );
-      await testNatUtils.pkExecNs(
-        userPid!,
-        agent1Pid!,
+      await testUtils.pkExec(
         [
           'nodes',
           'add',
@@ -233,22 +271,34 @@ describe('endpoint independent NAT traversal', () => {
           '--no-ping',
         ],
         {
-          PK_NODE_PATH: agent1NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent1NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent1Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       );
       // If we try to ping Agent 2 it will fail
       let exitCode, stdout;
-      ({ exitCode, stdout } = await testNatUtils.pkExecNs(
-        userPid!,
-        agent1Pid!,
+      ({ exitCode, stdout } = await testUtils.pkExec(
         ['nodes', 'ping', agent2NodeId, '--format', 'json'],
         {
-          PK_NODE_PATH: agent1NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent1NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent1Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(1);
       expect(JSON.parse(stdout)).toEqual({
@@ -256,15 +306,20 @@ describe('endpoint independent NAT traversal', () => {
         message: 'No response received',
       });
       // But Agent 2 can ping Agent 1 because it's expecting a response now
-      ({ exitCode, stdout } = await testNatUtils.pkExecNs(
-        userPid!,
-        agent2Pid!,
+      ({ exitCode, stdout } = await testUtils.pkExec(
         ['nodes', 'ping', agent1NodeId, '--format', 'json'],
         {
-          PK_NODE_PATH: agent2NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent2NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent2Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toEqual({
@@ -272,15 +327,20 @@ describe('endpoint independent NAT traversal', () => {
         message: 'Node is Active.',
       });
       // Can now ping Agent 2 (it will be expecting a response too)
-      ({ exitCode, stdout } = await testNatUtils.pkExecNs(
-        userPid!,
-        agent1Pid!,
+      ({ exitCode, stdout } = await testUtils.pkExec(
         ['nodes', 'ping', agent2NodeId, '--format', 'json'],
         {
-          PK_NODE_PATH: agent1NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent1NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent1Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toEqual({
@@ -309,30 +369,40 @@ describe('endpoint independent NAT traversal', () => {
       // Should be able to ping straight away using the seed node as a
       // signaller
       let exitCode, stdout;
-      ({ exitCode, stdout } = await testNatUtils.pkExecNs(
-        userPid!,
-        agent1Pid!,
+      ({ exitCode, stdout } = await testUtils.pkExec(
         ['nodes', 'ping', agent2NodeId, '--format', 'json'],
         {
-          PK_NODE_PATH: agent1NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent1NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent1Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toEqual({
         success: true,
         message: 'Node is Active.',
       });
-      ({ exitCode, stdout } = await testNatUtils.pkExecNs(
-        userPid!,
-        agent2Pid!,
+      ({ exitCode, stdout } = await testUtils.pkExec(
         ['nodes', 'ping', agent1NodeId, '--format', 'json'],
         {
-          PK_NODE_PATH: agent2NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent2NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent2Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(0);
       expect(JSON.parse(stdout)).toEqual({
@@ -360,30 +430,40 @@ describe('endpoint independent NAT traversal', () => {
       } = await testNatUtils.setupNATWithSeedNode('eim', 'edm', logger);
       // Since one of the nodes uses EDM NAT we cannot punch through
       let exitCode, stdout;
-      ({ exitCode, stdout } = await testNatUtils.pkExecNs(
-        userPid!,
-        agent2Pid!,
+      ({ exitCode, stdout } = await testUtils.pkExec(
         ['nodes', 'ping', agent1NodeId, '--format', 'json'],
         {
-          PK_NODE_PATH: agent2NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent2NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent2Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(1);
       expect(JSON.parse(stdout)).toEqual({
         success: false,
         message: `Failed to resolve node ID ${agent1NodeId} to an address.`,
       });
-      ({ exitCode, stdout } = await testNatUtils.pkExecNs(
-        userPid!,
-        agent1Pid!,
+      ({ exitCode, stdout } = await testUtils.pkExec(
         ['nodes', 'ping', agent2NodeId, '--format', 'json'],
         {
-          PK_NODE_PATH: agent1NodePath,
-          PK_PASSWORD: password,
+          env: {
+            PK_NODE_PATH: agent1NodePath,
+            PK_PASSWORD: password,
+          },
+          command: `nsenter ${testNatUtils
+            .nsenter(userPid!, agent1Pid!)
+            .join(' ')} ts-node --project ${testUtils.tsConfigPath} ${
+            testUtils.polykeyPath
+          }`,
+          cwd: dataDir,
         },
-        dataDir,
       ));
       expect(exitCode).toBe(1);
       expect(JSON.parse(stdout)).toEqual({

--- a/tests/nodes/NodeConnection.test.ts
+++ b/tests/nodes/NodeConnection.test.ts
@@ -2,7 +2,7 @@ import type { AddressInfo } from 'net';
 import type { ConnectionInfo, Host, Port, TLSConfig } from '@/network/types';
 import type { NodeId, NodeInfo } from '@/nodes/types';
 import type { Server } from '@grpc/grpc-js';
-import type * as child_process from 'child_process';
+import type { ChildProcessWithoutNullStreams } from 'child_process';
 import net from 'net';
 import os from 'os';
 import path from 'path';
@@ -38,7 +38,7 @@ import * as testNodesUtils from './utils';
 import * as grpcTestUtils from '../grpc/utils';
 import * as agentTestUtils from '../agent/utils';
 import { globalRootKeyPems } from '../fixtures/globalRootKeyPems';
-import { spawnFile } from '../utils/exec';
+import * as testUtils from '../utils';
 
 const destroyCallback = async () => {};
 
@@ -733,14 +733,25 @@ describe(`${NodeConnection.name} test`, () => {
         | NodeConnection<grpcTestUtils.GRPCClientTest>
         | undefined;
       let testProxy: Proxy | undefined;
-      let testProcess: child_process.ChildProcessWithoutNullStreams | undefined;
+      let testProcess: ChildProcessWithoutNullStreams | undefined;
       try {
-        const testProcess = spawnFile('tests/grpc/utils/testServer.ts');
+        const testProcess = await testUtils.spawn(
+          'ts-node',
+          [
+            '--project',
+            testUtils.tsConfigPath,
+            `${globalThis.testDir}/grpc/utils/testServer.ts`,
+          ],
+          undefined,
+          logger,
+        );
         const waitP = promise<string>();
-        testProcess.stdout.on('data', (data) => {
+        testProcess.stdout!.on('data', (data) => {
           waitP.resolveP(data);
         });
-        // TestProcess.stderr.on('data', data => console.log(data.toString()));
+        testProcess.stderr!.on('data', (data) =>
+          waitP.rejectP(data.toString()),
+        );
 
         // Lets make a reverse proxy
         testProxy = new Proxy({
@@ -799,14 +810,25 @@ describe(`${NodeConnection.name} test`, () => {
         | NodeConnection<grpcTestUtils.GRPCClientTest>
         | undefined;
       let testProxy: Proxy | undefined;
-      let testProcess: child_process.ChildProcessWithoutNullStreams | undefined;
+      let testProcess: ChildProcessWithoutNullStreams | undefined;
       try {
-        const testProcess = spawnFile('tests/grpc/utils/testServer.ts');
+        const testProcess = await testUtils.spawn(
+          'ts-node',
+          [
+            '--project',
+            testUtils.tsConfigPath,
+            `${globalThis.testDir}/grpc/utils/testServer.ts`,
+          ],
+          undefined,
+          logger,
+        );
         const waitP = promise<string>();
-        testProcess.stdout.on('data', (data) => {
+        testProcess.stdout!.on('data', (data) => {
           waitP.resolveP(data);
         });
-        // TestProcess.stderr.on('data', data => console.log(data.toString()));
+        testProcess.stderr!.on('data', (data) =>
+          waitP.rejectP(data.toString()),
+        );
 
         // Lets make a reverse proxy
         testProxy = new Proxy({

--- a/tests/vaults/VaultManager.test.ts
+++ b/tests/vaults/VaultManager.test.ts
@@ -32,7 +32,7 @@ import * as vaultsUtils from '@/vaults/utils';
 import { sleep } from '@/utils';
 import VaultInternal from '@/vaults/VaultInternal';
 import * as nodeTestUtils from '../nodes/utils';
-import { expectRemoteError } from '../utils';
+import * as testUtils from '../utils';
 import { globalRootKeyPems } from '../fixtures/globalRootKeyPems';
 
 describe('VaultManager', () => {
@@ -746,7 +746,7 @@ describe('VaultManager', () => {
           'pull',
         );
 
-        await expectRemoteError(
+        await testUtils.expectRemoteError(
           vaultManager.cloneVault(
             remoteKeynode1Id,
             'not-existing' as VaultName,
@@ -835,7 +835,7 @@ describe('VaultManager', () => {
       });
       try {
         // Should reject with no permissions set
-        await expectRemoteError(
+        await testUtils.expectRemoteError(
           vaultManager.cloneVault(remoteKeynode1Id, remoteVaultId),
           vaultsErrors.ErrorVaultsPermissionDenied,
         );
@@ -878,7 +878,7 @@ describe('VaultManager', () => {
           remoteVaultId,
         );
 
-        await expectRemoteError(
+        await testUtils.expectRemoteError(
           vaultManager.pullVault({ vaultId: clonedVaultId }),
           vaultsErrors.ErrorVaultsPermissionDenied,
         );
@@ -1564,13 +1564,13 @@ describe('VaultManager', () => {
           // Should throw
         }
       };
-      await expectRemoteError(
+      await testUtils.expectRemoteError(
         testFun(),
         vaultsErrors.ErrorVaultsPermissionDenied,
       );
       // Should throw due to lack of scan permission
       await remoteAgent.gestaltGraph.setGestaltActionByNode(nodeId1, 'notify');
-      await expectRemoteError(
+      await testUtils.expectRemoteError(
         testFun(),
         vaultsErrors.ErrorVaultsPermissionDenied,
       );


### PR DESCRIPTION
### Description
There are many ways of running our tests across different platforms, and this should be standardised.

- Our `pkExec`/`pkSpawn`/`pkExpect` methods should have a default and override implementation. Default should run polykey as normal while the override should run polykey from a different entrypoint. The override should be taken from an argument first and then from an environment variable.
- The remaining methods should not have override implementations, as these are meant for special cases (e.g. mocking for `pkStdio` and general process execution for `exec`). All places in the code where such methods are used and these special cases do not apply should switch over to using `pkExec` or similar.
- The override methods should be exported as well as the defaults to be used for edge cases.

We will need to ensure that signals and events are still handled correctly after making these changes.

### Issues Fixed
* Fixes #432 

### Tasks
- [x] 1. Move test/utils.ts into tests/utils/utils.ts and create tests/utils/index.ts
- [x] 2. Change the pkExec, pkSpawn, ~~pkExpect~~ signatures to taken an options object at the very end for the command, env, and cwd
- [x] 3. Refactor pkExec, pkSpawn, ~~pkExpect~~ according to spec in #432 
- [x] 4. Remove pkExecNs and pkSpawnNS and replace with pkExec and pkSpawn with command override options
- [x] 5. Incorporate https://eslint.org/docs/latest/rules/no-restricted-globals

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
