### PR TITLE
Feature: network cancellability and deadlines

### DIFF
--- a/src/network/Connection.ts
+++ b/src/network/Connection.ts
@@ -40,7 +40,7 @@ abstract class Connection {
     tlsConfig,
     keepAliveTimeoutTime = 20000,
     endTime = 1000,
-    punchIntervalTime = 1000,
+    punchIntervalTime = 50,
     keepAliveIntervalTime = 1000,
     logger,
   }: {

--- a/src/network/Proxy.ts
+++ b/src/network/Proxy.ts
@@ -535,7 +535,7 @@ class Proxy {
     proxyHost: Host,
     proxyPort: Port,
     clientSocket: Socket,
-    ctx: ContextTimed,
+    @context ctx: ContextTimed,
   ): Promise<void> {
     const conn = await this.establishConnectionForward(
       nodeId,
@@ -620,7 +620,7 @@ class Proxy {
   public async openConnectionReverse(
     proxyHost: Host,
     proxyPort: Port,
-    ctx: ContextTimed,
+    @context ctx: ContextTimed,
   ): Promise<void> {
     const proxyAddress = networkUtils.buildAddress(proxyHost, proxyPort);
     let lock = this.connectionLocksReverse.get(proxyAddress);
@@ -716,7 +716,7 @@ class Proxy {
     proxyHost: Host,
     proxyPort: Port,
     utpConn: UTPConnection,
-    ctx: ContextTimed,
+    @context ctx: ContextTimed,
   ): Promise<void> {
     const conn = await this.establishConnectionReverse(
       proxyHost,

--- a/src/network/Proxy.ts
+++ b/src/network/Proxy.ts
@@ -63,7 +63,7 @@ class Proxy {
     connConnectTime = 20000,
     connKeepAliveTimeoutTime = 20000,
     connEndTime = 1000,
-    connPunchIntervalTime = 1000,
+    connPunchIntervalTime = 50,
     connKeepAliveIntervalTime = 1000,
     connectionEstablishedCallback = () => {},
     logger,

--- a/src/nodes/NodeConnectionManager.ts
+++ b/src/nodes/NodeConnectionManager.ts
@@ -350,7 +350,11 @@ class NodeConnectionManager {
     proxyPort: Port,
     timer?: Timer,
   ): Promise<void> {
-    await this.proxy.openConnectionReverse(proxyHost, proxyPort, timer);
+    const abortController = new AbortController();
+    void timer?.timerP.then(() => abortController.abort());
+    await this.proxy.openConnectionReverse(proxyHost, proxyPort, {
+      signal: abortController.signal,
+    });
   }
 
   /**
@@ -373,11 +377,7 @@ class NodeConnectionManager {
     proxyPort: Port,
     ctx?: ContextTimed,
   ): Promise<void> {
-    const timer =
-      ctx?.timer.getTimeout() != null
-        ? timerStart(ctx.timer.getTimeout())
-        : undefined;
-    await this.proxy.openConnectionForward(nodeId, proxyHost, proxyPort, timer);
+    await this.proxy.openConnectionForward(nodeId, proxyHost, proxyPort, ctx);
   }
 
   /**


### PR DESCRIPTION
### Description

This PR focuses on updating the network domain with `timedCancellable`, general cancellability and deadlines.

### Issues Fixed

* Related #450 
* Fixes #464 

### Tasks

- [x] 1. Update methods for establishing connections to use the `timedCancellable` decorator.
- [x] 2. Replace the connection lock maps with `LockBox`.
- [x] 3. Fix tests based on changes
- ~Add tests to check for the problem in https://github.com/MatrixAI/Polykey/pull/445#issuecomment-1253162920 . the problem should also be fixed.~ New issue at #473 

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
