### PR TITLE
feat: centralising all ID types and utilities under `ids` domain

### DIFF
--- a/src/PolykeyClient.ts
+++ b/src/PolykeyClient.ts
@@ -1,5 +1,5 @@
 import type { FileSystem, Timer } from './types';
-import type { NodeId } from './nodes/types';
+import type { NodeId } from './ids/types';
 import type { Host, Port } from './network/types';
 import path from 'path';
 import Logger from '@matrixai/logger';

--- a/src/acl/ACL.ts
+++ b/src/acl/ACL.ts
@@ -5,7 +5,7 @@ import type {
   Permission,
   VaultActions,
 } from './types';
-import type { NodeId } from '../nodes/types';
+import type { NodeId } from '../ids/types';
 import type { GestaltAction } from '../gestalts/types';
 import type { VaultAction, VaultId } from '../vaults/types';
 import type { Ref } from '../types';

--- a/src/acl/types.ts
+++ b/src/acl/types.ts
@@ -1,10 +1,6 @@
-import type { Opaque } from '../types';
+import type { PermissionId, PermissionIdString } from '../ids/types';
 import type { GestaltAction } from '../gestalts/types';
 import type { VaultActions, VaultIdString } from '../vaults/types';
-import type { Id } from '@matrixai/id';
-
-type PermissionId = Opaque<'PermissionId', Id>;
-type PermissionIdString = Opaque<'PermissionIdString', string>;
 
 type Permission = {
   gestalt: GestaltActions;

--- a/src/acl/utils.ts
+++ b/src/acl/utils.ts
@@ -1,10 +1,5 @@
-import type { Permission, PermissionId } from './types';
-import { IdRandom } from '@matrixai/id';
-
-function createPermIdGenerator() {
-  const generator = new IdRandom<PermissionId>();
-  return () => generator.get();
-}
+import type { Permission } from './types';
+import { createPermIdGenerator } from '../ids';
 
 function permUnion(perm1: Permission, perm2: Permission): Permission {
   const vaults = {

--- a/src/agent/GRPCClientAgent.ts
+++ b/src/agent/GRPCClientAgent.ts
@@ -4,7 +4,7 @@ import type {
   AsyncGeneratorReadableStreamClient,
   AsyncGeneratorDuplexStreamClient,
 } from '../grpc/types';
-import type { NodeId } from '../nodes/types';
+import type { NodeId } from '../ids/types';
 import type { Host, Port, ProxyConfig, TLSConfig } from '../network/types';
 import type * as utilsPB from '../proto/js/polykey/v1/utils/utils_pb';
 import type * as vaultsPB from '../proto/js/polykey/v1/vaults/vaults_pb';

--- a/src/agent/service/nodesClosestLocalNodesGet.ts
+++ b/src/agent/service/nodesClosestLocalNodesGet.ts
@@ -1,7 +1,7 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { NodeGraph } from '../../nodes';
 import type { DB } from '@matrixai/db';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import type Logger from '@matrixai/logger';
 import * as grpcUtils from '../../grpc/utils';
 import * as nodesUtils from '../../nodes/utils';

--- a/src/agent/service/nodesCrossSignClaim.ts
+++ b/src/agent/service/nodesCrossSignClaim.ts
@@ -2,7 +2,7 @@ import type * as grpc from '@grpc/grpc-js';
 import type { DB } from '@matrixai/db';
 import type { ClaimEncoded, ClaimIntermediary } from '../../claims/types';
 import type NodeManager from '../../nodes/NodeManager';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import type Sigchain from '../../sigchain/Sigchain';
 import type KeyManager from '../../keys/KeyManager';
 import type * as nodesPB from '../../proto/js/polykey/v1/nodes/nodes_pb';

--- a/src/agent/service/nodesHolePunchMessageSend.ts
+++ b/src/agent/service/nodesHolePunchMessageSend.ts
@@ -3,7 +3,7 @@ import type { DB } from '@matrixai/db';
 import type NodeManager from '../../nodes/NodeManager';
 import type NodeConnectionManager from '../../nodes/NodeConnectionManager';
 import type KeyManager from '../../keys/KeyManager';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import type * as nodesPB from '../../proto/js/polykey/v1/nodes/nodes_pb';
 import type Logger from '@matrixai/logger';
 import * as networkUtils from '../../network/utils';

--- a/src/bin/nodes/CommandAdd.ts
+++ b/src/bin/nodes/CommandAdd.ts
@@ -1,5 +1,5 @@
 import type PolykeyClient from '../../PolykeyClient';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import type { Host, Port } from '../../network/types';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils/utils';

--- a/src/bin/nodes/CommandClaim.ts
+++ b/src/bin/nodes/CommandClaim.ts
@@ -1,5 +1,5 @@
 import type PolykeyClient from '../../PolykeyClient';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';

--- a/src/bin/nodes/CommandFind.ts
+++ b/src/bin/nodes/CommandFind.ts
@@ -1,5 +1,5 @@
 import type PolykeyClient from '../../PolykeyClient';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import type { Host, Port } from '../../network/types';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';

--- a/src/bin/nodes/CommandPing.ts
+++ b/src/bin/nodes/CommandPing.ts
@@ -1,5 +1,5 @@
 import type PolykeyClient from '../../PolykeyClient';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';

--- a/src/bin/notifications/CommandSend.ts
+++ b/src/bin/notifications/CommandSend.ts
@@ -1,5 +1,5 @@
 import type PolykeyClient from '../../PolykeyClient';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';

--- a/src/bin/types.ts
+++ b/src/bin/types.ts
@@ -3,7 +3,7 @@ import type { POJO } from '../types';
 import type { RecoveryCode } from '../keys/types';
 import type { Host, Port } from '../network/types';
 import type { StatusLive } from '../status/types';
-import type { NodeIdEncoded } from '../nodes/types';
+import type { NodeIdEncoded } from '../ids/types';
 
 type AgentStatusLiveData = Omit<StatusLive['data'], 'nodeId'> & {
   nodeId: NodeIdEncoded;

--- a/src/bin/utils/processors.ts
+++ b/src/bin/utils/processors.ts
@@ -1,6 +1,6 @@
 import type { FileSystem } from '../../types';
 import type { RecoveryCode, PrivateKeyPem } from '../../keys/types';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import type { Host, Port } from '../../network/types';
 import type {
   StatusStarting,

--- a/src/bin/vaults/CommandClone.ts
+++ b/src/bin/vaults/CommandClone.ts
@@ -1,5 +1,5 @@
 import type PolykeyClient from '../../PolykeyClient';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';

--- a/src/bin/vaults/CommandPull.ts
+++ b/src/bin/vaults/CommandPull.ts
@@ -1,5 +1,5 @@
 import type PolykeyClient from '../../PolykeyClient';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';

--- a/src/bin/vaults/CommandShare.ts
+++ b/src/bin/vaults/CommandShare.ts
@@ -1,5 +1,5 @@
 import type PolykeyClient from '../../PolykeyClient';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';

--- a/src/bin/vaults/CommandUnshare.ts
+++ b/src/bin/vaults/CommandUnshare.ts
@@ -1,5 +1,5 @@
 import type PolykeyClient from '../../PolykeyClient';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import CommandPolykey from '../CommandPolykey';
 import * as binUtils from '../utils';
 import * as binOptions from '../utils/options';

--- a/src/claims/types.ts
+++ b/src/claims/types.ts
@@ -1,7 +1,6 @@
-import type { Id } from '@matrixai/id';
 import type { GeneralJWS, FlattenedJWSInput } from 'jose';
-import type { Opaque } from '../types';
-import type { NodeIdEncoded } from '../nodes/types';
+import type { ClaimId, ClaimIdString, ClaimIdEncoded } from '../ids/types';
+import type { NodeIdEncoded } from '../ids/types';
 import type { ProviderId, IdentityId } from '../identities/types';
 
 /**
@@ -41,18 +40,6 @@ type SignatureData = {
     kid: NodeIdEncoded; // Node ID of the signing keynode
   };
 };
-
-/**
- * An arbitrary string serving as a unique identitifer for a particular claim.
- * Depending on the domain the claim is used in, its implementation detail will
- * differ. For example, the sigchain domain uses a lexicographic-integer as the
- * claim ID (representing the sequence number key of the claim).
- */
-type ClaimId = Opaque<'ClaimId', Id>;
-type ClaimIdString = Opaque<'ClaimIdString', string>;
-type ClaimIdEncoded = Opaque<'ClaimIdEncoded', string>;
-
-type ClaimIdGenerator = () => ClaimId;
 
 /**
  * A ClaimEncoded is an encoded version of Claim. It is exactly a JWS using
@@ -107,7 +94,6 @@ export type {
   ClaimId,
   ClaimIdString,
   ClaimIdEncoded,
-  ClaimIdGenerator,
   ClaimEncoded,
   ClaimData,
   ClaimLinkNode,

--- a/src/claims/utils.ts
+++ b/src/claims/utils.ts
@@ -1,13 +1,11 @@
 import type {
-  ClaimId,
-  ClaimIdEncoded,
   Claim,
   ClaimEncoded,
   ClaimData,
   SignatureData,
   ClaimIntermediary,
 } from './types';
-import type { NodeId, NodeIdEncoded } from '../nodes/types';
+import type { NodeIdEncoded } from '../ids/types';
 import type { PublicKeyPem, PrivateKeyPem } from '../keys/types';
 import type { POJO } from '../types';
 import type { GeneralJWSInput } from 'jose';
@@ -16,13 +14,13 @@ import { createPublicKey, createPrivateKey } from 'crypto';
 import { md } from 'node-forge';
 import canonicalize from 'canonicalize';
 import { GeneralSign, generalVerify, generateKeyPair, base64url } from 'jose';
-import { IdInternal, IdSortable } from '@matrixai/id';
 import {
   claimIdentityValidate,
   claimNodeSinglySignedValidate,
   claimNodeDoublySignedValidate,
 } from './schema';
 import * as claimsErrors from './errors';
+import { createClaimIdGenerator, encodeClaimId, decodeClaimId } from '../ids';
 import * as nodesPB from '../proto/js/polykey/v1/nodes/nodes_pb';
 
 /**
@@ -478,30 +476,6 @@ function reconstructClaimEncoded(claimMsg: nodesPB.AgentClaim): ClaimEncoded {
     }),
   };
   return claim;
-}
-
-function encodeClaimId(claimId: ClaimId): ClaimIdEncoded {
-  return claimId.toMultibase('base32hex') as ClaimIdEncoded;
-}
-
-function decodeClaimId(claimIdEncoded: string): ClaimId | undefined {
-  const claimId = IdInternal.fromMultibase<ClaimId>(claimIdEncoded);
-  if (claimId == null) {
-    return;
-  }
-  return claimId;
-}
-
-/**
- * Generator for `ClaimId`
- * Make sure the `nodeId` is set to this node's own `NodeId`
- */
-function createClaimIdGenerator(nodeId: NodeId, lastClaimId?: ClaimId) {
-  const generator = new IdSortable<ClaimId>({
-    lastId: lastClaimId,
-    nodeId,
-  });
-  return () => generator.get();
 }
 
 export {

--- a/src/client/GRPCClientClient.ts
+++ b/src/client/GRPCClientClient.ts
@@ -2,7 +2,7 @@ import type { Interceptor } from '@grpc/grpc-js';
 import type { ClientReadableStream } from '@grpc/grpc-js/build/src/call';
 import type { AsyncGeneratorReadableStreamClient } from '../grpc/types';
 import type { Session } from '../sessions';
-import type { NodeId } from '../nodes/types';
+import type { NodeId } from '../ids/types';
 import type { Host, Port, ProxyConfig, TLSConfig } from '../network/types';
 import type * as utilsPB from '../proto/js/polykey/v1/utils/utils_pb';
 import type * as agentPB from '../proto/js/polykey/v1/agent/agent_pb';

--- a/src/client/service/gestaltsActionsGetByNode.ts
+++ b/src/client/service/gestaltsActionsGetByNode.ts
@@ -1,7 +1,7 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { DB } from '@matrixai/db';
 import type { Authenticate } from '../types';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import type GestaltGraph from '../../gestalts/GestaltGraph';
 import type * as nodesPB from '../../proto/js/polykey/v1/nodes/nodes_pb';
 import type Logger from '@matrixai/logger';

--- a/src/client/service/gestaltsActionsSetByNode.ts
+++ b/src/client/service/gestaltsActionsSetByNode.ts
@@ -3,7 +3,7 @@ import type { DB } from '@matrixai/db';
 import type { Authenticate } from '../types';
 import type GestaltGraph from '../../gestalts/GestaltGraph';
 import type { GestaltAction } from '../../gestalts/types';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import type * as permissionsPB from '../../proto/js/polykey/v1/permissions/permissions_pb';
 import type Logger from '@matrixai/logger';
 import * as grpcUtils from '../../grpc/utils';

--- a/src/client/service/gestaltsActionsUnsetByNode.ts
+++ b/src/client/service/gestaltsActionsUnsetByNode.ts
@@ -3,7 +3,7 @@ import type { DB } from '@matrixai/db';
 import type { Authenticate } from '../types';
 import type GestaltGraph from '../../gestalts/GestaltGraph';
 import type { GestaltAction } from '../../gestalts/types';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import type * as permissionsPB from '../../proto/js/polykey/v1/permissions/permissions_pb';
 import type Logger from '@matrixai/logger';
 import * as grpcUtils from '../../grpc/utils';

--- a/src/client/service/gestaltsDiscoveryByNode.ts
+++ b/src/client/service/gestaltsDiscoveryByNode.ts
@@ -1,7 +1,7 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { Authenticate } from '../types';
 import type Discovery from '../../discovery/Discovery';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import type * as nodesPB from '../../proto/js/polykey/v1/nodes/nodes_pb';
 import type Logger from '@matrixai/logger';
 import { validateSync } from '../../validation';

--- a/src/client/service/gestaltsGestaltGetByNode.ts
+++ b/src/client/service/gestaltsGestaltGetByNode.ts
@@ -1,7 +1,7 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { DB } from '@matrixai/db';
 import type { Authenticate } from '../types';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import type GestaltGraph from '../../gestalts/GestaltGraph';
 import type * as nodesPB from '../../proto/js/polykey/v1/nodes/nodes_pb';
 import type Logger from '@matrixai/logger';

--- a/src/client/service/gestaltsGestaltTrustByNode.ts
+++ b/src/client/service/gestaltsGestaltTrustByNode.ts
@@ -3,7 +3,7 @@ import type { DB } from '@matrixai/db';
 import type { Authenticate } from '../types';
 import type GestaltGraph from '../../gestalts/GestaltGraph';
 import type Discovery from '../../discovery/Discovery';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import type * as nodesPB from '../../proto/js/polykey/v1/nodes/nodes_pb';
 import type Logger from '@matrixai/logger';
 import { validateSync } from '../../validation';

--- a/src/client/service/nodesClaim.ts
+++ b/src/client/service/nodesClaim.ts
@@ -2,7 +2,7 @@ import type * as grpc from '@grpc/grpc-js';
 import type { DB } from '@matrixai/db';
 import type { Authenticate } from '../types';
 import type NodeManager from '../../nodes/NodeManager';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import type NotificationsManager from '../../notifications/NotificationsManager';
 import type * as nodesPB from '../../proto/js/polykey/v1/nodes/nodes_pb';
 import type Logger from '@matrixai/logger';

--- a/src/client/service/nodesFind.ts
+++ b/src/client/service/nodesFind.ts
@@ -1,7 +1,7 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { Authenticate } from '../types';
 import type NodeConnectionManager from '../../nodes/NodeConnectionManager';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import type Logger from '@matrixai/logger';
 import * as nodesUtils from '../../nodes/utils';
 import * as nodesErrors from '../../nodes/errors';

--- a/src/client/service/nodesGetAll.ts
+++ b/src/client/service/nodesGetAll.ts
@@ -2,7 +2,7 @@ import type * as grpc from '@grpc/grpc-js';
 import type Logger from '@matrixai/logger';
 import type { Authenticate } from '../types';
 import type KeyManager from '../../keys/KeyManager';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import type * as utilsPB from '../../proto/js/polykey/v1/utils/utils_pb';
 import type NodeGraph from '../../nodes/NodeGraph';
 import { IdInternal } from '@matrixai/id';

--- a/src/client/service/nodesPing.ts
+++ b/src/client/service/nodesPing.ts
@@ -1,7 +1,7 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { Authenticate } from '../types';
 import type NodeManager from '../../nodes/NodeManager';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import type * as nodesPB from '../../proto/js/polykey/v1/nodes/nodes_pb';
 import type Logger from '@matrixai/logger';
 import * as grpcUtils from '../../grpc/utils';

--- a/src/client/service/notificationsSend.ts
+++ b/src/client/service/notificationsSend.ts
@@ -1,7 +1,7 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { Authenticate } from '../types';
 import type NotificationsManager from '../../notifications/NotificationsManager';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import type * as notificationsPB from '../../proto/js/polykey/v1/notifications/notifications_pb';
 import type Logger from '@matrixai/logger';
 import * as grpcUtils from '../../grpc/utils';

--- a/src/client/service/vaultsClone.ts
+++ b/src/client/service/vaultsClone.ts
@@ -1,7 +1,7 @@
 import type { DB } from '@matrixai/db';
 import type { Authenticate } from '../types';
 import type VaultManager from '../../vaults/VaultManager';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import type * as vaultsPB from '../../proto/js/polykey/v1/vaults/vaults_pb';
 import type Logger from '@matrixai/logger';
 import type * as grpc from '@grpc/grpc-js';

--- a/src/client/service/vaultsPermissionSet.ts
+++ b/src/client/service/vaultsPermissionSet.ts
@@ -1,6 +1,6 @@
 import type { DB } from '@matrixai/db';
 import type { Authenticate } from '../types';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import type { VaultName, VaultAction, VaultActions } from '../../vaults/types';
 import type VaultManager from '../../vaults/VaultManager';
 import type GestaltGraph from '../../gestalts/GestaltGraph';

--- a/src/client/service/vaultsPermissionUnset.ts
+++ b/src/client/service/vaultsPermissionUnset.ts
@@ -1,6 +1,6 @@
 import type { DB } from '@matrixai/db';
 import type { Authenticate } from '../types';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import type { VaultName, VaultAction } from '../../vaults/types';
 import type VaultManager from '../../vaults/VaultManager';
 import type GestaltGraph from '../../gestalts/GestaltGraph';

--- a/src/client/service/vaultsPull.ts
+++ b/src/client/service/vaultsPull.ts
@@ -2,7 +2,7 @@ import type { DB } from '@matrixai/db';
 import type { Authenticate } from '../types';
 import type VaultManager from '../../vaults/VaultManager';
 import type { VaultName } from '../../vaults/types';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import type * as vaultsPB from '../../proto/js/polykey/v1/vaults/vaults_pb';
 import type Logger from '@matrixai/logger';
 import type * as grpc from '@grpc/grpc-js';

--- a/src/client/service/vaultsScan.ts
+++ b/src/client/service/vaultsScan.ts
@@ -1,5 +1,5 @@
 import type { Authenticate } from '../types';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import type * as nodesPB from '../../proto/js/polykey/v1/nodes/nodes_pb';
 import type * as grpc from '@grpc/grpc-js';
 import type VaultManager from '../../vaults/VaultManager';

--- a/src/gestalts/utils.ts
+++ b/src/gestalts/utils.ts
@@ -7,7 +7,7 @@ import type {
   GestaltIdentityId,
   GestaltAction,
 } from './types';
-import type { NodeId } from '../nodes/types';
+import type { NodeId } from '../ids/types';
 import type { IdentityId, ProviderId } from '../identities/types';
 import canonicalize from 'canonicalize';
 import { gestaltActions } from './types';

--- a/src/grpc/GRPCClient.ts
+++ b/src/grpc/GRPCClient.ts
@@ -6,7 +6,7 @@ import type {
   ChannelOptions,
   Interceptor,
 } from '@grpc/grpc-js';
-import type { NodeId } from '../nodes/types';
+import type { NodeId } from '../ids/types';
 import type { Certificate } from '../keys/types';
 import type { Host, Port, TLSConfig, ProxyConfig } from '../network/types';
 import type { Timer } from '../types';

--- a/src/grpc/types.ts
+++ b/src/grpc/types.ts
@@ -8,7 +8,7 @@ import type {
   UntypedServiceImplementation,
   Metadata,
 } from '@grpc/grpc-js';
-import type { NodeId } from '../nodes/types';
+import type { NodeId } from '../ids/types';
 import type { Host, Port } from '../network/types';
 import type { POJO } from '../types';
 

--- a/src/grpc/utils/utils.ts
+++ b/src/grpc/utils/utils.ts
@@ -30,7 +30,7 @@ import type {
 import type { CertificatePemChain, PrivateKeyPem } from '../../keys/types';
 import type { POJO } from '../../types';
 import type { ClientMetadata } from '../types';
-import type { NodeId } from '../../nodes/types';
+import type { NodeId } from '../../ids/types';
 import { Buffer } from 'buffer';
 import { AbstractError } from '@matrixai/errors';
 import * as grpc from '@grpc/grpc-js';

--- a/src/ids/index.ts
+++ b/src/ids/index.ts
@@ -1,0 +1,193 @@
+import type {
+  PermissionId,
+  CertificateId,
+  CertificateIdEncoded,
+  NodeId,
+  NodeIdEncoded,
+  VaultId,
+  VaultIdEncoded,
+  TaskId,
+  TaskIdEncoded,
+  ClaimId,
+  ClaimIdEncoded,
+  NotificationId,
+} from './types';
+import { IdInternal, IdSortable, IdRandom } from '@matrixai/id';
+
+function createPermIdGenerator() {
+  const generator = new IdRandom<PermissionId>();
+  return () => generator.get();
+}
+
+/**
+ * Encodes the NodeId as a `base32hex` string
+ */
+function encodeNodeId(nodeId: NodeId): NodeIdEncoded {
+  return nodeId.toMultibase('base32hex') as NodeIdEncoded;
+}
+
+/**
+ * Decodes an encoded NodeId string into a NodeId
+ */
+function decodeNodeId(nodeIdEncoded: any): NodeId | undefined {
+  if (typeof nodeIdEncoded !== 'string') {
+    return;
+  }
+  const nodeId = IdInternal.fromMultibase<NodeId>(nodeIdEncoded);
+  if (nodeId == null) {
+    return;
+  }
+  // All NodeIds are 32 bytes long
+  // The NodeGraph requires a fixed size for Node Ids
+  if (nodeId.length !== 32) {
+    return;
+  }
+  return nodeId;
+}
+
+/**
+ * Generates CertificateId
+ */
+function createCertIdGenerator(
+  lastCertId?: CertificateId,
+): () => CertificateId {
+  const generator = new IdSortable<CertificateId>({
+    lastId: lastCertId,
+  });
+  return () => generator.get();
+}
+
+/**
+ * Encodes `CertificateId` to `CertificateIdEncoded`
+ */
+function encodeCertId(certId: CertificateId): CertificateIdEncoded {
+  return certId.toMultibase('base32hex') as CertificateIdEncoded;
+}
+
+/**
+ * Decodes `CertificateIdEncoded` to `CertificateId`
+ */
+function decodeCertId(certIdEncoded: unknown): CertificateId | undefined {
+  if (typeof certIdEncoded !== 'string') {
+    return;
+  }
+  const certId = IdInternal.fromMultibase<CertificateId>(certIdEncoded);
+  if (certId == null) {
+    return;
+  }
+  // All `CertificateId` are 16 bytes long
+  if (certId.length !== 16) {
+    return;
+  }
+  return certId;
+}
+
+function createVaultIdGenerator(): () => VaultId {
+  const generator = new IdRandom<VaultId>();
+  return () => generator.get();
+}
+
+function encodeVaultId(vaultId: VaultId): VaultIdEncoded {
+  return vaultId.toMultibase('base58btc') as VaultIdEncoded;
+}
+
+function decodeVaultId(vaultIdEncoded: any): VaultId | undefined {
+  if (typeof vaultIdEncoded !== 'string') return;
+  const vaultId = IdInternal.fromMultibase<VaultId>(vaultIdEncoded);
+  if (vaultId == null) return;
+  // All VaultIds are 16 bytes long
+  if (vaultId.length !== 16) return;
+  return vaultId;
+}
+
+/**
+ * Generates TaskId
+ * TaskIds are lexicographically sortable 128 bit IDs
+ * They are strictly monotonic and unique with respect to the `nodeId`
+ * When the `NodeId` changes, make sure to regenerate this generator
+ */
+function createTaskIdGenerator(lastTaskId?: TaskId) {
+  const generator = new IdSortable<TaskId>({
+    lastId: lastTaskId,
+  });
+  return () => generator.get();
+}
+
+/**
+ * Encodes the TaskId as a `base32hex` string
+ */
+function encodeTaskId(taskId: TaskId): TaskIdEncoded {
+  return taskId.toMultibase('base32hex') as TaskIdEncoded;
+}
+
+/**
+ * Decodes an encoded TaskId string into a TaskId
+ */
+function decodeTaskId(taskIdEncoded: any): TaskId | undefined {
+  if (typeof taskIdEncoded !== 'string') {
+    return;
+  }
+  const taskId = IdInternal.fromMultibase<TaskId>(taskIdEncoded);
+  if (taskId == null) {
+    return;
+  }
+  // All TaskIds are 16 bytes long
+  if (taskId.length !== 16) {
+    return;
+  }
+  return taskId;
+}
+
+/**
+ * Generator for `ClaimId`
+ * Make sure the `nodeId` is set to this node's own `NodeId`
+ */
+function createClaimIdGenerator(nodeId: NodeId, lastClaimId?: ClaimId) {
+  const generator = new IdSortable<ClaimId>({
+    lastId: lastClaimId,
+    nodeId,
+  });
+  return () => generator.get();
+}
+
+function encodeClaimId(claimId: ClaimId): ClaimIdEncoded {
+  return claimId.toMultibase('base32hex') as ClaimIdEncoded;
+}
+
+function decodeClaimId(claimIdEncoded: string): ClaimId | undefined {
+  const claimId = IdInternal.fromMultibase<ClaimId>(claimIdEncoded);
+  if (claimId == null) {
+    return;
+  }
+  return claimId;
+}
+
+function createNotificationIdGenerator(
+  lastId?: NotificationId,
+): () => NotificationId {
+  const generator = new IdSortable<NotificationId>({
+    lastId,
+  });
+  return () => generator.get();
+}
+
+export {
+  createPermIdGenerator,
+  encodeNodeId,
+  decodeNodeId,
+  createCertIdGenerator,
+  encodeCertId,
+  decodeCertId,
+  createVaultIdGenerator,
+  encodeVaultId,
+  decodeVaultId,
+  createTaskIdGenerator,
+  encodeTaskId,
+  decodeTaskId,
+  createClaimIdGenerator,
+  encodeClaimId,
+  decodeClaimId,
+  createNotificationIdGenerator,
+};
+
+export * from './types';

--- a/src/ids/types.ts
+++ b/src/ids/types.ts
@@ -1,0 +1,61 @@
+import type { Id } from '@matrixai/id';
+import type { Opaque } from '../types';
+
+type PermissionId = Opaque<'PermissionId', Id>;
+type PermissionIdString = Opaque<'PermissionIdString', string>;
+
+type CertificateId = Opaque<'CertificateId', Id>;
+type CertificateIdString = Opaque<'CertificateIdString', string>;
+type CertificateIdEncoded = Opaque<'CertificateIdEncoded', string>;
+
+type NodeId = Opaque<'NodeId', Id>;
+type NodeIdString = Opaque<'NodeIdString', string>;
+type NodeIdEncoded = Opaque<'NodeIdEncoded', string>;
+
+type VaultId = Opaque<'VaultId', Id>;
+type VaultIdString = Opaque<'VaultIdString', string>;
+type VaultIdEncoded = Opaque<'VaultIdEncoded', string>;
+
+type TaskId = Opaque<'TaskId', Id>;
+type TaskIdString = Opaque<'TaskIdEncoded', string>;
+type TaskIdEncoded = Opaque<'TaskIdEncoded', string>;
+
+type TaskHandlerId = Opaque<'TaskHandlerId', string>;
+
+/**
+ * An arbitrary string serving as a unique identitifer for a particular claim.
+ * Depending on the domain the claim is used in, its implementation detail will
+ * differ. For example, the sigchain domain uses a lexicographic-integer as the
+ * claim ID (representing the sequence number key of the claim).
+ */
+type ClaimId = Opaque<'ClaimId', Id>;
+type ClaimIdString = Opaque<'ClaimIdString', string>;
+type ClaimIdEncoded = Opaque<'ClaimIdEncoded', string>;
+
+type NotificationId = Opaque<'NotificationId', Id>;
+type NotificationIdString = Opaque<'NotificationIdString', string>;
+type NotificationIdEncoded = Opaque<'NotificationIdEncoded', string>;
+
+export type {
+  PermissionId,
+  PermissionIdString,
+  CertificateId,
+  CertificateIdString,
+  CertificateIdEncoded,
+  NodeId,
+  NodeIdString,
+  NodeIdEncoded,
+  VaultId,
+  VaultIdString,
+  VaultIdEncoded,
+  TaskId,
+  TaskIdString,
+  TaskIdEncoded,
+  TaskHandlerId,
+  ClaimId,
+  ClaimIdString,
+  ClaimIdEncoded,
+  NotificationId,
+  NotificationIdString,
+  NotificationIdEncoded,
+};

--- a/src/keys/KeyManager.ts
+++ b/src/keys/KeyManager.ts
@@ -9,7 +9,7 @@ import type {
   PrivateKeyPem,
 } from './types';
 import type { FileSystem } from '../types';
-import type { NodeId } from '../nodes/types';
+import type { NodeId } from '../ids/types';
 import type { PolykeyWorkerManagerInterface } from '../workers/types';
 import path from 'path';
 import { Buffer } from 'buffer';

--- a/src/keys/types.ts
+++ b/src/keys/types.ts
@@ -1,6 +1,11 @@
 import type { asn1, pki } from 'node-forge';
-import type { NodeId } from '../nodes/types';
 import type { Opaque } from '../types';
+import type {
+  CertificateId,
+  CertificateIdString,
+  CertificateIdEncoded,
+  NodeId,
+} from '../ids/types';
 
 type PublicKey = pki.rsa.PublicKey;
 type PrivateKey = pki.rsa.PrivateKey;
@@ -33,6 +38,9 @@ type KeyManagerChangeData = {
 };
 
 export type {
+  CertificateId,
+  CertificateIdString,
+  CertificateIdEncoded,
   PublicKey,
   PrivateKey,
   PublicKeyAsn1,

--- a/src/keys/utils.ts
+++ b/src/keys/utils.ts
@@ -13,7 +13,7 @@ import type {
   PublicKeyPem,
   RecoveryCode,
 } from './types';
-import type { NodeId } from '../nodes/types';
+import type { NodeId } from '../ids/types';
 import { Buffer } from 'buffer';
 import {
   asn1,

--- a/src/network/ConnectionForward.ts
+++ b/src/network/ConnectionForward.ts
@@ -3,7 +3,7 @@ import type { TLSSocket } from 'tls';
 import type UTPConnection from 'utp-native/lib/connection';
 import type { Certificate } from '../keys/types';
 import type { Address, Host, NetworkMessage, Port } from './types';
-import type { NodeId } from '../nodes/types';
+import type { NodeId } from '../ids/types';
 import type { AbstractConstructorParameters, Timer } from '../types';
 import tls from 'tls';
 import { StartStop, ready } from '@matrixai/async-init/dist/StartStop';

--- a/src/network/ConnectionReverse.ts
+++ b/src/network/ConnectionReverse.ts
@@ -2,7 +2,7 @@ import type { Socket, AddressInfo } from 'net';
 import type { TLSSocket } from 'tls';
 import type UTPConnection from 'utp-native/lib/connection';
 import type { Host, Port, Address, NetworkMessage } from './types';
-import type { NodeId } from '../nodes/types';
+import type { NodeId } from '../ids/types';
 import type { Certificate } from '../keys/types';
 import type { AbstractConstructorParameters, Timer } from '../types';
 import net from 'net';

--- a/src/network/Proxy.ts
+++ b/src/network/Proxy.ts
@@ -8,7 +8,7 @@ import type {
   ConnectionEstablishedCallback,
 } from './types';
 import type { ConnectionsForward } from './ConnectionForward';
-import type { NodeId } from '../nodes/types';
+import type { NodeId } from '../ids/types';
 import type { Timer } from '../types';
 import type UTPConnection from 'utp-native/lib/connection';
 import type { ConnectionsReverse } from './ConnectionReverse';

--- a/src/network/types.ts
+++ b/src/network/types.ts
@@ -1,4 +1,4 @@
-import type { NodeId } from '../nodes/types';
+import type { NodeId } from '../ids/types';
 import type {
   CertificatePemChain,
   PrivateKeyPem,

--- a/src/network/utils.ts
+++ b/src/network/utils.ts
@@ -2,7 +2,7 @@ import type { Socket } from 'net';
 import type { TLSSocket } from 'tls';
 import type { Host, Hostname, Port, Address, NetworkMessage } from './types';
 import type { Certificate, PublicKey } from '../keys/types';
-import type { NodeId } from '../nodes/types';
+import type { NodeId } from '../ids/types';
 import { Buffer } from 'buffer';
 import dns from 'dns';
 import { IPv4, IPv6, Validator } from 'ip-num';

--- a/src/nodes/types.ts
+++ b/src/nodes/types.ts
@@ -1,5 +1,4 @@
-import type { Id } from '@matrixai/id';
-import type { Opaque } from '../types';
+import type { NodeId, NodeIdString, NodeIdEncoded } from '../ids/types';
 import type { Host, Hostname, Port } from '../network/types';
 import type { Claim, ClaimId } from '../claims/types';
 import type { ChainData } from '../sigchain/types';
@@ -7,10 +6,6 @@ import type { ChainData } from '../sigchain/types';
 // This should be a string
 // actually cause it is a domain
 type NodeGraphSpace = '0' | '1';
-
-type NodeId = Opaque<'NodeId', Id>;
-type NodeIdString = Opaque<'NodeIdString', string>;
-type NodeIdEncoded = Opaque<'NodeIdEncoded', string>;
 
 type NodeAddress = {
   host: Host | Hostname;

--- a/src/nodes/utils.ts
+++ b/src/nodes/utils.ts
@@ -1,46 +1,16 @@
-import type {
-  NodeBucket,
-  NodeBucketIndex,
-  NodeId,
-  NodeIdEncoded,
-} from './types';
+import type { NodeBucket, NodeBucketIndex, NodeId } from './types';
 import type { KeyPath } from '@matrixai/db';
+import { utils as dbUtils } from '@matrixai/db';
 import { IdInternal } from '@matrixai/id';
 import lexi from 'lexicographic-integer';
-import { utils as dbUtils } from '@matrixai/db';
 import * as nodesErrors from './errors';
-import { bytes2BigInt } from '../utils';
 import * as keysUtils from '../keys/utils';
 import * as grpcErrors from '../grpc/errors';
 import * as agentErrors from '../agent/errors';
+import { encodeNodeId, decodeNodeId } from '../ids';
+import { bytes2BigInt } from '../utils';
 
 const sepBuffer = dbUtils.sep;
-
-/**
- * Encodes the NodeId as a `base32hex` string
- */
-function encodeNodeId(nodeId: NodeId): NodeIdEncoded {
-  return nodeId.toMultibase('base32hex') as NodeIdEncoded;
-}
-
-/**
- * Decodes an encoded NodeId string into a NodeId
- */
-function decodeNodeId(nodeIdEncoded: any): NodeId | undefined {
-  if (typeof nodeIdEncoded !== 'string') {
-    return;
-  }
-  const nodeId = IdInternal.fromMultibase<NodeId>(nodeIdEncoded);
-  if (nodeId == null) {
-    return;
-  }
-  // All NodeIds are 32 bytes long
-  // The NodeGraph requires a fixed size for Node Ids
-  if (nodeId.length !== 32) {
-    return;
-  }
-  return nodeId;
-}
 
 /**
  * Calculate the bucket index that the target node should be located in

--- a/src/notifications/NotificationsManager.ts
+++ b/src/notifications/NotificationsManager.ts
@@ -1,15 +1,10 @@
 import type { DB, DBTransaction, KeyPath, LevelPath } from '@matrixai/db';
-import type {
-  NotificationId,
-  Notification,
-  NotificationData,
-  NotificationIdGenerator,
-} from './types';
+import type { NotificationId, Notification, NotificationData } from './types';
 import type ACL from '../acl/ACL';
 import type KeyManager from '../keys/KeyManager';
 import type NodeManager from '../nodes/NodeManager';
 import type NodeConnectionManager from '../nodes/NodeConnectionManager';
-import type { NodeId } from '../nodes/types';
+import type { NodeId } from '../ids/types';
 import Logger from '@matrixai/logger';
 import { IdInternal } from '@matrixai/id';
 import {
@@ -93,7 +88,7 @@ class NotificationsManager {
     MESSAGE_COUNT_KEY,
   ];
 
-  protected notificationIdGenerator: NotificationIdGenerator;
+  protected notificationIdGenerator: () => NotificationId;
 
   constructor({
     acl,

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -1,11 +1,6 @@
-import type { Id } from '@matrixai/id';
 import type { Opaque } from '../types';
-import type { NodeIdEncoded } from '../nodes/types';
+import type { NotificationId, NodeIdEncoded } from '../ids/types';
 import type { VaultName, VaultActions, VaultIdEncoded } from '../vaults/types';
-
-type NotificationId = Opaque<'NotificationId', Id>;
-
-type NotificationIdGenerator = () => NotificationId;
 
 type GestaltInvite = {
   type: 'GestaltInvite';
@@ -33,7 +28,6 @@ type SignedNotification = Opaque<'SignedNotification', string>;
 
 export type {
   NotificationId,
-  NotificationIdGenerator,
   NotificationData,
   Notification,
   SignedNotification,

--- a/src/notifications/utils.ts
+++ b/src/notifications/utils.ts
@@ -4,16 +4,12 @@ import type {
   VaultShare,
   Notification,
   SignedNotification,
-  NotificationId,
-  NotificationIdGenerator,
 } from './types';
 import type { KeyPairPem } from '../keys/types';
-import type { NodeId } from '../nodes/types';
-import type { VaultId } from '../vaults/types';
+import type { NodeId, VaultId } from '../ids/types';
 import type { DefinedError } from 'ajv';
 import { createPublicKey, createPrivateKey } from 'crypto';
 import { SignJWT, exportJWK, jwtVerify, EmbeddedJWK } from 'jose';
-import { IdSortable } from '@matrixai/id';
 import {
   notificationValidate,
   generalNotificationValidate,
@@ -21,16 +17,8 @@ import {
   vaultShareNotificationValidate,
 } from './schema';
 import * as notificationsErrors from './errors';
+import { createNotificationIdGenerator } from '../ids';
 import * as nodesUtils from '../nodes/utils';
-
-function createNotificationIdGenerator(
-  lastId?: NotificationId,
-): NotificationIdGenerator {
-  const generator = new IdSortable<NotificationId>({
-    lastId,
-  });
-  return () => generator.get();
-}
 
 function constructGestaltInviteMessage(nodeId: NodeId): string {
   return `Keynode with ID ${nodeId} has invited this Keynode to join their Gestalt. Accept this invitation by typing the command: xxx`;

--- a/src/sigchain/Sigchain.ts
+++ b/src/sigchain/Sigchain.ts
@@ -4,12 +4,11 @@ import type {
   ClaimData,
   ClaimEncoded,
   ClaimId,
-  ClaimIdGenerator,
   ClaimIntermediary,
   ClaimType,
 } from '../claims/types';
 import type KeyManager from '../keys/KeyManager';
-import type { NodeIdEncoded } from '../nodes/types';
+import type { NodeIdEncoded } from '../ids/types';
 import Logger from '@matrixai/logger';
 import { IdInternal } from '@matrixai/id';
 import {
@@ -43,7 +42,7 @@ class Sigchain {
     'metadata',
   ];
 
-  protected generateClaimId: ClaimIdGenerator;
+  protected generateClaimId: () => ClaimId;
 
   static async createSigchain({
     db,

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -1,4 +1,4 @@
-import type { NodeId } from '../nodes/types';
+import type { NodeId } from '../ids/types';
 import type { Host, Port } from '../network/types';
 
 type StatusStarting = {

--- a/src/tasks/types.ts
+++ b/src/tasks/types.ts
@@ -1,18 +1,18 @@
-import type { Id } from '@matrixai/id';
+import type {
+  TaskHandlerId,
+  TaskId,
+  TaskIdString,
+  TaskIdEncoded,
+} from '../ids/types';
 import type { PromiseCancellable } from '@matrixai/async-cancellable';
 import type { Opaque } from '../types';
 import type { ContextTimed } from '../contexts/types';
-
-type TaskHandlerId = Opaque<'TaskHandlerId', string>;
 
 type TaskHandler = (
   ctx: ContextTimed,
   taskInfo: TaskInfo,
   ...params: TaskParameters
 ) => PromiseLike<any>;
-
-type TaskId = Opaque<'TaskId', Id>;
-type TaskIdEncoded = Opaque<'TaskIdEncoded', string>;
 
 /**
  * Task POJO returned to the user
@@ -107,6 +107,7 @@ export type {
   TaskHandlerId,
   TaskHandler,
   TaskId,
+  TaskIdString,
   TaskIdEncoded,
   Task,
   TaskInfo,

--- a/src/tasks/utils.ts
+++ b/src/tasks/utils.ts
@@ -1,49 +1,5 @@
-import type {
-  TaskId,
-  TaskIdEncoded,
-  TaskPriority,
-  TaskDelay,
-  TaskDeadline,
-} from './types';
-import { IdInternal, IdSortable } from '@matrixai/id';
-
-/**
- * Generates TaskId
- * TaskIds are lexicographically sortable 128 bit IDs
- * They are strictly monotonic and unique with respect to the `nodeId`
- * When the `NodeId` changes, make sure to regenerate this generator
- */
-function createTaskIdGenerator(lastTaskId?: TaskId) {
-  const generator = new IdSortable<TaskId>({
-    lastId: lastTaskId,
-  });
-  return () => generator.get();
-}
-
-/**
- * Encodes the TaskId as a `base32hex` string
- */
-function encodeTaskId(taskId: TaskId): TaskIdEncoded {
-  return taskId.toMultibase('base32hex') as TaskIdEncoded;
-}
-
-/**
- * Decodes an encoded TaskId string into a TaskId
- */
-function decodeTaskId(taskIdEncoded: any): TaskId | undefined {
-  if (typeof taskIdEncoded !== 'string') {
-    return;
-  }
-  const taskId = IdInternal.fromMultibase<TaskId>(taskIdEncoded);
-  if (taskId == null) {
-    return;
-  }
-  // All TaskIds are 16 bytes long
-  if (taskId.length !== 16) {
-    return;
-  }
-  return taskId;
-}
+import type { TaskPriority, TaskDelay, TaskDeadline } from './types';
+import { createTaskIdGenerator, encodeTaskId, decodeTaskId } from '../ids';
 
 /**
  * Encodes delay milliseconds

--- a/src/vaults/VaultInternal.ts
+++ b/src/vaults/VaultInternal.ts
@@ -13,7 +13,7 @@ import type {
   VaultRef,
 } from './types';
 import type KeyManager from '../keys/KeyManager';
-import type { NodeId, NodeIdEncoded } from '../nodes/types';
+import type { NodeId, NodeIdEncoded } from '../ids/types';
 import type NodeConnectionManager from '../nodes/NodeConnectionManager';
 import type GRPCClientAgent from '../agent/GRPCClientAgent';
 import type { POJO } from '../types';

--- a/src/vaults/VaultManager.ts
+++ b/src/vaults/VaultManager.ts
@@ -9,7 +9,7 @@ import type {
 import type { Vault } from './Vault';
 import type { FileSystem } from '../types';
 import type { PolykeyWorkerManagerInterface } from '../workers/types';
-import type { NodeId } from '../nodes/types';
+import type { NodeId } from '../ids/types';
 import type KeyManager from '../keys/KeyManager';
 import type NodeConnectionManager from '../nodes/NodeConnectionManager';
 import type GestaltGraph from '../gestalts/GestaltGraph';
@@ -121,6 +121,7 @@ class VaultManager {
   protected vaultLocks: LockBox<RWLockWriter> = new LockBox();
   protected vaultKey: Buffer;
   protected efs: EncryptedFS;
+  protected vaultIdGenerator = vaultsUtils.createVaultIdGenerator();
 
   constructor({
     vaultsPath,
@@ -904,7 +905,7 @@ class VaultManager {
 
   @ready(new vaultsErrors.ErrorVaultManagerNotRunning())
   protected async generateVaultId(): Promise<VaultId> {
-    let vaultId = vaultsUtils.generateVaultId();
+    let vaultId = this.vaultIdGenerator();
     let i = 0;
     while (await this.efs.exists(vaultsUtils.encodeVaultId(vaultId))) {
       i++;
@@ -913,7 +914,7 @@ class VaultManager {
           'Could not create a unique vaultId after 50 attempts',
         );
       }
-      vaultId = vaultsUtils.generateVaultId();
+      vaultId = this.vaultIdGenerator();
     }
     return vaultId;
   }

--- a/src/vaults/types.ts
+++ b/src/vaults/types.ts
@@ -1,4 +1,4 @@
-import type { Id } from '@matrixai/id';
+import type { VaultId, VaultIdString, VaultIdEncoded } from '../ids/types';
 import type { EncryptedFS } from 'encryptedfs';
 import type { Callback, Path } from 'encryptedfs/dist/types';
 import type { FdIndex } from 'encryptedfs/dist/fd/types';
@@ -19,10 +19,6 @@ const tagLast = 'last';
  * Tuple of static references
  */
 const refs = ['HEAD', tagLast] as const;
-
-type VaultId = Opaque<'VaultId', Id>;
-type VaultIdEncoded = Opaque<'VaultIdEncoded', string>;
-type VaultIdString = Opaque<'VaultIdString', string>;
 
 type VaultRef = typeof refs[number];
 

--- a/src/vaults/utils.ts
+++ b/src/vaults/utils.ts
@@ -1,16 +1,10 @@
-import type {
-  VaultId,
-  VaultIdEncoded,
-  VaultRef,
-  VaultAction,
-  CommitId,
-} from './types';
-import type { NodeId } from '../nodes/types';
 import type { EncryptedFS } from 'encryptedfs';
+import type { VaultRef, VaultAction, CommitId } from './types';
+import type { NodeId } from '../ids/types';
 import path from 'path';
-import { IdInternal, IdRandom } from '@matrixai/id';
 import { tagLast, refs, vaultActions } from './types';
 import * as nodesUtils from '../nodes/utils';
+import { createVaultIdGenerator, encodeVaultId, decodeVaultId } from '../ids';
 
 /**
  * Vault history is designed for linear-history
@@ -20,25 +14,6 @@ import * as nodesUtils from '../nodes/utils';
  */
 const canonicalBranch = 'master';
 const canonicalBranchRef = 'refs/heads/' + canonicalBranch;
-
-const vaultIdGenerator = new IdRandom<VaultId>();
-
-function generateVaultId(): VaultId {
-  return vaultIdGenerator.get();
-}
-
-function encodeVaultId(vaultId: VaultId): VaultIdEncoded {
-  return vaultId.toMultibase('base58btc') as VaultIdEncoded;
-}
-
-function decodeVaultId(vaultIdEncoded: any): VaultId | undefined {
-  if (typeof vaultIdEncoded !== 'string') return;
-  const vaultId = IdInternal.fromMultibase<VaultId>(vaultIdEncoded);
-  if (vaultId == null) return;
-  // All VaultIds are 16 bytes long
-  if (vaultId.length !== 16) return;
-  return vaultId;
-}
 
 /**
  * Vault reference can be HEAD, any of the special tags or a commit ID
@@ -95,7 +70,7 @@ export {
   refs,
   canonicalBranch,
   canonicalBranchRef,
-  generateVaultId,
+  createVaultIdGenerator,
   encodeVaultId,
   decodeVaultId,
   validateRef,

--- a/tests/acl/ACL.test.ts
+++ b/tests/acl/ACL.test.ts
@@ -1,5 +1,5 @@
 import type { Permission } from '@/acl/types';
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import type { VaultAction, VaultId } from '@/vaults/types';
 import type { GestaltAction } from '@/gestalts/types';
 import os from 'os';
@@ -17,6 +17,8 @@ describe(ACL.name, () => {
   const logger = new Logger(`${ACL.name} test`, LogLevel.WARN, [
     new StreamHandler(),
   ]);
+
+  const vaultIdGenerator = vaultsUtils.createVaultIdGenerator();
 
   // Node Ids
   const nodeIdX = testNodesUtils.generateRandomNodeId();
@@ -51,10 +53,10 @@ describe(ACL.name, () => {
         },
       },
     });
-    vaultId1 = vaultsUtils.generateVaultId();
-    vaultId2 = vaultsUtils.generateVaultId();
-    vaultId3 = vaultsUtils.generateVaultId();
-    vaultId4 = vaultsUtils.generateVaultId();
+    vaultId1 = vaultIdGenerator();
+    vaultId2 = vaultIdGenerator();
+    vaultId3 = vaultIdGenerator();
+    vaultId4 = vaultIdGenerator();
   });
   afterEach(async () => {
     await db.stop();

--- a/tests/agent/GRPCClientAgent.test.ts
+++ b/tests/agent/GRPCClientAgent.test.ts
@@ -1,6 +1,6 @@
 import type { Host, Port, TLSConfig } from '@/network/types';
 import type * as grpc from '@grpc/grpc-js';
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';

--- a/tests/agent/service/nodesChainDataGet.test.ts
+++ b/tests/agent/service/nodesChainDataGet.test.ts
@@ -1,5 +1,5 @@
 import type { Host, Port } from '@/network/types';
-import type { NodeIdEncoded } from '@/nodes/types';
+import type { NodeIdEncoded } from '@/ids/types';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';

--- a/tests/agent/service/nodesCrossSignClaim.test.ts
+++ b/tests/agent/service/nodesCrossSignClaim.test.ts
@@ -1,6 +1,6 @@
 import type { ClaimIdString, ClaimIntermediary } from '@/claims/types';
 import type { Host, Port } from '@/network/types';
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';

--- a/tests/agent/service/notificationsSend.test.ts
+++ b/tests/agent/service/notificationsSend.test.ts
@@ -1,6 +1,6 @@
 import type { Host, Port } from '@/network/types';
 import type { Notification } from '@/notifications/types';
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';

--- a/tests/bin/agent/start.test.ts
+++ b/tests/bin/agent/start.test.ts
@@ -1,6 +1,6 @@
 import type { RecoveryCode } from '@/keys/types';
 import type { StatusLive } from '@/status/types';
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import type { Host, Port } from '@/network/types';
 import path from 'path';
 import fs from 'fs';

--- a/tests/bin/identities/allowDisallowPermissions.test.ts
+++ b/tests/bin/identities/allowDisallowPermissions.test.ts
@@ -2,7 +2,7 @@ import type { Host, Port } from '@/network/types';
 import type { IdentityId, ProviderId } from '@/identities/types';
 import type { ClaimLinkIdentity } from '@/claims/types';
 import type { Gestalt } from '@/gestalts/types';
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import path from 'path';
 import fs from 'fs';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';

--- a/tests/bin/identities/discoverGet.test.ts
+++ b/tests/bin/identities/discoverGet.test.ts
@@ -2,7 +2,7 @@ import type { IdentityId, ProviderId } from '@/identities/types';
 import type { ClaimLinkIdentity } from '@/claims/types';
 import type { Gestalt } from '@/gestalts/types';
 import type { Host, Port } from '@/network/types';
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import path from 'path';
 import fs from 'fs';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';

--- a/tests/bin/identities/trustUntrustList.test.ts
+++ b/tests/bin/identities/trustUntrustList.test.ts
@@ -1,7 +1,7 @@
 import type { Host, Port } from '@/network/types';
 import type { IdentityId, ProviderId } from '@/identities/types';
 import type { ClaimLinkIdentity } from '@/claims/types';
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import path from 'path';
 import fs from 'fs';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';

--- a/tests/bin/nodes/add.test.ts
+++ b/tests/bin/nodes/add.test.ts
@@ -1,4 +1,4 @@
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import type { Host } from '@/network/types';
 import path from 'path';
 import fs from 'fs';

--- a/tests/bin/nodes/claim.test.ts
+++ b/tests/bin/nodes/claim.test.ts
@@ -1,4 +1,4 @@
-import type { NodeId, NodeIdEncoded } from '@/nodes/types';
+import type { NodeId, NodeIdEncoded } from '@/ids/types';
 import type { Host } from '@/network/types';
 import path from 'path';
 import fs from 'fs';

--- a/tests/bin/nodes/find.test.ts
+++ b/tests/bin/nodes/find.test.ts
@@ -1,5 +1,5 @@
 import type { Host, Port } from '@/network/types';
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import path from 'path';
 import fs from 'fs';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';

--- a/tests/bin/nodes/ping.test.ts
+++ b/tests/bin/nodes/ping.test.ts
@@ -1,4 +1,4 @@
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import type { Host } from '@/network/types';
 import path from 'path';
 import fs from 'fs';

--- a/tests/bin/notifications/sendReadClear.test.ts
+++ b/tests/bin/notifications/sendReadClear.test.ts
@@ -1,4 +1,4 @@
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import type { Host, Port } from '@/network/types';
 import type { Notification } from '@/notifications/types';
 import type { StatusLive } from '@/status/types';

--- a/tests/client/GRPCClientClient.test.ts
+++ b/tests/client/GRPCClientClient.test.ts
@@ -1,6 +1,6 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { Host, Port } from '@/network/types';
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import os from 'os';
 import path from 'path';
 import fs from 'fs';

--- a/tests/client/service/gestaltsGestaltGetByIdentity.test.ts
+++ b/tests/client/service/gestaltsGestaltGetByIdentity.test.ts
@@ -1,5 +1,5 @@
 import type { Gestalt } from '@/gestalts/types';
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import type { IdentityId, IdentityInfo, ProviderId } from '@/identities/types';
 import type { NodeInfo } from '@/nodes/types';
 import type { Host, Port } from '@/network/types';

--- a/tests/client/service/gestaltsGestaltList.test.ts
+++ b/tests/client/service/gestaltsGestaltList.test.ts
@@ -1,5 +1,5 @@
 import type { Gestalt } from '@/gestalts/types';
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import type { IdentityId, IdentityInfo, ProviderId } from '@/identities/types';
 import type { NodeInfo } from '@/nodes/types';
 import type { Host, Port } from '@/network/types';

--- a/tests/client/service/gestaltsGestaltTrustByIdentity.test.ts
+++ b/tests/client/service/gestaltsGestaltTrustByIdentity.test.ts
@@ -1,4 +1,4 @@
-import type { NodeIdEncoded } from '@/nodes/types';
+import type { NodeIdEncoded } from '@/ids/types';
 import type { ClaimLinkIdentity } from '@/claims/types';
 import type { ChainData } from '@/sigchain/types';
 import type { IdentityId } from '@/identities/types';

--- a/tests/client/service/gestaltsGestaltTrustByNode.test.ts
+++ b/tests/client/service/gestaltsGestaltTrustByNode.test.ts
@@ -1,4 +1,4 @@
-import type { NodeIdEncoded } from '@/nodes/types';
+import type { NodeIdEncoded } from '@/ids/types';
 import type { ClaimLinkIdentity } from '@/claims/types';
 import type { ChainData } from '@/sigchain/types';
 import type { Gestalt } from '@/gestalts/types';

--- a/tests/client/service/identitiesClaim.test.ts
+++ b/tests/client/service/identitiesClaim.test.ts
@@ -1,5 +1,5 @@
 import type { ClaimLinkIdentity } from '@/claims/types';
-import type { NodeIdEncoded } from '@/nodes/types';
+import type { NodeIdEncoded } from '@/ids/types';
 import type { IdentityId, ProviderId } from '@/identities/types';
 import type { Host, Port } from '@/network/types';
 import type NodeManager from '@/nodes/NodeManager';

--- a/tests/client/service/nodesClaim.test.ts
+++ b/tests/client/service/nodesClaim.test.ts
@@ -1,5 +1,5 @@
 import type { Notification } from '@/notifications/types';
-import type { NodeIdEncoded } from '@/nodes/types';
+import type { NodeIdEncoded } from '@/ids/types';
 import type { Host, Port } from '@/network/types';
 import fs from 'fs';
 import path from 'path';

--- a/tests/client/utils.ts
+++ b/tests/client/utils.ts
@@ -1,7 +1,7 @@
 import type { IClientServiceServer } from '@/proto/js/polykey/v1/client_service_grpc_pb';
 import type { SessionToken } from '@/sessions/types';
 import type PolykeyAgent from '@/PolykeyAgent';
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import type { Host, Port } from '@/network/types';
 import * as grpc from '@grpc/grpc-js';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';

--- a/tests/grpc/GRPCClient.test.ts
+++ b/tests/grpc/GRPCClient.test.ts
@@ -1,7 +1,7 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { PromiseUnaryCall } from '@/grpc/types';
 import type { SessionToken } from '@/sessions/types';
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import type { Host, Port } from '@/network/types';
 import type { KeyPair, Certificate } from '@/keys/types';
 import type { KeyManager } from '@/keys';

--- a/tests/grpc/utils/GRPCClientTest.ts
+++ b/tests/grpc/utils/GRPCClientTest.ts
@@ -1,6 +1,6 @@
 import type { Interceptor } from '@grpc/grpc-js';
 import type Session from '@/sessions/Session';
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import type { Host, Port, TLSConfig, ProxyConfig } from '@/network/types';
 import type * as utilsPB from '@/proto/js/polykey/v1/utils/utils_pb';
 import type { ClientReadableStream } from '@grpc/grpc-js/build/src/call';

--- a/tests/grpc/utils/utils.ts
+++ b/tests/grpc/utils/utils.ts
@@ -1,6 +1,6 @@
 import type Logger from '@matrixai/logger';
 import type { Authenticate } from '@/client/types';
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import * as grpc from '@grpc/grpc-js';
 import * as grpcUtils from '@/grpc/utils';
 import * as nodesUtils from '@/nodes/utils';

--- a/tests/identities/IdentitiesManager.test.ts
+++ b/tests/identities/IdentitiesManager.test.ts
@@ -4,7 +4,7 @@ import type {
   TokenData,
   IdentityData,
 } from '@/identities/types';
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import type { Claim, ClaimData, SignatureData } from '@/claims/types';
 import type { IdentityClaim } from '@/identities/types';
 import os from 'os';

--- a/tests/nodes/NodeGraph.test.ts
+++ b/tests/nodes/NodeGraph.test.ts
@@ -11,6 +11,7 @@ import fs from 'fs';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import { DB } from '@matrixai/db';
 import { IdInternal } from '@matrixai/id';
+import * as fc from 'fast-check';
 import NodeGraph from '@/nodes/NodeGraph';
 import KeyManager from '@/keys/KeyManager';
 import * as keysUtils from '@/keys/utils';
@@ -563,88 +564,308 @@ describe(`${NodeGraph.name} test`, () => {
     await nodeGraph.stop();
   });
   test('reset buckets', async () => {
-    const nodeGraph = await NodeGraph.createNodeGraph({
-      db,
-      keyManager,
-      logger,
-    });
-    const now = utils.getUnixtime();
-    for (let i = 0; i < 100; i++) {
-      await nodeGraph.setNode(testNodesUtils.generateRandomNodeId(), {
-        host: '127.0.0.1',
-        port: utils.getRandomInt(0, 2 ** 16),
-      } as NodeAddress);
-    }
-    const buckets0 = await utils.asyncIterableArray(nodeGraph.getBuckets());
-    // Reset the buckets according to the new node ID
-    // Note that this should normally be only executed when the key manager NodeID changes
-    // This means methods that use the KeyManager's node ID cannot be used here in this test
-    const nodeIdNew1 = testNodesUtils.generateRandomNodeId();
-    await nodeGraph.resetBuckets(nodeIdNew1);
-    const buckets1 = await utils.asyncIterableArray(nodeGraph.getBuckets());
-    expect(buckets1.length > 0).toBe(true);
-    for (const [bucketIndex, bucket] of buckets1) {
-      expect(bucket.length > 0).toBe(true);
-      for (const [nodeId, nodeData] of bucket) {
-        expect(nodeId.byteLength).toBe(32);
-        expect(nodesUtils.bucketIndex(nodeIdNew1, nodeId)).toBe(bucketIndex);
-        expect(nodeData.address.host).toBe('127.0.0.1');
-        // Port of 0 is not allowed
-        expect(nodeData.address.port > 0).toBe(true);
-        expect(nodeData.address.port < 2 ** 16).toBe(true);
-        expect(nodeData.lastUpdated >= now).toBe(true);
-      }
-    }
-    expect(buckets1).not.toStrictEqual(buckets0);
-    // Resetting again should change the space
-    const nodeIdNew2 = testNodesUtils.generateRandomNodeId();
-    await nodeGraph.resetBuckets(nodeIdNew2);
-    const buckets2 = await utils.asyncIterableArray(nodeGraph.getBuckets());
-    expect(buckets2.length > 0).toBe(true);
-    for (const [bucketIndex, bucket] of buckets2) {
-      expect(bucket.length > 0).toBe(true);
-      for (const [nodeId, nodeData] of bucket) {
-        expect(nodeId.byteLength).toBe(32);
-        expect(nodesUtils.bucketIndex(nodeIdNew2, nodeId)).toBe(bucketIndex);
-        expect(nodeData.address.host).toBe('127.0.0.1');
-        // Port of 0 is not allowed
-        expect(nodeData.address.port > 0).toBe(true);
-        expect(nodeData.address.port < 2 ** 16).toBe(true);
-        expect(nodeData.lastUpdated >= now).toBe(true);
-      }
-    }
-    expect(buckets2).not.toStrictEqual(buckets1);
-    // Resetting to the same NodeId results in the same bucket structure
-    await nodeGraph.resetBuckets(nodeIdNew2);
-    const buckets3 = await utils.asyncIterableArray(nodeGraph.getBuckets());
-    expect(buckets3).toStrictEqual(buckets2);
-    // Resetting to an existing NodeId
-    const nodeIdExisting = buckets3[0][1][0][0];
-    let nodeIdExistingFound = false;
-    await nodeGraph.resetBuckets(nodeIdExisting);
-    const buckets4 = await utils.asyncIterableArray(nodeGraph.getBuckets());
-    expect(buckets4.length > 0).toBe(true);
-    for (const [bucketIndex, bucket] of buckets4) {
-      expect(bucket.length > 0).toBe(true);
-      for (const [nodeId, nodeData] of bucket) {
-        if (nodeId.equals(nodeIdExisting)) {
-          nodeIdExistingFound = true;
-        }
-        expect(nodeId.byteLength).toBe(32);
-        expect(nodesUtils.bucketIndex(nodeIdExisting, nodeId)).toBe(
-          bucketIndex,
+    const getNodeIdMock = jest.fn();
+    const dummyKeyManager = {
+      getNodeId: getNodeIdMock,
+    } as unknown as KeyManager;
+
+    const nodeIdArb = fc
+      .int8Array({ minLength: 32, maxLength: 32 })
+      .map((value) => IdInternal.fromBuffer<NodeId>(Buffer.from(value)));
+    const nodeIdArrayArb = fc
+      .array(nodeIdArb, { maxLength: 100, minLength: 100 })
+      .noShrink();
+    const uniqueNodeIdArb = fc
+      .array(nodeIdArb, { maxLength: 3, minLength: 3 })
+      .noShrink()
+      .filter((values) => {
+        return (
+          !values[0].equals(values[1]) &&
+          !values[0].equals(values[2]) &&
+          !values[1].equals(values[2])
         );
-        expect(nodeData.address.host).toBe('127.0.0.1');
-        // Port of 0 is not allowed
-        expect(nodeData.address.port > 0).toBe(true);
-        expect(nodeData.address.port < 2 ** 16).toBe(true);
-        expect(nodeData.lastUpdated >= now).toBe(true);
-      }
-    }
-    expect(buckets4).not.toStrictEqual(buckets3);
-    // The existing node ID should not be put into the NodeGraph
-    expect(nodeIdExistingFound).toBe(false);
-    await nodeGraph.stop();
+      });
+    await fc.assert(
+      fc.asyncProperty(
+        uniqueNodeIdArb,
+        nodeIdArrayArb,
+        async (nodeIds, initialNodes) => {
+          getNodeIdMock.mockImplementation(() => nodeIds[0]);
+          const nodeGraph = await NodeGraph.createNodeGraph({
+            db,
+            keyManager: dummyKeyManager,
+            logger,
+          });
+          for (const nodeId of initialNodes) {
+            await nodeGraph.setNode(nodeId, {
+              host: '127.0.0.1',
+              port: utils.getRandomInt(0, 2 ** 16),
+            } as NodeAddress);
+          }
+          const buckets0 = await utils.asyncIterableArray(
+            nodeGraph.getBuckets(),
+          );
+          // Reset the buckets according to the new node ID
+          // Note that this should normally be only executed when the key manager NodeID changes
+          // This means methods that use the KeyManager's node ID cannot be used here in this test
+          getNodeIdMock.mockImplementation(() => nodeIds[1]);
+          const nodeIdNew1 = nodeIds[1];
+          await nodeGraph.resetBuckets(nodeIdNew1);
+          const buckets1 = await utils.asyncIterableArray(
+            nodeGraph.getBuckets(),
+          );
+          expect(buckets1.length > 0).toBe(true);
+          for (const [bucketIndex, bucket] of buckets1) {
+            expect(bucket.length > 0).toBe(true);
+            for (const [nodeId, nodeData] of bucket) {
+              expect(nodeId.byteLength).toBe(32);
+              expect(nodesUtils.bucketIndex(nodeIdNew1, nodeId)).toBe(
+                bucketIndex,
+              );
+              expect(nodeData.address.host).toBe('127.0.0.1');
+              // Port of 0 is not allowed
+              expect(nodeData.address.port > 0).toBe(true);
+              expect(nodeData.address.port < 2 ** 16).toBe(true);
+            }
+          }
+          expect(buckets1).not.toStrictEqual(buckets0);
+          // Resetting again should change the space
+          getNodeIdMock.mockImplementation(() => nodeIds[2]);
+          const nodeIdNew2 = nodeIds[2];
+          await nodeGraph.resetBuckets(nodeIdNew2);
+          const buckets2 = await utils.asyncIterableArray(
+            nodeGraph.getBuckets(),
+          );
+          expect(buckets2.length > 0).toBe(true);
+          for (const [bucketIndex, bucket] of buckets2) {
+            expect(bucket.length > 0).toBe(true);
+            for (const [nodeId, nodeData] of bucket) {
+              expect(nodeId.byteLength).toBe(32);
+              expect(nodesUtils.bucketIndex(nodeIdNew2, nodeId)).toBe(
+                bucketIndex,
+              );
+              expect(nodeData.address.host).toBe('127.0.0.1');
+              // Port of 0 is not allowed
+              expect(nodeData.address.port > 0).toBe(true);
+              expect(nodeData.address.port < 2 ** 16).toBe(true);
+            }
+          }
+          expect(buckets2).not.toStrictEqual(buckets1);
+          // Resetting to the same NodeId results in the same bucket structure
+          await nodeGraph.resetBuckets(nodeIdNew2);
+          const buckets3 = await utils.asyncIterableArray(
+            nodeGraph.getBuckets(),
+          );
+          expect(buckets3).toStrictEqual(buckets2);
+          // Resetting to an existing NodeId
+          const nodeIdExisting = buckets3[0][1][0][0];
+          let nodeIdExistingFound = false;
+          await nodeGraph.resetBuckets(nodeIdExisting);
+          const buckets4 = await utils.asyncIterableArray(
+            nodeGraph.getBuckets(),
+          );
+          expect(buckets4.length > 0).toBe(true);
+          for (const [bucketIndex, bucket] of buckets4) {
+            expect(bucket.length > 0).toBe(true);
+            for (const [nodeId, nodeData] of bucket) {
+              if (nodeId.equals(nodeIdExisting)) {
+                nodeIdExistingFound = true;
+              }
+              expect(nodeId.byteLength).toBe(32);
+              expect(nodesUtils.bucketIndex(nodeIdExisting, nodeId)).toBe(
+                bucketIndex,
+              );
+              expect(nodeData.address.host).toBe('127.0.0.1');
+              // Port of 0 is not allowed
+              expect(nodeData.address.port > 0).toBe(true);
+              expect(nodeData.address.port < 2 ** 16).toBe(true);
+            }
+          }
+          expect(buckets4).not.toStrictEqual(buckets3);
+          // The existing node ID should not be put into the NodeGraph
+          expect(nodeIdExistingFound).toBe(false);
+          await nodeGraph.stop();
+        },
+      ),
+      { numRuns: 1 },
+    );
+  });
+  test('reset buckets should re-order the buckets', async () => {
+    const getNodeIdMock = jest.fn();
+    const dummyKeyManager = {
+      getNodeId: getNodeIdMock,
+    } as unknown as KeyManager;
+
+    const nodeIdArb = fc
+      .int8Array({ minLength: 32, maxLength: 32 })
+      .map((value) => IdInternal.fromBuffer<NodeId>(Buffer.from(value)));
+    const nodeIdArrayArb = fc
+      .array(nodeIdArb, { maxLength: 50, minLength: 50 })
+      .noShrink();
+    const uniqueNodeIdArb = fc
+      .array(nodeIdArb, { maxLength: 2, minLength: 2 })
+      .noShrink()
+      .filter((values) => {
+        return !values[0].equals(values[1]);
+      });
+    await fc.assert(
+      fc.asyncProperty(
+        uniqueNodeIdArb,
+        nodeIdArrayArb,
+        async (nodeIds, initialNodes) => {
+          getNodeIdMock.mockImplementation(() => nodeIds[0]);
+          const nodeGraph = await NodeGraph.createNodeGraph({
+            db,
+            keyManager: dummyKeyManager,
+            fresh: true,
+            logger,
+          });
+          for (const nodeId of initialNodes) {
+            await nodeGraph.setNode(nodeId, {
+              host: '127.0.0.1',
+              port: utils.getRandomInt(0, 2 ** 16),
+            } as NodeAddress);
+          }
+          const buckets0 = await utils.asyncIterableArray(
+            nodeGraph.getBuckets(),
+          );
+          // Reset the buckets according to the new node ID
+          // Note that this should normally be only executed when the key manager NodeID changes
+          // This means methods that use the KeyManager's node ID cannot be used here in this test
+          getNodeIdMock.mockImplementation(() => nodeIds[1]);
+          const nodeIdNew1 = nodeIds[1];
+          await nodeGraph.resetBuckets(nodeIdNew1);
+          const buckets1 = await utils.asyncIterableArray(
+            nodeGraph.getBuckets(),
+          );
+          expect(buckets1).not.toStrictEqual(buckets0);
+          await nodeGraph.stop();
+        },
+      ),
+      { numRuns: 20 },
+    );
+  });
+  test('reset buckets should not corrupt data', async () => {
+    const getNodeIdMock = jest.fn();
+    const dummyKeyManager = {
+      getNodeId: getNodeIdMock,
+    } as unknown as KeyManager;
+
+    const nodeIdArb = fc
+      .int8Array({ minLength: 32, maxLength: 32 })
+      .map((value) => IdInternal.fromBuffer<NodeId>(Buffer.from(value)));
+    const nodeIdArrayArb = fc
+      .array(nodeIdArb, { maxLength: 10, minLength: 10 })
+      .noShrink();
+    const uniqueNodeIdArb = fc
+      .array(nodeIdArb, { maxLength: 2, minLength: 2 })
+      .noShrink()
+      .filter((values) => {
+        return !values[0].equals(values[1]);
+      });
+    await fc.assert(
+      fc.asyncProperty(
+        uniqueNodeIdArb,
+        nodeIdArrayArb,
+        async (nodeIds, initialNodes) => {
+          getNodeIdMock.mockImplementation(() => nodeIds[0]);
+          const nodeGraph = await NodeGraph.createNodeGraph({
+            db,
+            keyManager: dummyKeyManager,
+            fresh: true,
+            logger,
+          });
+          const nodeAddresses: Map<string, NodeAddress> = new Map();
+          for (const nodeId of initialNodes) {
+            const nodeAddress = {
+              host: '127.0.0.1',
+              port: utils.getRandomInt(0, 2 ** 16),
+            } as NodeAddress;
+            await nodeGraph.setNode(nodeId, nodeAddress);
+            nodeAddresses.set(nodeId.toString(), nodeAddress);
+          }
+          // Reset the buckets according to the new node ID
+          // Note that this should normally be only executed when the key manager NodeID changes
+          // This means methods that use the KeyManager's node ID cannot be used here in this test
+          getNodeIdMock.mockImplementation(() => nodeIds[1]);
+          const nodeIdNew1 = nodeIds[1];
+          await nodeGraph.resetBuckets(nodeIdNew1);
+          const buckets1 = await utils.asyncIterableArray(
+            nodeGraph.getBuckets(),
+          );
+          expect(buckets1.length > 0).toBe(true);
+          for (const [bucketIndex, bucket] of buckets1) {
+            expect(bucket.length > 0).toBe(true);
+            for (const [nodeId, nodeData] of bucket) {
+              expect(nodeId.byteLength).toBe(32);
+              expect(nodesUtils.bucketIndex(nodeIdNew1, nodeId)).toBe(
+                bucketIndex,
+              );
+              expect(nodeData.address.host).toBe('127.0.0.1');
+              expect(nodeAddresses.get(nodeId.toString())).toBeDefined();
+              expect(nodeAddresses.get(nodeId.toString())?.port).toBe(
+                nodeData.address.port,
+              );
+            }
+          }
+          await nodeGraph.stop();
+        },
+      ),
+      { numRuns: 20 },
+    );
+  });
+  test('reset buckets to an existing node should remove node', async () => {
+    const getNodeIdMock = jest.fn();
+    const dummyKeyManager = {
+      getNodeId: getNodeIdMock,
+    } as unknown as KeyManager;
+
+    const nodeIdArb = fc
+      .int8Array({ minLength: 32, maxLength: 32 })
+      .map((value) => IdInternal.fromBuffer<NodeId>(Buffer.from(value)));
+    const nodeIdArrayArb = fc
+      .array(nodeIdArb, { maxLength: 20, minLength: 20 })
+      .noShrink();
+    await fc.assert(
+      fc.asyncProperty(
+        nodeIdArb,
+        nodeIdArrayArb,
+        fc.integer({ min: 0, max: 19 }),
+        async (nodeId, initialNodes, nodeIndex) => {
+          getNodeIdMock.mockImplementation(() => nodeId);
+          const nodeGraph = await NodeGraph.createNodeGraph({
+            db,
+            keyManager: dummyKeyManager,
+            logger,
+          });
+          for (const nodeId of initialNodes) {
+            await nodeGraph.setNode(nodeId, {
+              host: '127.0.0.1',
+              port: utils.getRandomInt(0, 2 ** 16),
+            } as NodeAddress);
+          }
+          // Reset the buckets according to the new node ID
+          // Note that this should normally be only executed when the key manager NodeID changes
+          // This means methods that use the KeyManager's node ID cannot be used here in this test
+          getNodeIdMock.mockImplementation(() => initialNodes[nodeIndex]);
+          const nodeIdNew1 = initialNodes[nodeIndex];
+          await nodeGraph.resetBuckets(nodeIdNew1);
+          const buckets1 = await utils.asyncIterableArray(
+            nodeGraph.getBuckets(),
+          );
+          expect(buckets1.length > 0).toBe(true);
+          for (const [, bucket] of buckets1) {
+            expect(bucket.length > 0).toBe(true);
+            for (const [nodeId] of bucket) {
+              // The new node should not be in the graph
+              expect(nodeIdNew1.equals(nodeId)).toBeFalse();
+            }
+          }
+          await nodeGraph.stop();
+        },
+      ),
+      { numRuns: 15 },
+    );
   });
   test('reset buckets is persistent', async () => {
     const nodeGraph = await NodeGraph.createNodeGraph({

--- a/tests/nodes/utils.test.ts
+++ b/tests/nodes/utils.test.ts
@@ -1,4 +1,4 @@
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import os from 'os';
 import path from 'path';
 import fs from 'fs';

--- a/tests/notifications/NotificationsManager.test.ts
+++ b/tests/notifications/NotificationsManager.test.ts
@@ -1,4 +1,4 @@
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import type { Host, Port } from '@/network/types';
 import type { VaultActions, VaultName } from '@/vaults/types';
 import type { Notification, NotificationData } from '@/notifications/types';
@@ -42,6 +42,7 @@ describe('NotificationsManager', () => {
       0, 0, 0, 0, 0, 0, 5,
     ]),
   );
+  const vaultIdGenerator = vaultsUtils.createVaultIdGenerator();
   /**
    * Shared ACL, DB, NodeManager, KeyManager for all tests
    */
@@ -211,7 +212,7 @@ describe('NotificationsManager', () => {
     };
     const vaultNotification: NotificationData = {
       type: 'VaultShare',
-      vaultId: vaultsUtils.encodeVaultId(vaultsUtils.generateVaultId()),
+      vaultId: vaultsUtils.encodeVaultId(vaultIdGenerator()),
       vaultName: 'vaultName' as VaultName,
       actions: {
         clone: null,
@@ -275,7 +276,7 @@ describe('NotificationsManager', () => {
     };
     const vaultNotification: NotificationData = {
       type: 'VaultShare',
-      vaultId: vaultsUtils.encodeVaultId(vaultsUtils.generateVaultId()),
+      vaultId: vaultsUtils.encodeVaultId(vaultIdGenerator()),
       vaultName: 'vaultName' as VaultName,
       actions: {
         clone: null,
@@ -338,7 +339,7 @@ describe('NotificationsManager', () => {
     const notification3: Notification = {
       data: {
         type: 'VaultShare',
-        vaultId: vaultsUtils.encodeVaultId(vaultsUtils.generateVaultId()),
+        vaultId: vaultsUtils.encodeVaultId(vaultIdGenerator()),
         vaultName: 'vaultName' as VaultName,
         actions: {
           clone: null,

--- a/tests/notifications/utils.test.ts
+++ b/tests/notifications/utils.test.ts
@@ -13,7 +13,8 @@ import { globalRootKeyPems } from '../fixtures/globalRootKeyPems';
 describe('Notifications utils', () => {
   const nodeId = testNodesUtils.generateRandomNodeId();
   const nodeIdEncoded = nodesUtils.encodeNodeId(nodeId);
-  const vaultId = vaultsUtils.generateVaultId();
+  const vaultIdGenerator = vaultsUtils.createVaultIdGenerator();
+  const vaultId = vaultIdGenerator();
   const vaultIdEncoded = vaultsUtils.encodeVaultId(vaultId);
 
   test('generates notification ids', async () => {

--- a/tests/sigchain/Sigchain.test.ts
+++ b/tests/sigchain/Sigchain.test.ts
@@ -1,5 +1,5 @@
 import type { ProviderId, IdentityId } from '@/identities/types';
-import type { NodeIdEncoded } from '@/nodes/types';
+import type { NodeIdEncoded } from '@/ids/types';
 import type { Claim, ClaimData } from '@/claims/types';
 import os from 'os';
 import path from 'path';

--- a/tests/utils/utils.ts
+++ b/tests/utils/utils.ts
@@ -1,4 +1,4 @@
-import type { NodeId } from '@/nodes/types';
+import type { NodeId } from '@/ids/types';
 import type { PrivateKeyPem } from '@/keys/types';
 import type { StatusLive } from '@/status/types';
 import type Logger from '@matrixai/logger';

--- a/tests/vaults/VaultInternal.test.ts
+++ b/tests/vaults/VaultInternal.test.ts
@@ -31,6 +31,8 @@ describe('VaultInternal', () => {
   let db: DB;
   let vaultsDbPath: LevelPath;
 
+  const vaultIdGenerator = vaultsUtils.createVaultIdGenerator();
+
   const fakeKeyManager = {
     getNodeId: () => {
       return nodeTestUtils.generateRandomNodeId();
@@ -74,7 +76,7 @@ describe('VaultInternal', () => {
     });
     vaultsDbPath = ['vaults'];
 
-    vaultId = vaultsUtils.generateVaultId();
+    vaultId = vaultIdGenerator();
     vault = await VaultInternal.createVaultInternal({
       vaultId,
       keyManager: fakeKeyManager,
@@ -870,7 +872,7 @@ describe('VaultInternal', () => {
   test('can create with CreateVaultInternal', async () => {
     let vault1: VaultInternal | undefined;
     try {
-      const vaultId1 = vaultsUtils.generateVaultId();
+      const vaultId1 = vaultIdGenerator();
       vault1 = await VaultInternal.createVaultInternal({
         db,
         efs,
@@ -892,7 +894,7 @@ describe('VaultInternal', () => {
     let vault1: VaultInternal | undefined;
     let vault2: VaultInternal | undefined;
     try {
-      const vaultId1 = vaultsUtils.generateVaultId();
+      const vaultId1 = vaultIdGenerator();
       vault1 = await VaultInternal.createVaultInternal({
         db,
         efs,

--- a/tests/vaults/VaultManager.test.ts
+++ b/tests/vaults/VaultManager.test.ts
@@ -1,4 +1,4 @@
-import type { NodeId, NodeIdEncoded } from '@/nodes/types';
+import type { NodeId, NodeIdEncoded } from '@/ids/types';
 import type {
   VaultAction,
   VaultId,
@@ -41,6 +41,7 @@ describe('VaultManager', () => {
   const logger = new Logger('VaultManager Test', LogLevel.WARN, [
     new StreamHandler(),
   ]);
+  const vaultIdGenerator = vaultsUtils.createVaultIdGenerator();
   const nonExistentVaultId = IdInternal.fromString<VaultId>('DoesNotExistxxxx');
   const password = 'password';
   let remoteVaultId: VaultId;
@@ -1919,7 +1920,7 @@ describe('VaultManager', () => {
       logger: logger.getChild(VaultManager.name),
     });
     try {
-      const vaultId = vaultsUtils.generateVaultId();
+      const vaultId = vaultIdGenerator();
       await expect(
         vaultManager.withVaults([vaultId], async () => {
           // Do nothing
@@ -1941,7 +1942,10 @@ describe('VaultManager', () => {
       db,
       logger: logger.getChild(VaultManager.name),
     });
-    const generateVaultIdMock = jest.spyOn(vaultsUtils, 'generateVaultId');
+    const generateVaultIdMock = jest.spyOn(
+      vaultManager as any,
+      'vaultIdGenerator',
+    );
     try {
       // Generate 100 ids
       const vaultIds: VaultId[] = [];
@@ -1958,6 +1962,7 @@ describe('VaultManager', () => {
 
       const vaultId = await vaultManager.createVault('testVault');
       // Now only returns duplicates
+      // @ts-ignore - mocking protected method
       generateVaultIdMock.mockReturnValue(vaultId);
       const asd = async () => {
         for (let i = 0; i < 100; i++) {

--- a/tests/vaults/VaultOps.test.ts
+++ b/tests/vaults/VaultOps.test.ts
@@ -25,6 +25,7 @@ describe('VaultOps', () => {
   let vault: Vault;
   let db: DB;
   let vaultsDbPath: LevelPath;
+  const vaultIdGenerator = vaultsUtils.createVaultIdGenerator();
   const dummyKeyManager = {
     getNodeId: () => {
       return testNodesUtils.generateRandomNodeId();
@@ -44,7 +45,7 @@ describe('VaultOps', () => {
     });
     await baseEfs.start();
 
-    vaultId = vaultsUtils.generateVaultId();
+    vaultId = vaultIdGenerator();
     await baseEfs.mkdir(
       path.join(vaultsUtils.encodeVaultId(vaultId), 'contents'),
       {


### PR DESCRIPTION
### Description

This makes it easier to prototype breaking changes as other domains that depend on the ID types and utilities can instead depend on the common factor that is `ids` rather than the actual domains. The types and utilities are still re-exported by their respective domain for ease of use, but now generally if you need only the ID type or utility, use the `ids` domain instead.

### Issues Fixed

* Related to #446 (first dealt with there)

### Tasks

- [x] 1. Created `src/ids`
- [x] 2. Centralised types under `src/ids/types.ts`
- [x] 3. Centralised utilities under `src/ids/index.ts`
- [x] 4. Re-exported ids related utilities and types for all domains
- [x] 5. Changed vault id generator to actually be a generator creator to match all other ID behaviour

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
