### PR TITLE
Updating the `Nodes` domain with `timedCancellable`

### DIFF
--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -672,7 +672,7 @@ class PolykeyAgent {
       await this.nodeManager.start();
       await this.nodeConnectionManager.start({ nodeManager: this.nodeManager });
       await this.nodeGraph.start({ fresh });
-      await this.nodeManager.syncNodeGraph(false);
+      await this.nodeManager.syncNodeGraph(false, 2000);
       await this.discovery.start({ fresh });
       await this.vaultManager.start({ fresh });
       await this.notificationsManager.start({ fresh });

--- a/src/contexts/decorators/cancellable.ts
+++ b/src/contexts/decorators/cancellable.ts
@@ -25,8 +25,12 @@ function cancellable(lazy: boolean = false) {
       let ctx: Partial<ContextCancellable> = args[contextIndex];
       if (ctx === undefined) {
         ctx = {};
-        args[contextIndex] = ctx;
+      } else {
+        // Copy the ctx into a new ctx object to avoid mutating the ctx in case
+        // it is used again
+        ctx = { ...ctx };
       }
+      args[contextIndex] = ctx;
       // Runtime type check on the context parameter
       contextsUtils.checkContextCancellable(ctx, key, targetName);
       return setupCancellable(

--- a/src/contexts/decorators/timed.ts
+++ b/src/contexts/decorators/timed.ts
@@ -31,8 +31,12 @@ function timed(
         let ctx: Partial<ContextTimed> = args[contextIndex];
         if (ctx === undefined) {
           ctx = {};
-          args[contextIndex] = ctx;
+        } else {
+          // Copy the ctx into a new ctx object to avoid mutating the ctx in case
+          // it is used again
+          ctx = { ...ctx };
         }
+        args[contextIndex] = ctx;
         // Runtime type check on the context parameter
         contextsUtils.checkContextTimed(ctx, key, targetName);
         const teardownContext = setupTimedContext(
@@ -51,8 +55,12 @@ function timed(
         let ctx: Partial<ContextTimed> = args[contextIndex];
         if (ctx === undefined) {
           ctx = {};
-          args[contextIndex] = ctx;
+        } else {
+          // Copy the ctx into a new ctx object to avoid mutating the ctx in case
+          // it is used again
+          ctx = { ...ctx };
         }
+        args[contextIndex] = ctx;
         // Runtime type check on the context parameter
         contextsUtils.checkContextTimed(ctx, key, targetName);
         const teardownContext = setupTimedContext(
@@ -71,8 +79,12 @@ function timed(
         let ctx: Partial<ContextTimed> = args[contextIndex];
         if (ctx === undefined) {
           ctx = {};
-          args[contextIndex] = ctx;
+        } else {
+          // Copy the ctx into a new ctx object to avoid mutating the ctx in case
+          // it is used again
+          ctx = { ...ctx };
         }
+        args[contextIndex] = ctx;
         // Runtime type check on the context parameter
         contextsUtils.checkContextTimed(ctx, key, targetName);
         const teardownContext = setupTimedContext(
@@ -91,8 +103,12 @@ function timed(
         let ctx: Partial<ContextTimed> = args[contextIndex];
         if (ctx === undefined) {
           ctx = {};
-          args[contextIndex] = ctx;
+        } else {
+          // Copy the ctx into a new ctx object to avoid mutating the ctx in case
+          // it is used again
+          ctx = { ...ctx };
         }
+        args[contextIndex] = ctx;
         // Runtime type check on the context parameter
         contextsUtils.checkContextTimed(ctx, key, targetName);
         const teardownContext = setupTimedContext(

--- a/src/contexts/decorators/timedCancellable.ts
+++ b/src/contexts/decorators/timedCancellable.ts
@@ -31,8 +31,12 @@ function timedCancellable(
       let ctx: Partial<ContextTimed> = args[contextIndex];
       if (ctx === undefined) {
         ctx = {};
-        args[contextIndex] = ctx;
+      } else {
+        // Copy the ctx into a new ctx object to avoid mutating the ctx in case
+        // it is used again
+        ctx = { ...ctx };
       }
+      args[contextIndex] = ctx;
       // Runtime type check on the context parameter
       contextsUtils.checkContextTimed(ctx, key, targetName);
       const lazy_ = typeof lazy === 'boolean' ? lazy : lazy(this);

--- a/src/contexts/functions/cancellable.ts
+++ b/src/contexts/functions/cancellable.ts
@@ -73,7 +73,7 @@ function cancellable<C extends ContextCancellable, P extends Array<any>, R>(
   lazy: boolean = false,
 ): (...params: ContextAndParameters<C, P>) => PromiseCancellable<R> {
   return (...params) => {
-    const ctx = params[0] ?? {};
+    const ctx = params[0] != null ? { ...params[0] } : {};
     const args = params.slice(1) as P;
     return setupCancellable(f, lazy, ctx, args);
   };

--- a/src/contexts/functions/timed.ts
+++ b/src/contexts/functions/timed.ts
@@ -125,7 +125,7 @@ function timed<C extends ContextTimed, P extends Array<any>>(
 ): (...params: ContextAndParameters<C, P>) => any {
   if (f instanceof utils.AsyncFunction) {
     return async (...params) => {
-      const ctx = params[0] ?? {};
+      const ctx = params[0] != null ? { ...params[0] } : {};
       const args = params.slice(1) as P;
       const teardownContext = setupTimedContext(
         delay,
@@ -140,7 +140,7 @@ function timed<C extends ContextTimed, P extends Array<any>>(
     };
   } else if (f instanceof utils.GeneratorFunction) {
     return function* (...params) {
-      const ctx = params[0] ?? {};
+      const ctx = params[0] != null ? { ...params[0] } : {};
       const args = params.slice(1) as P;
       const teardownContext = setupTimedContext(
         delay,
@@ -155,7 +155,7 @@ function timed<C extends ContextTimed, P extends Array<any>>(
     };
   } else if (f instanceof utils.AsyncGeneratorFunction) {
     return async function* (...params) {
-      const ctx = params[0] ?? {};
+      const ctx = params[0] != null ? { ...params[0] } : {};
       const args = params.slice(1) as P;
       const teardownContext = setupTimedContext(
         delay,
@@ -170,7 +170,7 @@ function timed<C extends ContextTimed, P extends Array<any>>(
     };
   } else {
     return (...params) => {
-      const ctx = params[0] ?? {};
+      const ctx = params[0] != null ? { ...params[0] } : {};
       const args = params.slice(1) as P;
       const teardownContext = setupTimedContext(
         delay,

--- a/src/contexts/functions/timedCancellable.ts
+++ b/src/contexts/functions/timedCancellable.ts
@@ -153,7 +153,7 @@ function timedCancellable<C extends ContextTimed, P extends Array<any>, R>(
   errorTimeoutConstructor: new () => Error = contextsErrors.ErrorContextsTimedTimeOut,
 ): (...params: ContextAndParameters<C, P>) => PromiseCancellable<R> {
   return (...params) => {
-    const ctx = params[0] ?? {};
+    const ctx = params[0] != null ? { ...params[0] } : {};
     const args = params.slice(1) as P;
     return setupTimedCancellable(
       f,

--- a/src/network/ConnectionForward.ts
+++ b/src/network/ConnectionForward.ts
@@ -121,7 +121,11 @@ class ConnectionForward extends Connection {
       promise<void>();
     // Promise for abortion and timeout
     const { p: abortedP, resolveP: resolveAbortedP } = promise<void>();
-    ctx.signal.addEventListener('abort', () => resolveAbortedP());
+    if (ctx.signal.aborted) {
+      resolveAbortedP();
+    } else {
+      ctx.signal.addEventListener('abort', () => resolveAbortedP());
+    }
     this.resolveReadyP = resolveReadyP;
     this.utpSocket.on('message', this.handleMessage);
     const handleStartError = (e) => {

--- a/src/nodes/NodeConnection.ts
+++ b/src/nodes/NodeConnection.ts
@@ -81,7 +81,6 @@ class NodeConnection<T extends GRPCClient> {
       targetHost: Host;
       targetPort: Port;
       targetHostname?: Hostname;
-      ctx?: Partial<ContextTimed>;
       proxy: Proxy;
       keyManager: KeyManager;
       clientFactory: (...args) => Promise<T>;

--- a/src/nodes/NodeConnection.ts
+++ b/src/nodes/NodeConnection.ts
@@ -160,6 +160,8 @@ class NodeConnection<T extends GRPCClient> {
             await nodeConnection.destroy();
           }
         },
+        // FIXME: this needs to be replaced with
+        //  the GRPC timerCancellable update
         timer: timerStart(ctx.timer.getTimeout()),
       });
       // 5. When finished, you have a connection to other node

--- a/src/nodes/NodeConnectionManager.ts
+++ b/src/nodes/NodeConnectionManager.ts
@@ -292,22 +292,24 @@ class NodeConnectionManager {
           await this.destroyConnection(targetNodeId);
         };
         // Creating new connection
-        const newConnection = await NodeConnection.createNodeConnection({
-          targetNodeId: targetNodeId,
-          targetHost: targetHost,
-          targetHostname: targetHostname,
-          targetPort: targetAddress.port,
-          proxy: this.proxy,
-          keyManager: this.keyManager,
-          nodeConnectionManager: this,
-          destroyCallback,
+        const newConnection = await NodeConnection.createNodeConnection(
+          {
+            targetNodeId: targetNodeId,
+            targetHost: targetHost,
+            targetHostname: targetHostname,
+            targetPort: targetAddress.port,
+            proxy: this.proxy,
+            keyManager: this.keyManager,
+            nodeConnectionManager: this,
+            destroyCallback,
+            logger: this.logger.getChild(
+              `${NodeConnection.name} ${targetHost}:${targetAddress.port}`,
+            ),
+            clientFactory: async (args) =>
+              GRPCClientAgent.createGRPCClientAgent(args),
+          },
           ctx,
-          logger: this.logger.getChild(
-            `${NodeConnection.name} ${targetHost}:${targetAddress.port}`,
-          ),
-          clientFactory: async (args) =>
-            GRPCClientAgent.createGRPCClientAgent(args),
-        });
+        );
         // We can assume connection was established and destination was valid,
         // we can add the target to the nodeGraph
         await this.nodeManager?.setNode(targetNodeId, targetAddress);
@@ -766,7 +768,7 @@ class NodeConnectionManager {
       Buffer.from(proxyAddress),
     );
     // FIXME: this needs to handle aborting
-    const holePunchPromises = Array.from(this.getSeedNodes(), (seedNodeId) => {
+    void Array.from(this.getSeedNodes(), (seedNodeId) => {
       return this.sendHolePunchMessage(
         seedNodeId,
         this.keyManager.getNodeId(),

--- a/src/nodes/NodeConnectionManager.ts
+++ b/src/nodes/NodeConnectionManager.ts
@@ -161,19 +161,10 @@ class NodeConnectionManager {
    * @param ctx
    * @returns ResourceAcquire Resource API for use in with contexts
    */
-  public acquireConnection(
-    targetNodeId: NodeId,
-    ctx?: Partial<ContextTimed>,
-  ): PromiseCancellable<ResourceAcquire<NodeConnection<GRPCClientAgent>>>;
   @ready(new nodesErrors.ErrorNodeConnectionManagerNotRunning())
-  @timedCancellable(
-    true,
-    (nodeConnectionManager: NodeConnectionManager) =>
-      nodeConnectionManager.connConnectTime,
-  )
   public async acquireConnection(
     targetNodeId: NodeId,
-    @context ctx: ContextTimed,
+    ctx?: Partial<ContextTimed>,
   ): Promise<ResourceAcquire<NodeConnection<GRPCClientAgent>>> {
     return async () => {
       const { connection, timer: timeToLiveTimer } = await this.getConnection(
@@ -273,9 +264,18 @@ class NodeConnectionManager {
    * @param ctx
    * @returns ConnectionAndLock that was created or exists in the connection map
    */
+  protected getConnection(
+    targetNodeId: NodeId,
+    ctx?: Partial<ContextTimed>,
+  ): PromiseCancellable<ConnectionAndTimer>;
+  @timedCancellable(
+    true,
+    (nodeConnectionManager: NodeConnectionManager) =>
+      nodeConnectionManager.connConnectTime,
+  )
   protected async getConnection(
     targetNodeId: NodeId,
-    ctx: ContextTimed,
+    @context ctx: ContextTimed,
   ): Promise<ConnectionAndTimer> {
     const targetNodeIdString = targetNodeId.toString() as NodeIdString;
     return await this.connectionLocks.withF(

--- a/src/nodes/NodeConnectionManager.ts
+++ b/src/nodes/NodeConnectionManager.ts
@@ -775,21 +775,12 @@ class NodeConnectionManager {
         signature,
       );
     });
-    const forwardPunchPromise = this.holePunchForward(nodeId, host, port, ctx);
-
-    const abortPromise = new Promise((_resolve, reject) => {
-      if (ctx.signal.aborted) throw ctx.signal.reason;
-      ctx.signal.addEventListener('abort', () => reject(ctx.signal.reason));
-    });
-
     try {
-      await Promise.race([
-        Promise.any([forwardPunchPromise, ...holePunchPromises]),
-        abortPromise,
-      ]);
+      await this.holePunchForward(nodeId, host, port, ctx);
     } catch (e) {
       return false;
     }
+    // FIXME: clean up in a finally block, holePunchPromises should be cancelled
     return true;
   }
 

--- a/src/nodes/NodeManager.ts
+++ b/src/nodes/NodeManager.ts
@@ -734,7 +734,7 @@ class NodeManager {
     nodeAddress: NodeAddress,
     block: boolean = false,
     pingTimeout: number = 2000,
-    ctx?: ContextTimed,
+    ctx: ContextTimed,
     tran?: DBTransaction,
   ): Promise<void> {
     if (!this.pendingNodes.has(bucketIndex)) {

--- a/src/nodes/NodeManager.ts
+++ b/src/nodes/NodeManager.ts
@@ -206,7 +206,10 @@ class NodeManager {
     address?: NodeAddress,
     ctx?: Partial<ContextTimed>,
   ): PromiseCancellable<boolean>;
-  @timedCancellable(true, 20000)
+  @timedCancellable(
+    true,
+    (nodeManager: NodeManager) => nodeManager.nodeConnectionManager.pingTimeout,
+  )
   public async pingNode(
     nodeId: NodeId,
     address: NodeAddress | undefined,
@@ -521,13 +524,17 @@ class NodeManager {
     tran?: DBTransaction,
   ): PromiseCancellable<void>;
   @ready(new nodesErrors.ErrorNodeManagerNotRunning())
-  @timedCancellable(true, 20000)
+  @timedCancellable(
+    true,
+    (nodeManager: NodeManager) =>
+      nodeManager.nodeConnectionManager.connConnectTime,
+  )
   public async setNode(
     nodeId: NodeId,
     nodeAddress: NodeAddress,
     block: boolean = false,
     force: boolean = false,
-    pingTimeout: number = 10000,
+    pingTimeout: number = 2000,
     @context ctx: ContextTimed,
     tran?: DBTransaction,
   ): Promise<void> {
@@ -620,10 +627,14 @@ class NodeManager {
     ctx?: Partial<ContextTimed>,
     tran?: DBTransaction,
   ): PromiseCancellable<void>;
-  @timedCancellable(true, 20000)
+  @timedCancellable(
+    true,
+    (nodeManager: NodeManager) =>
+      nodeManager.nodeConnectionManager.connConnectTime,
+  )
   protected async garbageCollectBucket(
     bucketIndex: number,
-    pingTimeout: number = 10000,
+    pingTimeout: number = 2000,
     @context ctx: ContextTimed,
     tran?: DBTransaction,
   ): Promise<void> {
@@ -722,7 +733,7 @@ class NodeManager {
     nodeId: NodeId,
     nodeAddress: NodeAddress,
     block: boolean = false,
-    pingTimeout: number = 10000,
+    pingTimeout: number = 2000,
     ctx?: ContextTimed,
     tran?: DBTransaction,
   ): Promise<void> {
@@ -808,7 +819,11 @@ class NodeManager {
     bucketIndex: number,
     ctx?: Partial<ContextTimed>,
   ): PromiseCancellable<void>;
-  @timedCancellable(true, 20000)
+  @timedCancellable(
+    true,
+    (nodeManager: NodeManager) =>
+      nodeManager.nodeConnectionManager.connConnectTime,
+  )
   public async refreshBucket(
     bucketIndex: NodeBucketIndex,
     @context ctx: ContextTimed,
@@ -985,7 +1000,11 @@ class NodeManager {
     ctx?: Partial<ContextTimed>,
   ): PromiseCancellable<void>;
   @ready(new nodesErrors.ErrorNodeManagerNotRunning())
-  @timedCancellable(true, 20000)
+  @timedCancellable(
+    true,
+    (nodeManager: NodeManager) =>
+      nodeManager.nodeConnectionManager.connConnectTime,
+  )
   public async syncNodeGraph(
     block: boolean = true,
     @context ctx: ContextTimed,

--- a/src/nodes/utils.ts
+++ b/src/nodes/utils.ts
@@ -297,7 +297,8 @@ function isConnectionError(e): boolean {
   return (
     e instanceof nodesErrors.ErrorNodeConnectionDestroyed ||
     e instanceof grpcErrors.ErrorGRPC ||
-    e instanceof agentErrors.ErrorAgentClientDestroyed
+    e instanceof agentErrors.ErrorAgentClientDestroyed ||
+    e instanceof nodesErrors.ErrorNodeConnectionTimeout
   );
 }
 

--- a/tests/nodes/NodeConnection.test.ts
+++ b/tests/nodes/NodeConnection.test.ts
@@ -10,6 +10,7 @@ import fs from 'fs';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import { DB } from '@matrixai/db';
 import { destroyed } from '@matrixai/async-init';
+import { Timer } from '@matrixai/timer';
 import TaskManager from '@/tasks/TaskManager';
 import Proxy from '@/network/Proxy';
 import NodeConnection from '@/nodes/NodeConnection';
@@ -33,7 +34,6 @@ import * as GRPCErrors from '@/grpc/errors';
 import * as nodesUtils from '@/nodes/utils';
 import * as agentErrors from '@/agent/errors';
 import * as grpcUtils from '@/grpc/utils';
-import { timerStart } from '@/utils';
 import * as testNodesUtils from './utils';
 import * as grpcTestUtils from '../grpc/utils';
 import * as agentTestUtils from '../agent/utils';
@@ -64,7 +64,7 @@ const mockedGenerateDeterministicKeyPair = jest.spyOn(
 );
 
 describe(`${NodeConnection.name} test`, () => {
-  const logger = new Logger(`${NodeConnection.name} test`, LogLevel.WARN, [
+  const logger = new Logger(`${NodeConnection.name} test`, LogLevel.INFO, [
     new StreamHandler(),
   ]);
   grpcUtils.setLogger(logger.getChild('grpc'));
@@ -505,18 +505,20 @@ describe(`${NodeConnection.name} test`, () => {
       });
       // Have a nodeConnection try to connect to it
       const killSelf = jest.fn();
-      nodeConnection = await NodeConnection.createNodeConnection({
-        timer: timerStart(2000),
-        proxy: clientProxy,
-        keyManager: clientKeyManager,
-        logger: logger,
-        nodeConnectionManager: dummyNodeConnectionManager,
-        destroyCallback: killSelf,
-        targetHost: polykeyAgent.proxy.getProxyHost(),
-        targetNodeId: polykeyAgent.keyManager.getNodeId(),
-        targetPort: polykeyAgent.proxy.getProxyPort(),
-        clientFactory: (args) => GRPCClientAgent.createGRPCClientAgent(args),
-      });
+      nodeConnection = await NodeConnection.createNodeConnection(
+        {
+          proxy: clientProxy,
+          keyManager: clientKeyManager,
+          logger: logger,
+          nodeConnectionManager: dummyNodeConnectionManager,
+          destroyCallback: killSelf,
+          targetHost: polykeyAgent.proxy.getProxyHost(),
+          targetNodeId: polykeyAgent.keyManager.getNodeId(),
+          targetPort: polykeyAgent.proxy.getProxyPort(),
+          clientFactory: (args) => GRPCClientAgent.createGRPCClientAgent(args),
+        },
+        { timer: new Timer({ delay: 2000 }) },
+      );
 
       // Resolves if the shutdownCallback was called
       await polykeyAgent.stop();
@@ -537,18 +539,20 @@ describe(`${NodeConnection.name} test`, () => {
   });
   test('fails to connect to target (times out)', async () => {
     await expect(
-      NodeConnection.createNodeConnection({
-        targetNodeId: targetNodeId,
-        targetHost: '128.0.0.1' as Host,
-        targetPort: 12345 as Port,
-        timer: timerStart(300),
-        proxy: clientProxy,
-        keyManager: clientKeyManager,
-        nodeConnectionManager: dummyNodeConnectionManager,
-        destroyCallback,
-        logger: logger,
-        clientFactory: (args) => GRPCClientAgent.createGRPCClientAgent(args),
-      }),
+      NodeConnection.createNodeConnection(
+        {
+          targetNodeId: targetNodeId,
+          targetHost: '128.0.0.1' as Host,
+          targetPort: 12345 as Port,
+          proxy: clientProxy,
+          keyManager: clientKeyManager,
+          nodeConnectionManager: dummyNodeConnectionManager,
+          destroyCallback,
+          logger: logger,
+          clientFactory: (args) => GRPCClientAgent.createGRPCClientAgent(args),
+        },
+        { timer: new Timer({ delay: 300 }) },
+      ),
     ).rejects.toThrow(nodesErrors.ErrorNodeConnectionTimeout);
   });
   test('getRootCertChain', async () => {
@@ -615,18 +619,20 @@ describe(`${NodeConnection.name} test`, () => {
       });
       // Have a nodeConnection try to connect to it
       const killSelf = jest.fn();
-      const nodeConnectionP = NodeConnection.createNodeConnection({
-        timer: timerStart(500),
-        proxy: clientProxy,
-        keyManager: clientKeyManager,
-        logger: logger,
-        nodeConnectionManager: dummyNodeConnectionManager,
-        destroyCallback: killSelf,
-        targetHost: proxy.getProxyHost(),
-        targetNodeId: targetNodeId,
-        targetPort: proxy.getProxyPort(),
-        clientFactory: (args) => GRPCClientAgent.createGRPCClientAgent(args),
-      });
+      const nodeConnectionP = NodeConnection.createNodeConnection(
+        {
+          proxy: clientProxy,
+          keyManager: clientKeyManager,
+          logger: logger,
+          nodeConnectionManager: dummyNodeConnectionManager,
+          destroyCallback: killSelf,
+          targetHost: proxy.getProxyHost(),
+          targetNodeId: targetNodeId,
+          targetPort: proxy.getProxyPort(),
+          clientFactory: (args) => GRPCClientAgent.createGRPCClientAgent(args),
+        },
+        { timer: new Timer({ delay: 500 }) },
+      );
 
       // Expecting the connection to fail
       await expect(nodeConnectionP).rejects.toThrow(
@@ -658,18 +664,20 @@ describe(`${NodeConnection.name} test`, () => {
       });
       // Have a nodeConnection try to connect to it
       const killSelf = jest.fn();
-      const nodeConnectionP = NodeConnection.createNodeConnection({
-        timer: timerStart(500),
-        proxy: clientProxy,
-        keyManager: clientKeyManager,
-        logger: logger,
-        nodeConnectionManager: dummyNodeConnectionManager,
-        destroyCallback: killSelf,
-        targetHost: proxy.getProxyHost(),
-        targetNodeId: targetNodeId,
-        targetPort: proxy.getProxyPort(),
-        clientFactory: (args) => GRPCClientAgent.createGRPCClientAgent(args),
-      });
+      const nodeConnectionP = NodeConnection.createNodeConnection(
+        {
+          proxy: clientProxy,
+          keyManager: clientKeyManager,
+          logger: logger,
+          nodeConnectionManager: dummyNodeConnectionManager,
+          destroyCallback: killSelf,
+          targetHost: proxy.getProxyHost(),
+          targetNodeId: targetNodeId,
+          targetPort: proxy.getProxyPort(),
+          clientFactory: (args) => GRPCClientAgent.createGRPCClientAgent(args),
+        },
+        { timer: new Timer({ delay: 500 }) },
+      );
 
       // Expecting the connection to fail
       await expect(nodeConnectionP).rejects.toThrow(
@@ -699,18 +707,20 @@ describe(`${NodeConnection.name} test`, () => {
       });
       // Have a nodeConnection try to connect to it
       const killSelf = jest.fn();
-      nodeConnection = await NodeConnection.createNodeConnection({
-        timer: timerStart(500),
-        proxy: clientProxy,
-        keyManager: clientKeyManager,
-        logger: logger,
-        nodeConnectionManager: dummyNodeConnectionManager,
-        destroyCallback: killSelf,
-        targetHost: polykeyAgent.proxy.getProxyHost(),
-        targetNodeId: polykeyAgent.keyManager.getNodeId(),
-        targetPort: polykeyAgent.proxy.getProxyPort(),
-        clientFactory: (args) => GRPCClientAgent.createGRPCClientAgent(args),
-      });
+      nodeConnection = await NodeConnection.createNodeConnection(
+        {
+          proxy: clientProxy,
+          keyManager: clientKeyManager,
+          logger: logger,
+          nodeConnectionManager: dummyNodeConnectionManager,
+          destroyCallback: killSelf,
+          targetHost: polykeyAgent.proxy.getProxyHost(),
+          targetNodeId: polykeyAgent.keyManager.getNodeId(),
+          targetPort: polykeyAgent.proxy.getProxyPort(),
+          clientFactory: (args) => GRPCClientAgent.createGRPCClientAgent(args),
+        },
+        { timer: new Timer({ delay: 500 }) },
+      );
 
       // Resolves if the shutdownCallback was called
       await polykeyAgent.stop();
@@ -768,22 +778,24 @@ describe(`${NodeConnection.name} test`, () => {
         // Have a nodeConnection try to connect to it
         const killSelfCheck = jest.fn();
         const killSelfP = promise<null>();
-        nodeConnection = await NodeConnection.createNodeConnection({
-          timer: timerStart(2000),
-          proxy: clientProxy,
-          keyManager: clientKeyManager,
-          logger: logger,
-          nodeConnectionManager: dummyNodeConnectionManager,
-          destroyCallback: async () => {
-            await killSelfCheck();
-            killSelfP.resolveP(null);
+        nodeConnection = await NodeConnection.createNodeConnection(
+          {
+            proxy: clientProxy,
+            keyManager: clientKeyManager,
+            logger: logger,
+            nodeConnectionManager: dummyNodeConnectionManager,
+            destroyCallback: async () => {
+              await killSelfCheck();
+              killSelfP.resolveP(null);
+            },
+            targetNodeId: serverKeyManager.getNodeId(),
+            targetHost: testProxy.getProxyHost(),
+            targetPort: testProxy.getProxyPort(),
+            clientFactory: (args) =>
+              grpcTestUtils.GRPCClientTest.createGRPCClientTest(args),
           },
-          targetNodeId: serverKeyManager.getNodeId(),
-          targetHost: testProxy.getProxyHost(),
-          targetPort: testProxy.getProxyPort(),
-          clientFactory: (args) =>
-            grpcTestUtils.GRPCClientTest.createGRPCClientTest(args),
-        });
+          { timer: new Timer({ delay: 2000 }) },
+        );
 
         const client = nodeConnection.getClient();
         const echoMessage = new utilsPB.EchoMessage().setChallenge(option);
@@ -845,22 +857,24 @@ describe(`${NodeConnection.name} test`, () => {
         // Have a nodeConnection try to connect to it
         const killSelfCheck = jest.fn();
         const killSelfP = promise<null>();
-        nodeConnection = await NodeConnection.createNodeConnection({
-          timer: timerStart(2000),
-          proxy: clientProxy,
-          keyManager: clientKeyManager,
-          logger: logger,
-          nodeConnectionManager: dummyNodeConnectionManager,
-          destroyCallback: async () => {
-            await killSelfCheck();
-            killSelfP.resolveP(null);
+        nodeConnection = await NodeConnection.createNodeConnection(
+          {
+            proxy: clientProxy,
+            keyManager: clientKeyManager,
+            logger: logger,
+            nodeConnectionManager: dummyNodeConnectionManager,
+            destroyCallback: async () => {
+              await killSelfCheck();
+              killSelfP.resolveP(null);
+            },
+            targetNodeId: serverKeyManager.getNodeId(),
+            targetHost: testProxy.getProxyHost(),
+            targetPort: testProxy.getProxyPort(),
+            clientFactory: (args) =>
+              grpcTestUtils.GRPCClientTest.createGRPCClientTest(args),
           },
-          targetNodeId: serverKeyManager.getNodeId(),
-          targetHost: testProxy.getProxyHost(),
-          targetPort: testProxy.getProxyPort(),
-          clientFactory: (args) =>
-            grpcTestUtils.GRPCClientTest.createGRPCClientTest(args),
-        });
+          { timer: new Timer({ delay: 2000 }) },
+        );
 
         const client = nodeConnection.getClient();
         const echoMessage = new utilsPB.EchoMessage().setChallenge(option);
@@ -887,19 +901,21 @@ describe(`${NodeConnection.name} test`, () => {
   test('existing connection handles a resetRootKeyPair on sending side', async () => {
     let conn: NodeConnection<GRPCClientAgent> | undefined;
     try {
-      conn = await NodeConnection.createNodeConnection({
-        targetNodeId: targetNodeId,
-        targetHost: localHost,
-        targetPort: targetPort,
-        proxy: clientProxy,
-        keyManager: clientKeyManager,
-        nodeConnectionManager: dummyNodeConnectionManager,
-        destroyCallback,
-        logger: logger,
-        clientFactory: async (args) =>
-          GRPCClientAgent.createGRPCClientAgent(args),
-        timer: timerStart(2000),
-      });
+      conn = await NodeConnection.createNodeConnection(
+        {
+          targetNodeId: targetNodeId,
+          targetHost: localHost,
+          targetPort: targetPort,
+          proxy: clientProxy,
+          keyManager: clientKeyManager,
+          nodeConnectionManager: dummyNodeConnectionManager,
+          destroyCallback,
+          logger: logger,
+          clientFactory: async (args) =>
+            GRPCClientAgent.createGRPCClientAgent(args),
+        },
+        { timer: new Timer({ delay: 2000 }) },
+      );
       const client = conn.getClient();
       await client.echo(new utilsPB.EchoMessage().setChallenge('hello!'));
 
@@ -916,19 +932,21 @@ describe(`${NodeConnection.name} test`, () => {
   test('existing connection handles a renewRootKeyPair on sending side', async () => {
     let conn: NodeConnection<GRPCClientAgent> | undefined;
     try {
-      conn = await NodeConnection.createNodeConnection({
-        targetNodeId: targetNodeId,
-        targetHost: localHost,
-        targetPort: targetPort,
-        proxy: clientProxy,
-        keyManager: clientKeyManager,
-        nodeConnectionManager: dummyNodeConnectionManager,
-        destroyCallback,
-        logger: logger,
-        clientFactory: async (args) =>
-          GRPCClientAgent.createGRPCClientAgent(args),
-        timer: timerStart(2000),
-      });
+      conn = await NodeConnection.createNodeConnection(
+        {
+          targetNodeId: targetNodeId,
+          targetHost: localHost,
+          targetPort: targetPort,
+          proxy: clientProxy,
+          keyManager: clientKeyManager,
+          nodeConnectionManager: dummyNodeConnectionManager,
+          destroyCallback,
+          logger: logger,
+          clientFactory: async (args) =>
+            GRPCClientAgent.createGRPCClientAgent(args),
+        },
+        { timer: new Timer({ delay: 2000 }) },
+      );
       const client = conn.getClient();
       await client.echo(new utilsPB.EchoMessage().setChallenge('hello!'));
 
@@ -945,19 +963,21 @@ describe(`${NodeConnection.name} test`, () => {
   test('existing connection handles a resetRootCert on sending side', async () => {
     let conn: NodeConnection<GRPCClientAgent> | undefined;
     try {
-      conn = await NodeConnection.createNodeConnection({
-        targetNodeId: targetNodeId,
-        targetHost: localHost,
-        targetPort: targetPort,
-        proxy: clientProxy,
-        keyManager: clientKeyManager,
-        nodeConnectionManager: dummyNodeConnectionManager,
-        destroyCallback,
-        logger: logger,
-        clientFactory: async (args) =>
-          GRPCClientAgent.createGRPCClientAgent(args),
-        timer: timerStart(2000),
-      });
+      conn = await NodeConnection.createNodeConnection(
+        {
+          targetNodeId: targetNodeId,
+          targetHost: localHost,
+          targetPort: targetPort,
+          proxy: clientProxy,
+          keyManager: clientKeyManager,
+          nodeConnectionManager: dummyNodeConnectionManager,
+          destroyCallback,
+          logger: logger,
+          clientFactory: async (args) =>
+            GRPCClientAgent.createGRPCClientAgent(args),
+        },
+        { timer: new Timer({ delay: 2000 }) },
+      );
       const client = conn.getClient();
       await client.echo(new utilsPB.EchoMessage().setChallenge('hello!'));
 
@@ -974,19 +994,21 @@ describe(`${NodeConnection.name} test`, () => {
   test('existing connection handles a resetRootKeyPair on receiving side', async () => {
     let conn: NodeConnection<GRPCClientAgent> | undefined;
     try {
-      conn = await NodeConnection.createNodeConnection({
-        targetNodeId: targetNodeId,
-        targetHost: localHost,
-        targetPort: targetPort,
-        proxy: clientProxy,
-        keyManager: clientKeyManager,
-        nodeConnectionManager: dummyNodeConnectionManager,
-        destroyCallback,
-        logger: logger,
-        clientFactory: async (args) =>
-          GRPCClientAgent.createGRPCClientAgent(args),
-        timer: timerStart(2000),
-      });
+      conn = await NodeConnection.createNodeConnection(
+        {
+          targetNodeId: targetNodeId,
+          targetHost: localHost,
+          targetPort: targetPort,
+          proxy: clientProxy,
+          keyManager: clientKeyManager,
+          nodeConnectionManager: dummyNodeConnectionManager,
+          destroyCallback,
+          logger: logger,
+          clientFactory: async (args) =>
+            GRPCClientAgent.createGRPCClientAgent(args),
+        },
+        { timer: new Timer({ delay: 2000 }) },
+      );
       const client = conn.getClient();
       await client.echo(new utilsPB.EchoMessage().setChallenge('hello!'));
 
@@ -1003,19 +1025,21 @@ describe(`${NodeConnection.name} test`, () => {
   test('existing connection handles a renewRootKeyPair on receiving side', async () => {
     let conn: NodeConnection<GRPCClientAgent> | undefined;
     try {
-      conn = await NodeConnection.createNodeConnection({
-        targetNodeId: targetNodeId,
-        targetHost: localHost,
-        targetPort: targetPort,
-        proxy: clientProxy,
-        keyManager: clientKeyManager,
-        nodeConnectionManager: dummyNodeConnectionManager,
-        destroyCallback,
-        logger: logger,
-        clientFactory: async (args) =>
-          GRPCClientAgent.createGRPCClientAgent(args),
-        timer: timerStart(2000),
-      });
+      conn = await NodeConnection.createNodeConnection(
+        {
+          targetNodeId: targetNodeId,
+          targetHost: localHost,
+          targetPort: targetPort,
+          proxy: clientProxy,
+          keyManager: clientKeyManager,
+          nodeConnectionManager: dummyNodeConnectionManager,
+          destroyCallback,
+          logger: logger,
+          clientFactory: async (args) =>
+            GRPCClientAgent.createGRPCClientAgent(args),
+        },
+        { timer: new Timer({ delay: 2000 }) },
+      );
       const client = conn.getClient();
       await client.echo(new utilsPB.EchoMessage().setChallenge('hello!'));
 
@@ -1032,19 +1056,21 @@ describe(`${NodeConnection.name} test`, () => {
   test('existing connection handles a resetRootCert on receiving side', async () => {
     let conn: NodeConnection<GRPCClientAgent> | undefined;
     try {
-      conn = await NodeConnection.createNodeConnection({
-        targetNodeId: targetNodeId,
-        targetHost: localHost,
-        targetPort: targetPort,
-        proxy: clientProxy,
-        keyManager: clientKeyManager,
-        nodeConnectionManager: dummyNodeConnectionManager,
-        destroyCallback,
-        logger: logger,
-        clientFactory: async (args) =>
-          GRPCClientAgent.createGRPCClientAgent(args),
-        timer: timerStart(2000),
-      });
+      conn = await NodeConnection.createNodeConnection(
+        {
+          targetNodeId: targetNodeId,
+          targetHost: localHost,
+          targetPort: targetPort,
+          proxy: clientProxy,
+          keyManager: clientKeyManager,
+          nodeConnectionManager: dummyNodeConnectionManager,
+          destroyCallback,
+          logger: logger,
+          clientFactory: async (args) =>
+            GRPCClientAgent.createGRPCClientAgent(args),
+        },
+        { timer: new Timer({ delay: 2000 }) },
+      );
       const client = conn.getClient();
       await client.echo(new utilsPB.EchoMessage().setChallenge('hello!'));
 
@@ -1065,19 +1091,21 @@ describe(`${NodeConnection.name} test`, () => {
       await clientKeyManager.resetRootKeyPair(password);
       clientProxy.setTLSConfig(await newTlsConfig(clientKeyManager));
 
-      conn = await NodeConnection.createNodeConnection({
-        targetNodeId: targetNodeId,
-        targetHost: localHost,
-        targetPort: targetPort,
-        proxy: clientProxy,
-        keyManager: clientKeyManager,
-        nodeConnectionManager: dummyNodeConnectionManager,
-        destroyCallback,
-        logger: logger,
-        clientFactory: async (args) =>
-          GRPCClientAgent.createGRPCClientAgent(args),
-        timer: timerStart(2000),
-      });
+      conn = await NodeConnection.createNodeConnection(
+        {
+          targetNodeId: targetNodeId,
+          targetHost: localHost,
+          targetPort: targetPort,
+          proxy: clientProxy,
+          keyManager: clientKeyManager,
+          nodeConnectionManager: dummyNodeConnectionManager,
+          destroyCallback,
+          logger: logger,
+          clientFactory: async (args) =>
+            GRPCClientAgent.createGRPCClientAgent(args),
+        },
+        { timer: new Timer({ delay: 2000 }) },
+      );
 
       const client = conn.getClient();
       await client.echo(new utilsPB.EchoMessage().setChallenge('hello!'));
@@ -1092,19 +1120,21 @@ describe(`${NodeConnection.name} test`, () => {
       await clientKeyManager.renewRootKeyPair(password);
       clientProxy.setTLSConfig(await newTlsConfig(clientKeyManager));
 
-      conn = await NodeConnection.createNodeConnection({
-        targetNodeId: targetNodeId,
-        targetHost: localHost,
-        targetPort: targetPort,
-        proxy: clientProxy,
-        keyManager: clientKeyManager,
-        nodeConnectionManager: dummyNodeConnectionManager,
-        destroyCallback,
-        logger: logger,
-        clientFactory: async (args) =>
-          GRPCClientAgent.createGRPCClientAgent(args),
-        timer: timerStart(2000),
-      });
+      conn = await NodeConnection.createNodeConnection(
+        {
+          targetNodeId: targetNodeId,
+          targetHost: localHost,
+          targetPort: targetPort,
+          proxy: clientProxy,
+          keyManager: clientKeyManager,
+          nodeConnectionManager: dummyNodeConnectionManager,
+          destroyCallback,
+          logger: logger,
+          clientFactory: async (args) =>
+            GRPCClientAgent.createGRPCClientAgent(args),
+        },
+        { timer: new Timer({ delay: 2000 }) },
+      );
 
       const client = conn.getClient();
       await client.echo(new utilsPB.EchoMessage().setChallenge('hello!'));
@@ -1119,19 +1149,21 @@ describe(`${NodeConnection.name} test`, () => {
       await clientKeyManager.resetRootCert();
       clientProxy.setTLSConfig(await newTlsConfig(clientKeyManager));
 
-      conn = await NodeConnection.createNodeConnection({
-        targetNodeId: targetNodeId,
-        targetHost: localHost,
-        targetPort: targetPort,
-        proxy: clientProxy,
-        keyManager: clientKeyManager,
-        nodeConnectionManager: dummyNodeConnectionManager,
-        destroyCallback,
-        logger: logger,
-        clientFactory: async (args) =>
-          GRPCClientAgent.createGRPCClientAgent(args),
-        timer: timerStart(2000),
-      });
+      conn = await NodeConnection.createNodeConnection(
+        {
+          targetNodeId: targetNodeId,
+          targetHost: localHost,
+          targetPort: targetPort,
+          proxy: clientProxy,
+          keyManager: clientKeyManager,
+          nodeConnectionManager: dummyNodeConnectionManager,
+          destroyCallback,
+          logger: logger,
+          clientFactory: async (args) =>
+            GRPCClientAgent.createGRPCClientAgent(args),
+        },
+        { timer: new Timer({ delay: 2000 }) },
+      );
 
       const client = conn.getClient();
       await client.echo(new utilsPB.EchoMessage().setChallenge('hello!'));
@@ -1144,19 +1176,21 @@ describe(`${NodeConnection.name} test`, () => {
     await serverKeyManager.resetRootKeyPair(password);
     serverProxy.setTLSConfig(await newTlsConfig(serverKeyManager));
 
-    const connProm = NodeConnection.createNodeConnection({
-      targetNodeId: targetNodeId,
-      targetHost: localHost,
-      targetPort: targetPort,
-      proxy: clientProxy,
-      keyManager: clientKeyManager,
-      nodeConnectionManager: dummyNodeConnectionManager,
-      destroyCallback,
-      logger: logger,
-      clientFactory: async (args) =>
-        GRPCClientAgent.createGRPCClientAgent(args),
-      timer: timerStart(2000),
-    });
+    const connProm = NodeConnection.createNodeConnection(
+      {
+        targetNodeId: targetNodeId,
+        targetHost: localHost,
+        targetPort: targetPort,
+        proxy: clientProxy,
+        keyManager: clientKeyManager,
+        nodeConnectionManager: dummyNodeConnectionManager,
+        destroyCallback,
+        logger: logger,
+        clientFactory: async (args) =>
+          GRPCClientAgent.createGRPCClientAgent(args),
+      },
+      { timer: new Timer({ delay: 2000 }) },
+    );
 
     await expect(connProm).rejects.toThrow(
       nodesErrors.ErrorNodeConnectionTimeout,
@@ -1190,19 +1224,21 @@ describe(`${NodeConnection.name} test`, () => {
       await serverKeyManager.renewRootKeyPair(password);
       serverProxy.setTLSConfig(await newTlsConfig(serverKeyManager));
 
-      conn = await NodeConnection.createNodeConnection({
-        targetNodeId: targetNodeId,
-        targetHost: localHost,
-        targetPort: targetPort,
-        proxy: clientProxy,
-        keyManager: clientKeyManager,
-        nodeConnectionManager: dummyNodeConnectionManager,
-        destroyCallback,
-        logger: logger,
-        clientFactory: async (args) =>
-          GRPCClientAgent.createGRPCClientAgent(args),
-        timer: timerStart(2000),
-      });
+      conn = await NodeConnection.createNodeConnection(
+        {
+          targetNodeId: targetNodeId,
+          targetHost: localHost,
+          targetPort: targetPort,
+          proxy: clientProxy,
+          keyManager: clientKeyManager,
+          nodeConnectionManager: dummyNodeConnectionManager,
+          destroyCallback,
+          logger: logger,
+          clientFactory: async (args) =>
+            GRPCClientAgent.createGRPCClientAgent(args),
+        },
+        { timer: new Timer({ delay: 2000 }) },
+      );
 
       const client = conn.getClient();
       await client.echo(new utilsPB.EchoMessage().setChallenge('hello!'));
@@ -1217,19 +1253,21 @@ describe(`${NodeConnection.name} test`, () => {
       await serverKeyManager.resetRootCert();
       serverProxy.setTLSConfig(await newTlsConfig(serverKeyManager));
 
-      conn = await NodeConnection.createNodeConnection({
-        targetNodeId: targetNodeId,
-        targetHost: localHost,
-        targetPort: targetPort,
-        proxy: clientProxy,
-        keyManager: clientKeyManager,
-        nodeConnectionManager: dummyNodeConnectionManager,
-        destroyCallback,
-        logger: logger,
-        clientFactory: async (args) =>
-          GRPCClientAgent.createGRPCClientAgent(args),
-        timer: timerStart(2000),
-      });
+      conn = await NodeConnection.createNodeConnection(
+        {
+          targetNodeId: targetNodeId,
+          targetHost: localHost,
+          targetPort: targetPort,
+          proxy: clientProxy,
+          keyManager: clientKeyManager,
+          nodeConnectionManager: dummyNodeConnectionManager,
+          destroyCallback,
+          logger: logger,
+          clientFactory: async (args) =>
+            GRPCClientAgent.createGRPCClientAgent(args),
+        },
+        { timer: new Timer({ delay: 2000 }) },
+      );
 
       const client = conn.getClient();
       await client.echo(new utilsPB.EchoMessage().setChallenge('hello!'));

--- a/tests/nodes/NodeConnection.test.ts
+++ b/tests/nodes/NodeConnection.test.ts
@@ -64,7 +64,7 @@ const mockedGenerateDeterministicKeyPair = jest.spyOn(
 );
 
 describe(`${NodeConnection.name} test`, () => {
-  const logger = new Logger(`${NodeConnection.name} test`, LogLevel.INFO, [
+  const logger = new Logger(`${NodeConnection.name} test`, LogLevel.WARN, [
     new StreamHandler(),
   ]);
   grpcUtils.setLogger(logger.getChild('grpc'));

--- a/tests/nodes/NodeConnectionManager.general.test.ts
+++ b/tests/nodes/NodeConnectionManager.general.test.ts
@@ -321,8 +321,6 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     },
     globalThis.polykeyStartupTimeout,
   );
-  // FIXME: This is a know failure due to connection deadline bug,
-  //  disabling for now
   test(
     'cannot find node (contacts remote node)',
     async () => {

--- a/tests/nodes/NodeConnectionManager.general.test.ts
+++ b/tests/nodes/NodeConnectionManager.general.test.ts
@@ -323,7 +323,7 @@ describe(`${NodeConnectionManager.name} general test`, () => {
   );
   // FIXME: This is a know failure due to connection deadline bug,
   //  disabling for now
-  test.skip(
+  test(
     'cannot find node (contacts remote node)',
     async () => {
       // NodeConnectionManager under test

--- a/tests/nodes/NodeConnectionManager.seednodes.test.ts
+++ b/tests/nodes/NodeConnectionManager.seednodes.test.ts
@@ -8,6 +8,7 @@ import { DB } from '@matrixai/db';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import { IdInternal } from '@matrixai/id';
 import { PromiseCancellable } from '@matrixai/async-cancellable';
+import { Timer } from '@matrixai/timer';
 import NodeManager from '@/nodes/NodeManager';
 import PolykeyAgent from '@/PolykeyAgent';
 import KeyManager from '@/keys/KeyManager';
@@ -317,7 +318,7 @@ describe(`${NodeConnectionManager.name} seed nodes test`, () => {
       });
       await nodeConnectionManager.start({ nodeManager });
       await taskManager.startProcessing();
-      await nodeManager.syncNodeGraph();
+      await nodeManager.syncNodeGraph(true, 2000);
       expect(await nodeGraph.getNode(nodeId1)).toBeDefined();
       expect(await nodeGraph.getNode(nodeId2)).toBeDefined();
       expect(await nodeGraph.getNode(dummyNodeId)).toBeUndefined();
@@ -380,7 +381,7 @@ describe(`${NodeConnectionManager.name} seed nodes test`, () => {
       });
       await nodeConnectionManager.start({ nodeManager });
       await taskManager.startProcessing();
-      await nodeManager.syncNodeGraph();
+      await nodeManager.syncNodeGraph(true, 2000);
       await sleep(1000);
       expect(mockedRefreshBucket).toHaveBeenCalled();
     } finally {
@@ -452,7 +453,9 @@ describe(`${NodeConnectionManager.name} seed nodes test`, () => {
       await nodeConnectionManager.start({ nodeManager });
       await taskManager.startProcessing();
       // This should complete without error
-      await nodeManager.syncNodeGraph(true);
+      await nodeManager.syncNodeGraph(true, 5000, {
+        timer: new Timer({ delay: 20000 }),
+      });
       // Information on remotes are found
       expect(await nodeGraph.getNode(nodeId1)).toBeDefined();
       expect(await nodeGraph.getNode(nodeId2)).toBeDefined();
@@ -517,8 +520,8 @@ describe(`${NodeConnectionManager.name} seed nodes test`, () => {
           logger,
         });
 
-        await node1.nodeManager.syncNodeGraph(true);
-        await node2.nodeManager.syncNodeGraph(true);
+        await node1.nodeManager.syncNodeGraph(true, 2000);
+        await node2.nodeManager.syncNodeGraph(true, 2000);
 
         const getAllNodes = async (node: PolykeyAgent) => {
           const nodes: Array<NodeIdEncoded> = [];

--- a/tests/nodes/NodeConnectionManager.termination.test.ts
+++ b/tests/nodes/NodeConnectionManager.termination.test.ts
@@ -30,7 +30,7 @@ import { globalRootKeyPems } from '../fixtures/globalRootKeyPems';
 describe(`${NodeConnectionManager.name} termination test`, () => {
   const logger = new Logger(
     `${NodeConnectionManager.name} test`,
-    LogLevel.WARN,
+    LogLevel.DEBUG,
     [new StreamHandler()],
   );
   grpcUtils.setLogger(logger.getChild('grpc'));

--- a/tests/nodes/NodeConnectionManager.termination.test.ts
+++ b/tests/nodes/NodeConnectionManager.termination.test.ts
@@ -30,7 +30,7 @@ import { globalRootKeyPems } from '../fixtures/globalRootKeyPems';
 describe(`${NodeConnectionManager.name} termination test`, () => {
   const logger = new Logger(
     `${NodeConnectionManager.name} test`,
-    LogLevel.DEBUG,
+    LogLevel.WARN,
     [new StreamHandler()],
   );
   grpcUtils.setLogger(logger.getChild('grpc'));

--- a/tests/nodes/NodeManager.test.ts
+++ b/tests/nodes/NodeManager.test.ts
@@ -52,6 +52,7 @@ describe(`${NodeManager.name} test`, () => {
   const externalPort = 0 as Port;
   const mockedPingNode = jest.fn(); // Jest.spyOn(NodeManager.prototype, 'pingNode');
   const dummyNodeConnectionManager = {
+    connConnectTime: 5000,
     pingNode: mockedPingNode,
   } as unknown as NodeConnectionManager;
 
@@ -188,7 +189,7 @@ describe(`${NodeManager.name} test`, () => {
         // Check if active
         // Case 1: cannot establish new connection, so offline
         const active1 = await nodeManager.pingNode(serverNodeId, undefined, {
-          timer: new Timer({ delay: 10000 }),
+          timer: new Timer({ delay: 2000 }),
         });
         expect(active1).toBe(false);
         // Bring server node online
@@ -207,7 +208,7 @@ describe(`${NodeManager.name} test`, () => {
         // Check if active
         // Case 2: can establish new connection, so online
         const active2 = await nodeManager.pingNode(serverNodeId, undefined, {
-          timer: new Timer({ delay: 10000 }),
+          timer: new Timer({ delay: 2000 }),
         });
         expect(active2).toBe(true);
         // Turn server node offline again
@@ -216,7 +217,7 @@ describe(`${NodeManager.name} test`, () => {
         // Check if active
         // Case 3: pre-existing connection no longer active, so offline
         const active3 = await nodeManager.pingNode(serverNodeId, undefined, {
-          timer: new Timer({ delay: 10000 }),
+          timer: new Timer({ delay: 2000 }),
         });
         expect(active3).toBe(false);
       } finally {
@@ -472,7 +473,7 @@ describe(`${NodeManager.name} test`, () => {
       sigchain: {} as Sigchain,
       keyManager,
       nodeGraph,
-      nodeConnectionManager: {} as NodeConnectionManager,
+      nodeConnectionManager: dummyNodeConnectionManager,
       taskManager,
       logger,
     });
@@ -500,7 +501,7 @@ describe(`${NodeManager.name} test`, () => {
       sigchain: {} as Sigchain,
       keyManager,
       nodeGraph,
-      nodeConnectionManager: {} as NodeConnectionManager,
+      nodeConnectionManager: dummyNodeConnectionManager,
       taskManager,
       logger,
     });
@@ -540,7 +541,7 @@ describe(`${NodeManager.name} test`, () => {
       sigchain: {} as Sigchain,
       keyManager,
       nodeGraph,
-      nodeConnectionManager: {} as NodeConnectionManager,
+      nodeConnectionManager: dummyNodeConnectionManager,
       taskManager,
       logger,
     });
@@ -591,7 +592,7 @@ describe(`${NodeManager.name} test`, () => {
       sigchain: {} as Sigchain,
       keyManager,
       nodeGraph,
-      nodeConnectionManager: {} as NodeConnectionManager,
+      nodeConnectionManager: dummyNodeConnectionManager,
       taskManager,
       logger,
     });
@@ -644,7 +645,7 @@ describe(`${NodeManager.name} test`, () => {
       sigchain: {} as Sigchain,
       keyManager,
       nodeGraph,
-      nodeConnectionManager: {} as NodeConnectionManager,
+      nodeConnectionManager: dummyNodeConnectionManager,
       taskManager,
       logger,
     });
@@ -690,7 +691,7 @@ describe(`${NodeManager.name} test`, () => {
       sigchain: {} as Sigchain,
       keyManager,
       nodeGraph,
-      nodeConnectionManager: {} as NodeConnectionManager,
+      nodeConnectionManager: dummyNodeConnectionManager,
       taskManager,
       logger,
     });
@@ -870,7 +871,6 @@ describe(`${NodeManager.name} test`, () => {
     }
   });
   test('should update deadline when updating a bucket', async () => {
-    const refreshBucketTimeout = 100000;
     const nodeManager = new NodeManager({
       db,
       sigchain: {} as Sigchain,
@@ -878,7 +878,7 @@ describe(`${NodeManager.name} test`, () => {
       nodeGraph,
       nodeConnectionManager: dummyNodeConnectionManager,
       taskManager,
-      refreshBucketDelay: refreshBucketTimeout,
+      refreshBucketDelay: 100000,
       logger,
     });
     const mockRefreshBucket = jest.spyOn(
@@ -947,7 +947,6 @@ describe(`${NodeManager.name} test`, () => {
     }
   });
   test('refreshBucket tasks should have spread delays', async () => {
-    const refreshBucketTimeout = 100000;
     const nodeManager = new NodeManager({
       db,
       sigchain: {} as Sigchain,
@@ -955,7 +954,7 @@ describe(`${NodeManager.name} test`, () => {
       nodeGraph,
       nodeConnectionManager: dummyNodeConnectionManager,
       taskManager,
-      refreshBucketDelay: refreshBucketTimeout,
+      refreshBucketDelay: 100000,
       logger,
     });
     const mockRefreshBucket = jest.spyOn(


### PR DESCRIPTION
### Description

This PR addresses the `timedCancellable` changes for the nodes domain. Part of this work was done in #445. This is just to fully finish off the domain. 

### Issues Fixed

* Fixes #465 

### Tasks

- [x] 1. Where needed the nodes methods need to be updated to support cancellability.
- [x] 2. where needed the nodes methods need to use the timedCancellable decorator.
- [x] 3. parts of the code making use of these timedCancellable methods needs to be updated to exploit this new functionality.
- [x] 4. Tests need to be expanded to test a wide range of timeout and cancellation conditions.
- ~5. If possible use the transaction locking for the object maps. #443~ This was already using `LockBox`. So it has already been addressed.

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
