### PR TITLE
Multi-Host DNS and Multi NodeID resolution - for network entry and general usage

### DIFF
--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -573,6 +573,8 @@ class PolykeyAgent {
         PolykeyAgent.eventSymbols.Proxy,
         async (data: ConnectionData) => {
           if (data.type === 'reverse') {
+            console.log(`${nodesUtils.encodeNodeId(this.keyManager.getNodeId())} VS ${nodesUtils.encodeNodeId(data.remoteNodeId)}`)
+            if (this.keyManager.getNodeId().equals(data.remoteNodeId)) return;
             const address = networkUtils.buildAddress(
               data.remoteHost,
               data.remotePort,

--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -573,7 +573,6 @@ class PolykeyAgent {
         PolykeyAgent.eventSymbols.Proxy,
         async (data: ConnectionData) => {
           if (data.type === 'reverse') {
-            console.log(`${nodesUtils.encodeNodeId(this.keyManager.getNodeId())} VS ${nodesUtils.encodeNodeId(data.remoteNodeId)}`)
             if (this.keyManager.getNodeId().equals(data.remoteNodeId)) return;
             const address = networkUtils.buildAddress(
               data.remoteHost,

--- a/src/agent/GRPCClientAgent.ts
+++ b/src/agent/GRPCClientAgent.ts
@@ -72,8 +72,12 @@ class GRPCClientAgent extends GRPCClient<AgentServiceClient> {
     return grpcClientAgent;
   }
 
-  public async destroy() {
-    await super.destroy();
+  public async destroy({
+    timeout,
+  }: {
+    timeout?: number;
+  } = {}) {
+    await super.destroy({ timeout });
   }
 
   @ready(new agentErrors.ErrorAgentClientDestroyed())

--- a/src/agent/service/nodesHolePunchMessageSend.ts
+++ b/src/agent/service/nodesHolePunchMessageSend.ts
@@ -71,7 +71,7 @@ function nodesHolePunchMessageSend({
               call.request.getProxyAddress(),
             );
             logger.debug(
-              `Received signalling message to target ${call.request.getSrcId()}@${host}:${port}`,
+              `Received signaling message to target ${call.request.getSrcId()}@${host}:${port}`,
             );
             // Ignore failure
             try {
@@ -81,7 +81,7 @@ function nodesHolePunchMessageSend({
             }
           } else {
             logger.error(
-              'Received signalling message, target information was missing, skipping reverse hole punch',
+              'Received signaling message, target information was missing, skipping reverse hole punch',
             );
           }
         } else if (await nodeManager.knowsNode(sourceId, tran)) {
@@ -95,19 +95,19 @@ function nodesHolePunchMessageSend({
           // Checking if the source and destination are the same
           if (sourceId?.equals(targetId)) {
             // Logging and silently dropping operation
-            logger.warn('Signalling relay message requested signal to itself');
+            logger.warn('Signaling relay message requested signal to itself');
             callback(null, response);
             return;
           }
           call.request.setProxyAddress(proxyAddress);
           logger.debug(
-            `Relaying signalling message from ${srcNodeId}@${
+            `Relaying signaling message from ${srcNodeId}@${
               connectionInfo!.remoteHost
             }:${
               connectionInfo!.remotePort
             } to ${targetNodeId} with information ${proxyAddress}`,
           );
-          await nodeConnectionManager.relaySignallingMessage(call.request, {
+          await nodeConnectionManager.relaySignalingMessage(call.request, {
             host: connectionInfo!.remoteHost,
             port: connectionInfo!.remotePort,
           });

--- a/src/agent/service/nodesHolePunchMessageSend.ts
+++ b/src/agent/service/nodesHolePunchMessageSend.ts
@@ -92,6 +92,13 @@ function nodesHolePunchMessageSend({
             connectionInfo!.remoteHost,
             connectionInfo!.remotePort,
           );
+          // Checking if the source and destination are the same
+          if (sourceId?.equals(targetId)) {
+            // Logging and silently dropping operation
+            logger.warn('Signalling relay message requested signal to itself');
+            callback(null, response);
+            return;
+          }
           call.request.setProxyAddress(proxyAddress);
           logger.debug(
             `Relaying signalling message from ${srcNodeId}@${

--- a/src/bin/CommandPolykey.ts
+++ b/src/bin/CommandPolykey.ts
@@ -1,6 +1,11 @@
 import type { FileSystem } from '../types';
 import commander from 'commander';
-import Logger, { StreamHandler, formatting, levelToString, evalLogDataValue } from '@matrixai/logger';
+import Logger, {
+  StreamHandler,
+  formatting,
+  levelToString,
+  evalLogDataValue,
+} from '@matrixai/logger';
 import * as binUtils from './utils';
 import * as binOptions from './utils/options';
 import * as binErrors from './errors';

--- a/src/bin/utils/ExitHandlers.ts
+++ b/src/bin/utils/ExitHandlers.ts
@@ -67,7 +67,6 @@ class ExitHandlers {
     const error = new binErrors.ErrorBinUnhandledRejection(undefined, {
       cause: e,
     });
-    console.log('unhandledRejectionHandler');
     process.stderr.write(
       binUtils.outputFormatter({
         type: this._errFormat,
@@ -92,7 +91,6 @@ class ExitHandlers {
     const error = new binErrors.ErrorBinUncaughtException(undefined, {
       cause: e,
     });
-    console.log('UncaughtExceptionhandler');
     process.stderr.write(
       binUtils.outputFormatter({
         type: this._errFormat,
@@ -107,7 +105,6 @@ class ExitHandlers {
   protected deadlockHandler = async () => {
     if (process.exitCode == null) {
       const e = new binErrors.ErrorBinAsynchronousDeadlock();
-      console.log('deadlockHandler');
       process.stderr.write(
         binUtils.outputFormatter({
           type: this._errFormat,

--- a/src/bin/utils/ExitHandlers.ts
+++ b/src/bin/utils/ExitHandlers.ts
@@ -67,6 +67,7 @@ class ExitHandlers {
     const error = new binErrors.ErrorBinUnhandledRejection(undefined, {
       cause: e,
     });
+    console.log('unhandledRejectionHandler');
     process.stderr.write(
       binUtils.outputFormatter({
         type: this._errFormat,
@@ -91,6 +92,7 @@ class ExitHandlers {
     const error = new binErrors.ErrorBinUncaughtException(undefined, {
       cause: e,
     });
+    console.log('UncaughtExceptionhandler');
     process.stderr.write(
       binUtils.outputFormatter({
         type: this._errFormat,
@@ -105,6 +107,7 @@ class ExitHandlers {
   protected deadlockHandler = async () => {
     if (process.exitCode == null) {
       const e = new binErrors.ErrorBinAsynchronousDeadlock();
+      console.log('deadlockHandler');
       process.stderr.write(
         binUtils.outputFormatter({
           type: this._errFormat,

--- a/src/config.ts
+++ b/src/config.ts
@@ -97,7 +97,16 @@ const config = {
     // This is not used by the `PolykeyAgent` which defaults to `{}`
     network: {
       mainnet: {},
-      testnet: {},
+      testnet: {
+        vg9a9e957878s2qgtbdmu2atvli8ms7muukb1dk4dpbm4llkki3h0: {
+          host: 'testnet.polykey.io' as Host,
+          port: 1314 as Port,
+        },
+        vh9oqtvct10eaiv3cl4ebm0ko33sl0qqpvb59vud8cngfvqs4p4ng: {
+          host: 'testnet.polykey.io' as Host,
+          port: 1314 as Port,
+        },
+      },
     },
   },
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,29 @@
 import type { Host, Port } from './network/types';
+import type { NodeAddress } from 'nodes/types';
 import { getDefaultNodePath } from './utils';
 // @ts-ignore package.json is outside rootDir
 import { version } from '../package.json';
+
+/**
+ * Configuration for testnet node addresses.
+ * Extracted here to enforce types properly.
+ */
+const testnet: Record<string, NodeAddress> = {
+  vg9a9e957878s2qgtbdmu2atvli8ms7muukb1dk4dpbm4llkki3h0: {
+    host: 'testnet.polykey.io' as Host,
+    port: 1314 as Port,
+  },
+  vh9oqtvct10eaiv3cl4ebm0ko33sl0qqpvb59vud8cngfvqs4p4ng: {
+    host: 'testnet.polykey.io' as Host,
+    port: 1314 as Port,
+  },
+};
+
+/**
+ * Configuration for main net node addresses.
+ * Extracted here to enforce types properly.
+ */
+const mainnet: Record<string, NodeAddress> = {};
 
 /**
  * Polykey static configuration
@@ -96,17 +118,8 @@ const config = {
     },
     // This is not used by the `PolykeyAgent` which defaults to `{}`
     network: {
-      mainnet: {},
-      testnet: {
-        vg9a9e957878s2qgtbdmu2atvli8ms7muukb1dk4dpbm4llkki3h0: {
-          host: 'testnet.polykey.io' as Host,
-          port: 1314 as Port,
-        },
-        vh9oqtvct10eaiv3cl4ebm0ko33sl0qqpvb59vud8cngfvqs4p4ng: {
-          host: 'testnet.polykey.io' as Host,
-          port: 1314 as Port,
-        },
-      },
+      mainnet: mainnet,
+      testnet: testnet,
     },
   },
 };

--- a/src/contexts/functions/timedCancellable.ts
+++ b/src/contexts/functions/timedCancellable.ts
@@ -104,6 +104,8 @@ function setupTimedCancellable<C extends ContextTimed, P extends Array<any>, R>(
     );
     ctx.signal = abortController.signal;
     teardownContext = () => {
+      // The timer is not cancelled here because
+      // it was not created in this scope
       finished = true;
     };
   } else {

--- a/src/grpc/GRPCClient.ts
+++ b/src/grpc/GRPCClient.ts
@@ -152,7 +152,7 @@ abstract class GRPCClient<T extends Client = Client> {
       const socket = session.socket as TLSSocket;
       serverCertChain = networkUtils.getCertificateChain(socket);
       try {
-        networkUtils.verifyServerCertificateChain(nodeId, serverCertChain);
+        networkUtils.verifyServerCertificateChain([nodeId], serverCertChain);
       } catch (e) {
         const e_ = e;
         if (e instanceof networkErrors.ErrorCertChain) {

--- a/src/network/ConnectionForward.ts
+++ b/src/network/ConnectionForward.ts
@@ -125,7 +125,7 @@ class ConnectionForward extends Connection {
     // Promise for abortion and timeout
     const { p: abortedP, resolveP: resolveAbortedP } = promise<void>();
     if (ctx.signal.aborted) {
-      this.logger.debug(`Failed to start Connection Forward: aborted`);
+      this.logger.info(`Failed to start Connection Forward: aborted`);
       // This is for arbitrary abortion reason provided by the caller
       // Re-throw the default timeout error as a network timeout error
       if (
@@ -186,7 +186,7 @@ class ConnectionForward extends Connection {
         this.tlsSocket.destroy();
       }
       this.utpSocket.off('message', this.handleMessage);
-      this.logger.debug(`Failed to start Connection Forward: ${e.message}`);
+      this.logger.info(`Failed to start Connection Forward: ${e.message}`);
       throw new networkErrors.ErrorConnectionStart(undefined, {
         cause: e,
       });
@@ -196,7 +196,7 @@ class ConnectionForward extends Connection {
     this.tlsSocket.on('error', this.handleError);
     this.tlsSocket.off('error', handleStartError);
     if (ctx.signal.aborted) {
-      this.logger.debug(`Failed to start Connection Forward: aborted`);
+      this.logger.info(`Failed to start Connection Forward: aborted`);
       // Clean up partial start
       // TLSSocket isn't established yet, so it is destroyed
       if (!this.tlsSocket.destroyed) {
@@ -220,7 +220,7 @@ class ConnectionForward extends Connection {
         serverCertChain,
       );
     } catch (e) {
-      this.logger.debug(
+      this.logger.info(
         `Failed to start Connection Forward: verification failed`,
       );
       // Clean up partial start

--- a/src/network/ConnectionForward.ts
+++ b/src/network/ConnectionForward.ts
@@ -125,7 +125,7 @@ class ConnectionForward extends Connection {
     // Promise for abortion and timeout
     const { p: abortedP, resolveP: resolveAbortedP } = promise<void>();
     if (ctx.signal.aborted) {
-      this.logger.info(`Failed to start Connection Forward: aborted`);
+      this.logger.debug(`Failed to start Connection Forward: aborted`);
       // This is for arbitrary abortion reason provided by the caller
       // Re-throw the default timeout error as a network timeout error
       if (
@@ -186,7 +186,7 @@ class ConnectionForward extends Connection {
         this.tlsSocket.destroy();
       }
       this.utpSocket.off('message', this.handleMessage);
-      this.logger.info(`Failed to start Connection Forward: ${e.message}`);
+      this.logger.debug(`Failed to start Connection Forward: ${e.message}`);
       throw new networkErrors.ErrorConnectionStart(undefined, {
         cause: e,
       });
@@ -196,7 +196,7 @@ class ConnectionForward extends Connection {
     this.tlsSocket.on('error', this.handleError);
     this.tlsSocket.off('error', handleStartError);
     if (ctx.signal.aborted) {
-      this.logger.info(`Failed to start Connection Forward: aborted`);
+      this.logger.debug(`Failed to start Connection Forward: aborted`);
       // Clean up partial start
       // TLSSocket isn't established yet, so it is destroyed
       if (!this.tlsSocket.destroyed) {
@@ -220,7 +220,7 @@ class ConnectionForward extends Connection {
         serverCertChain,
       );
     } catch (e) {
-      this.logger.info(
+      this.logger.debug(
         `Failed to start Connection Forward: verification failed`,
       );
       // Clean up partial start

--- a/src/network/ConnectionForward.ts
+++ b/src/network/ConnectionForward.ts
@@ -137,6 +137,10 @@ class ConnectionForward extends Connection {
     } else {
       ctx.signal.addEventListener('abort', () => resolveAbortedP());
     }
+    void ctx.timer.then(
+      () => resolveAbortedP(),
+      () => {},
+    );
     this.resolveReadyP = resolveReadyP;
     this.utpSocket.on('message', this.handleMessage);
     const handleStartError = (e) => {

--- a/src/network/errors.ts
+++ b/src/network/errors.ts
@@ -57,6 +57,11 @@ class ErrorConnectionEndTimeout<T> extends ErrorConnection<T> {
   exitCode = sysexits.UNAVAILABLE;
 }
 
+class ErrorConnectionNodesEmpty<T> extends ErrorConnection<T> {
+  static description = 'Nodes list to verify against was empty';
+  exitCode = sysexits.USAGE;
+}
+
 /**
  * Used by ConnectionForward and ConnectionReverse
  */
@@ -148,6 +153,7 @@ export {
   ErrorConnectionMessageParse,
   ErrorConnectionTimeout,
   ErrorConnectionEndTimeout,
+  ErrorConnectionNodesEmpty,
   ErrorConnectionStart,
   ErrorConnectionStartTimeout,
   ErrorConnectionStartTimeoutMax,

--- a/src/network/errors.ts
+++ b/src/network/errors.ts
@@ -129,9 +129,9 @@ class ErrorCertChainSignatureInvalid<T> extends ErrorCertChain<T> {
   exitCode = sysexits.PROTOCOL;
 }
 
-class ErrorHostnameResolutionFailed<T> extends ErrorNetwork<T> {
-  static description = 'Unable to resolve hostname';
-  exitCode = sysexits.USAGE;
+class ErrorDNSResolver<T> extends ErrorNetwork<T> {
+  static description = 'DNS resolution failed';
+  exitCode = sysexits.SOFTWARE;
 }
 
 export {
@@ -161,5 +161,5 @@ export {
   ErrorCertChainNameInvalid,
   ErrorCertChainKeyInvalid,
   ErrorCertChainSignatureInvalid,
-  ErrorHostnameResolutionFailed,
+  ErrorDNSResolver,
 };

--- a/src/network/utils.ts
+++ b/src/network/utils.ts
@@ -485,7 +485,12 @@ function verifyClientCertificateChain(certChain: Array<Certificate>): void {
   }
 }
 
-async function resolveAddresses(addresses: Array<NodeAddress>) {
+/**
+ * Takes an array of host or hostnames and resolves them to the host addresses.
+ * It will also filter out any duplicates or IPV6 addresses.
+ * @param addresses
+ */
+async function resolveHostnames(addresses: Array<NodeAddress>) {
   const existingAddresses: Set<string> = new Set();
   const final: Array<{ host: Host; port: Port }> = [];
   for (const address of addresses) {
@@ -526,5 +531,5 @@ export {
   getCertificateChain,
   verifyServerCertificateChain,
   verifyClientCertificateChain,
-  resolveAddresses,
+  resolveHostnames,
 };

--- a/src/network/utils.ts
+++ b/src/network/utils.ts
@@ -490,7 +490,9 @@ function verifyClientCertificateChain(certChain: Array<Certificate>): void {
  * It will also filter out any duplicates or IPV6 addresses.
  * @param addresses
  */
-async function resolveHostnames(addresses: Array<NodeAddress>) {
+async function resolveHostnames(
+  addresses: Array<NodeAddress>,
+): Promise<Array<{ host: Host; port: Port }>> {
   const existingAddresses: Set<string> = new Set();
   const final: Array<{ host: Host; port: Port }> = [];
   for (const address of addresses) {

--- a/src/nodes/NodeConnection.ts
+++ b/src/nodes/NodeConnection.ts
@@ -44,6 +44,7 @@ class NodeConnection<T extends GRPCClient> {
       proxy,
       clientFactory,
       destroyCallback = async () => {},
+      destroyTimeout,
       logger = new Logger(this.name),
     }: {
       targetNodeId: NodeId;
@@ -53,6 +54,7 @@ class NodeConnection<T extends GRPCClient> {
       proxy: Proxy;
       clientFactory: (...args) => Promise<T>;
       destroyCallback?: () => Promise<void>;
+      destroyTimeout?: number;
       logger?: Logger;
     },
     ctx?: Partial<ContextTimed>,

--- a/src/nodes/NodeConnection.ts
+++ b/src/nodes/NodeConnection.ts
@@ -121,7 +121,7 @@ class NodeConnection<T extends GRPCClient> {
         // Think about this
         logger: clientLogger,
         destroyCallback: async () => {
-          clientLogger.info(`GRPC client triggered destroyedCallback`);
+          clientLogger.debug(`GRPC client triggered destroyedCallback`);
           if (
             nodeConnection[asyncInit.status] !== 'destroying' &&
             !nodeConnection[asyncInit.destroyed]
@@ -189,7 +189,7 @@ class NodeConnection<T extends GRPCClient> {
     ) {
       await this.client.destroy({ timeout });
     }
-    this.logger.info(`${this.constructor.name} triggered destroyedCallback`);
+    this.logger.debug(`${this.constructor.name} triggered destroyedCallback`);
     await this.destroyCallback();
     this.logger.info(`Destroyed ${this.constructor.name}`);
   }

--- a/src/nodes/NodeConnectionManager.ts
+++ b/src/nodes/NodeConnectionManager.ts
@@ -811,6 +811,16 @@ class NodeConnectionManager {
     proxyAddress: string | undefined,
     @context ctx: ContextTimed,
   ): Promise<void> {
+    if (
+      this.keyManager.getNodeId().equals(relayNodeId) ||
+      this.keyManager.getNodeId().equals(targetNodeId)
+    ) {
+      // Logging and silently dropping operation
+      this.logger.warn(
+        'Attempted to send signalling message to our own NodeId',
+      );
+      return;
+    }
     const rlyNode = nodesUtils.encodeNodeId(relayNodeId);
     const srcNode = nodesUtils.encodeNodeId(sourceNodeId);
     const tgtNode = nodesUtils.encodeNodeId(targetNodeId);

--- a/src/nodes/NodeConnectionManager.ts
+++ b/src/nodes/NodeConnectionManager.ts
@@ -331,7 +331,7 @@ class NodeConnectionManager {
           //  It needs to timeout as well as abort for cleanup
           void Array.from(seedNodes, (seedNodeId) => {
             return (
-              this.sendSignallingMessage(
+              this.sendSignalingMessage(
                 seedNodeId,
                 this.keyManager.getNodeId(),
                 targetNodeId,
@@ -804,7 +804,7 @@ class NodeConnectionManager {
    * @param proxyAddress string of address in the form `proxyHost:proxyPort`
    * @param ctx
    */
-  public sendSignallingMessage(
+  public sendSignalingMessage(
     relayNodeId: NodeId,
     sourceNodeId: NodeId,
     targetNodeId: NodeId,
@@ -817,7 +817,7 @@ class NodeConnectionManager {
     (nodeConnectionManager: NodeConnectionManager) =>
       nodeConnectionManager.connConnectTime,
   )
-  public async sendSignallingMessage(
+  public async sendSignalingMessage(
     relayNodeId: NodeId,
     sourceNodeId: NodeId,
     targetNodeId: NodeId,
@@ -830,7 +830,7 @@ class NodeConnectionManager {
     ) {
       // Logging and silently dropping operation
       this.logger.warn(
-        'Attempted to send signalling message to our own NodeId',
+        'Attempted to send signaling message to our own NodeId',
       );
       return;
     }
@@ -838,7 +838,7 @@ class NodeConnectionManager {
     const srcNode = nodesUtils.encodeNodeId(sourceNodeId);
     const tgtNode = nodesUtils.encodeNodeId(targetNodeId);
     this.logger.debug(
-      `sendSignallingMessage sending Signalling message relay: ${rlyNode}, source: ${srcNode}, target: ${tgtNode}, proxy: ${proxyAddress}`,
+      `sendSignalingMessage sending Signaling message relay: ${rlyNode}, source: ${srcNode}, target: ${tgtNode}, proxy: ${proxyAddress}`,
     );
     const relayMsg = new nodesPB.Relay();
     relayMsg.setSrcId(srcNode);
@@ -865,7 +865,7 @@ class NodeConnectionManager {
    * @param sourceAddress
    * @param ctx
    */
-  public relaySignallingMessage(
+  public relaySignalingMessage(
     message: nodesPB.Relay,
     sourceAddress: NodeAddress,
     ctx?: Partial<ContextTimed>,
@@ -876,7 +876,7 @@ class NodeConnectionManager {
     (nodeConnectionManager: NodeConnectionManager) =>
       nodeConnectionManager.connConnectTime,
   )
-  public async relaySignallingMessage(
+  public async relaySignalingMessage(
     message: nodesPB.Relay,
     sourceAddress: NodeAddress,
     @context ctx: ContextTimed,
@@ -885,7 +885,7 @@ class NodeConnectionManager {
     // If we're relaying then we trust our own node graph records over
     // what was provided in the message
     const sourceNode = validationUtils.parseNodeId(message.getSrcId());
-    await this.sendSignallingMessage(
+    await this.sendSignalingMessage(
       validationUtils.parseNodeId(message.getTargetId()),
       sourceNode,
       validationUtils.parseNodeId(message.getTargetId()),
@@ -951,7 +951,7 @@ class NodeConnectionManager {
     if (!isSeedNode) {
       void Array.from(this.getSeedNodes(), async (seedNodeId) => {
         // FIXME: this needs to handle aborting
-        void this.sendSignallingMessage(
+        void this.sendSignalingMessage(
           seedNodeId,
           this.keyManager.getNodeId(),
           nodeId,

--- a/src/nodes/NodeConnectionManager.ts
+++ b/src/nodes/NodeConnectionManager.ts
@@ -1030,6 +1030,10 @@ class NodeConnectionManager {
     return establishedMap;
   }
 
+  public hasConnection(nodeId: NodeId): boolean {
+    return this.connections.has(nodeId.toString() as NodeIdString);
+  }
+
   protected hasBackoff(nodeId: NodeId): boolean {
     const backoff = this.nodesBackoffMap.get(nodeId.toString());
     if (backoff == null) return false;

--- a/src/nodes/NodeConnectionManager.ts
+++ b/src/nodes/NodeConnectionManager.ts
@@ -829,9 +829,7 @@ class NodeConnectionManager {
       this.keyManager.getNodeId().equals(targetNodeId)
     ) {
       // Logging and silently dropping operation
-      this.logger.warn(
-        'Attempted to send signaling message to our own NodeId',
-      );
+      this.logger.warn('Attempted to send signaling message to our own NodeId');
       return;
     }
     const rlyNode = nodesUtils.encodeNodeId(relayNodeId);

--- a/src/nodes/NodeConnectionManager.ts
+++ b/src/nodes/NodeConnectionManager.ts
@@ -295,24 +295,24 @@ class NodeConnectionManager {
   ): Promise<ConnectionAndTimer> {
     const targetNodeIdString = targetNodeId.toString() as NodeIdString;
     const targetNodeIdEncoded = nodesUtils.encodeNodeId(targetNodeId);
-    this.logger.info(`Getting NodeConnection for ${targetNodeIdEncoded}`);
+    this.logger.debug(`Getting NodeConnection for ${targetNodeIdEncoded}`);
     return await this.connectionLocks.withF(
       [targetNodeIdString, Lock],
       async () => {
         const connAndTimer = this.connections.get(targetNodeIdString);
         if (connAndTimer != null) {
-          this.logger.info(
+          this.logger.debug(
             `Found existing NodeConnection for ${targetNodeIdEncoded}`,
           );
           return connAndTimer;
         }
         // Creating the connection and set in map
-        this.logger.info(`Finding address for ${targetNodeIdEncoded}`);
+        this.logger.debug(`Finding address for ${targetNodeIdEncoded}`);
         const targetAddress = await this.findNode(targetNodeId);
         if (targetAddress == null) {
           throw new nodesErrors.ErrorNodeGraphNodeIdNotFound();
         }
-        this.logger.info(
+        this.logger.debug(
           `Found address for ${targetNodeIdEncoded} at ${targetAddress.host}:${targetAddress.port}`,
         );
         // If the stored host is not a valid host (IP address),
@@ -323,7 +323,7 @@ class NodeConnectionManager {
         const targetAddresses = await networkUtils.resolveHostnames([
           targetAddress,
         ]);
-        this.logger.info(`Creating NodeConnection for ${targetNodeIdEncoded}`);
+        this.logger.debug(`Creating NodeConnection for ${targetNodeIdEncoded}`);
         // Start the hole punching only if we are not connecting to seed nodes
         const seedNodes = this.getSeedNodes();
         if (this.isSeedNode(targetNodeId)) {
@@ -376,7 +376,7 @@ class NodeConnectionManager {
           void nodeConnectionProm.then(
             () => firstConnectionIndexProm.resolveP(index),
             (e) => {
-              this.logger.info(
+              this.logger.debug(
                 `Creating NodeConnection failed for ${targetNodeIdEncoded}`,
               );
               // Disable destroyCallback clean up
@@ -394,7 +394,7 @@ class NodeConnectionManager {
           newConnection = await Promise.any(nodeConnectionProms);
         } catch (e) {
           // All connections failed to establish
-          this.logger.info(
+          this.logger.debug(
             `Failed NodeConnection for ${targetNodeIdEncoded} with ${errors}`,
           );
           if (errors.length === 1) {
@@ -423,7 +423,7 @@ class NodeConnectionManager {
         );
         // Final set up
         void destroyCallbackProms[successfulIndex].p.then(async () => {
-          this.logger.info('DestroyedCallback was called');
+          this.logger.debug('DestroyedCallback was called');
           // To avoid deadlock only in the case where this is called
           // we want to check for destroying connection and read lock
           const connAndTimer = this.connections.get(targetNodeIdString);
@@ -454,7 +454,7 @@ class NodeConnectionManager {
         };
         this.connections.set(targetNodeIdString, newConnAndTimer);
         // Enable destroyCallback clean up
-        this.logger.info(`Created NodeConnection for ${targetNodeIdEncoded}`);
+        this.logger.debug(`Created NodeConnection for ${targetNodeIdEncoded}`);
         return newConnAndTimer;
       },
     );
@@ -471,7 +471,7 @@ class NodeConnectionManager {
       async () => {
         const connAndTimer = this.connections.get(targetNodeIdString);
         if (connAndTimer?.connection == null) return;
-        this.logger.info(
+        this.logger.debug(
           `Destroying NodeConnection for ${nodesUtils.encodeNodeId(
             targetNodeId,
           )}`,

--- a/src/nodes/NodeConnectionManager.ts
+++ b/src/nodes/NodeConnectionManager.ts
@@ -120,6 +120,8 @@ class NodeConnectionManager {
     this.nodeGraph = nodeGraph;
     this.proxy = proxy;
     this.taskManager = taskManager;
+    const localNodeIdEncoded = nodesUtils.encodeNodeId(keyManager.getNodeId());
+    delete seedNodes[localNodeIdEncoded];
     this.seedNodes = seedNodes;
     this.initialClosestNodes = initialClosestNodes;
     this.connConnectTime = connConnectTime;

--- a/src/nodes/NodeManager.ts
+++ b/src/nodes/NodeManager.ts
@@ -1132,7 +1132,7 @@ class NodeManager {
       )}`,
     );
     logger.info(
-      `and addresses addresses ${filteredAddresses.map(
+      `and addresses ${filteredAddresses.map(
         (address) => `${address.host}:${address.port}`,
       )}`,
     );

--- a/src/nodes/NodeManager.ts
+++ b/src/nodes/NodeManager.ts
@@ -21,7 +21,6 @@ import * as nodesErrors from './errors';
 import * as nodesUtils from './utils';
 import * as tasksErrors from '../tasks/errors';
 import { timedCancellable, context } from '../contexts';
-import * as networkUtils from '../network/utils';
 import * as validationUtils from '../validation/utils';
 import * as utilsPB from '../proto/js/polykey/v1/utils/utils_pb';
 import * as claimsErrors from '../claims/errors';
@@ -107,18 +106,8 @@ class NodeManager {
       );
       never();
     }
-    const host_ = await networkUtils.resolveHost(host);
-    if (
-      await this.pingNode(nodeId, { host: host_, port }, { signal: ctx.signal })
-    ) {
-      await this.setNode(
-        nodeId,
-        { host: host_, port },
-        false,
-        false,
-        2000,
-        ctx,
-      );
+    if (await this.pingNode(nodeId, { host, port }, { signal: ctx.signal })) {
+      await this.setNode(nodeId, { host, port }, false, false, 2000, ctx);
     }
   };
   public readonly pingAndSetNodeHandlerId: TaskHandlerId =
@@ -237,10 +226,9 @@ class NodeManager {
     if (targetAddress == null) {
       return false;
     }
-    const targetHost = await networkUtils.resolveHost(targetAddress.host);
     return await this.nodeConnectionManager.pingNode(
       nodeId,
-      targetHost,
+      targetAddress.host,
       targetAddress.port,
       ctx,
     );

--- a/src/nodes/NodeManager.ts
+++ b/src/nodes/NodeManager.ts
@@ -123,7 +123,7 @@ class NodeManager {
     ctx,
     taskInfo,
   ) => {
-    this.logger.info('Checking seed connections');
+    this.logger.debug('Checking seed connections');
     // Check for existing seed node connections
     const seedNodes = this.nodeConnectionManager.getSeedNodes();
     const allInactive = !seedNodes
@@ -131,7 +131,7 @@ class NodeManager {
       .reduce((a, b) => a || b);
     try {
       if (allInactive) {
-        this.logger.info(
+        this.logger.debug(
           'No active seed connections were found, retrying network entry',
         );
         // If no seed node connections exist then we redo syncNodeGraph
@@ -142,7 +142,7 @@ class NodeManager {
           seedNodes.map((nodeId) => {
             // Retry any failed seed node connections
             if (!this.nodeConnectionManager.hasConnection(nodeId)) {
-              this.logger.info(
+              this.logger.debug(
                 `Re-establishing seed connection for ${nodesUtils.encodeNodeId(
                   nodeId,
                 )}`,
@@ -159,7 +159,7 @@ class NodeManager {
         );
       }
     } finally {
-      this.logger.info('Checked seed connections');
+      this.logger.debug('Checked seed connections');
       // Re-schedule this task
       await this.taskManager.scheduleTask({
         delay: taskInfo.delay,
@@ -1126,12 +1126,12 @@ class NodeManager {
     const filteredAddresses = addresses.filter(
       (address) => address != null,
     ) as Array<NodeAddress>;
-    logger.info(
+    logger.debug(
       `establishing multi-connection to the following seed nodes ${seedNodes.map(
         (nodeId) => nodesUtils.encodeNodeId(nodeId),
       )}`,
     );
-    logger.info(
+    logger.debug(
       `and addresses ${filteredAddresses.map(
         (address) => `${address.host}:${address.port}`,
       )}`,
@@ -1145,9 +1145,9 @@ class NodeManager {
         undefined,
         { signal: ctx.signal },
       );
-    logger.info(`Multi-connection established for`);
+    logger.debug(`Multi-connection established for`);
     connections.forEach((address, key) => {
-      logger.info(
+      logger.debug(
         `${nodesUtils.encodeNodeId(key)}@${address.host}:${address.port}`,
       );
     });
@@ -1162,7 +1162,7 @@ class NodeManager {
     const closestNodesAll: Map<NodeId, NodeData> = new Map();
     const localNodeId = this.keyManager.getNodeId();
     let closestNode: NodeId | null = null;
-    logger.info('Getting closest nodes');
+    logger.debug('Getting closest nodes');
     for (const [nodeId] of connections) {
       const closestNodes =
         await this.nodeConnectionManager.getRemoteNodeClosestNodes(
@@ -1187,11 +1187,11 @@ class NodeManager {
       const distB = nodesUtils.nodeDistance(localNodeId, closestNode);
       if (distA < distB) closestNode = closeNode;
     }
-    logger.info('Starting pingsAndSet tasks');
+    logger.debug('Starting pingsAndSet tasks');
     const pingTasks: Array<Task> = [];
     for (const [nodeId, nodeData] of closestNodesAll) {
       if (!localNodeId.equals(nodeId)) {
-        logger.info(
+        logger.debug(
           `pingAndSetTask for ${nodesUtils.encodeNodeId(nodeId)}@${
             nodeData.address.host
           }:${nodeData.address.port}`,
@@ -1215,7 +1215,7 @@ class NodeManager {
     }
     if (block) {
       // We want to wait for all the tasks
-      logger.info('Awaiting all pingAndSetTasks');
+      logger.debug('Awaiting all pingAndSetTasks');
       await Promise.all(
         pingTasks.map((task) => {
           const prom = task.promise();
@@ -1233,7 +1233,7 @@ class NodeManager {
       );
     }
     // Refreshing every bucket above the closest node
-    logger.info(`Triggering refreshBucket tasks`);
+    logger.debug(`Triggering refreshBucket tasks`);
     let index = this.nodeGraph.nodeIdBits;
     if (closestNode != null) {
       const [bucketIndex] = this.nodeGraph.bucketIndex(closestNode);
@@ -1245,7 +1245,7 @@ class NodeManager {
       refreshBuckets.push(task.promise());
     }
     if (block) {
-      logger.info(`Awaiting refreshBucket tasks`);
+      logger.debug(`Awaiting refreshBucket tasks`);
       await Promise.all(refreshBuckets);
     }
   }

--- a/src/nodes/NodeManager.ts
+++ b/src/nodes/NodeManager.ts
@@ -690,6 +690,8 @@ class NodeManager {
     const unsetLock = new Lock();
     const pendingPromises: Array<Promise<void>> = [];
     for (const nodeId of bucket) {
+      // We want to retain seed nodes regardless of state, so skip them
+      if (this.nodeConnectionManager.isSeedNode(nodeId)) continue;
       if (removedNodes >= pendingNodes.size) break;
       await semaphore.waitForUnlock();
       if (ctx.signal?.aborted === true) break;

--- a/src/nodes/NodeManager.ts
+++ b/src/nodes/NodeManager.ts
@@ -311,7 +311,6 @@ class NodeManager {
           ) as PublicKeyPem;
           return [unverifiedChainData, publicKey];
         },
-        connectionTimeout,
         { signal: ctx.signal, timer },
       );
 
@@ -345,7 +344,6 @@ class NodeManager {
             async (connection) => {
               return connection.getExpectedPublicKey(endNodeId) as PublicKeyPem;
             },
-            connectionTimeout,
             { signal: ctx.signal, timer },
           );
           if (!endPublicKey) {

--- a/src/nodes/errors.ts
+++ b/src/nodes/errors.ts
@@ -62,6 +62,11 @@ class ErrorNodeConnectionTimeout<T> extends ErrorNodes<T> {
   exitCode = sysexits.UNAVAILABLE;
 }
 
+class ErrorNodeConnectionMultiConnectionFailed<T> extends ErrorNodes<T> {
+  static description: 'Could not establish connection when multiple resolved hosts were involved';
+  exitCode = sysexits.UNAVAILABLE;
+}
+
 class ErrorNodeConnectionInfoNotExist<T> extends ErrorNodes<T> {
   static description: 'NodeConnection info was not found';
   exitCode = sysexits.UNAVAILABLE;
@@ -101,6 +106,7 @@ export {
   ErrorNodeGraphBucketIndex,
   ErrorNodeConnectionDestroyed,
   ErrorNodeConnectionTimeout,
+  ErrorNodeConnectionMultiConnectionFailed,
   ErrorNodeConnectionInfoNotExist,
   ErrorNodeConnectionPublicKeyNotFound,
   ErrorNodeConnectionManagerNotRunning,

--- a/src/nodes/errors.ts
+++ b/src/nodes/errors.ts
@@ -86,6 +86,13 @@ class ErrorNodeConnectionHostWildcard<T> extends ErrorNodes<T> {
   static description = 'An IP wildcard was provided for the target host';
   exitCode = sysexits.USAGE;
 }
+
+class ErrorNodeConnectionSameNodeId<T> extends ErrorNodes<T> {
+  static description =
+    'Provided NodeId is the same as this agent, attempts to connect is improper usage';
+  exitCode = sysexits.USAGE;
+}
+
 class ErrorNodePingFailed<T> extends ErrorNodes<T> {
   static description =
     'Failed to ping the node when attempting to authenticate';
@@ -111,5 +118,6 @@ export {
   ErrorNodeConnectionPublicKeyNotFound,
   ErrorNodeConnectionManagerNotRunning,
   ErrorNodeConnectionHostWildcard,
+  ErrorNodeConnectionSameNodeId,
   ErrorNodePingFailed,
 };

--- a/src/nodes/utils.ts
+++ b/src/nodes/utils.ts
@@ -298,7 +298,8 @@ function isConnectionError(e): boolean {
     e instanceof nodesErrors.ErrorNodeConnectionDestroyed ||
     e instanceof grpcErrors.ErrorGRPC ||
     e instanceof agentErrors.ErrorAgentClientDestroyed ||
-    e instanceof nodesErrors.ErrorNodeConnectionTimeout
+    e instanceof nodesErrors.ErrorNodeConnectionTimeout ||
+    e instanceof nodesErrors.ErrorNodeConnectionMultiConnectionFailed
   );
 }
 

--- a/tests/agent/service/nodesHolePunchMessage.test.ts
+++ b/tests/agent/service/nodesHolePunchMessage.test.ts
@@ -47,7 +47,12 @@ describe('nodesHolePunchMessage', () => {
         nodeConnectionManager: pkAgent.nodeConnectionManager,
         nodeManager: pkAgent.nodeManager,
         db: pkAgent.db,
-        connectionInfoGet: () => ({} as ConnectionInfo),
+        connectionInfoGet: () =>
+          ({
+            remoteHost: '127.0.0.1' as Host,
+            remotePort: 55555 as Port,
+            remoteNodeId: pkAgent.keyManager.getNodeId(),
+          } as ConnectionInfo),
         logger,
       }),
     };

--- a/tests/bin/agent/start.test.ts
+++ b/tests/bin/agent/start.test.ts
@@ -517,7 +517,7 @@ describe('start', () => {
           // This line is brittle
           // It may change if the log format changes
           // Make sure to keep it updated at the exact point when the DB is created
-          if (l === 'INFO:DB:Created DB') {
+          if (l === 'INFO:polykey.PolykeyAgent.DB:Created DB') {
             agentProcess1.kill('SIGINT');
             resolve();
           }

--- a/tests/bin/bootstrap.test.ts
+++ b/tests/bin/bootstrap.test.ts
@@ -279,7 +279,7 @@ describe('bootstrap', () => {
           // This line is brittle
           // It may change if the log format changes
           // Make sure to keep it updated at the exact point when the root key pair is generated
-          if (l === 'INFO:KeyManager:Generating root key pair') {
+          if (l === 'INFO:polykey.KeyManager:Generating root key pair') {
             bootstrapProcess1.kill('SIGINT');
             resolve();
           }

--- a/tests/bin/polykey.test.ts
+++ b/tests/bin/polykey.test.ts
@@ -64,7 +64,7 @@ describe('polykey', () => {
     const stderrParsed = JSON.parse(stderrStart);
     expect(stderrParsed).toMatchObject({
       level: expect.stringMatching(/INFO|WARN|ERROR|DEBUG/),
-      key: expect.any(String),
+      keys: expect.any(String),
       msg: expect.any(String),
     });
     agentProcess.kill('SIGTERM');

--- a/tests/network/Proxy.test.ts
+++ b/tests/network/Proxy.test.ts
@@ -259,7 +259,7 @@ describe(Proxy.name, () => {
     });
     // Cannot open connection to port 0
     await expect(() =>
-      proxy.openConnectionForward(nodeIdABC, localHost, 0 as Port),
+      proxy.openConnectionForward([nodeIdABC], localHost, 0 as Port),
     ).rejects.toThrow(networkErrors.ErrorConnectionStart);
     await expect(() =>
       httpConnect(
@@ -305,7 +305,7 @@ describe(Proxy.name, () => {
     const utpSocketHangPort = utpSocketHang.address().port;
     await expect(() =>
       proxy.openConnectionForward(
-        nodeIdABC,
+        [nodeIdABC],
         localHost,
         utpSocketHangPort as Port,
       ),
@@ -315,7 +315,7 @@ describe(Proxy.name, () => {
     const timer = new Timer({ delay: 2000 });
     await expect(() =>
       proxy.openConnectionForward(
-        nodeIdABC,
+        [nodeIdABC],
         localHost,
         utpSocketHangPort as Port,
         { timer },
@@ -342,6 +342,7 @@ describe(Proxy.name, () => {
     const proxy = new Proxy({
       authToken,
       logger: logger.getChild('Proxy connection reset'),
+      connConnectTime: 10000,
     });
     await proxy.start({
       tlsConfig: {
@@ -368,7 +369,7 @@ describe(Proxy.name, () => {
     const utpSocketEndPort = utpSocketEnd.address().port;
     await expect(() =>
       proxy.openConnectionForward(
-        nodeIdABC,
+        [nodeIdABC],
         localHost,
         utpSocketEndPort as Port,
       ),
@@ -377,11 +378,11 @@ describe(Proxy.name, () => {
     // The actual error is UTP_ECONNRESET to be precise
     await expect(() =>
       proxy.openConnectionForward(
-        nodeIdABC,
+        [nodeIdABC],
         localHost,
         utpSocketEndPort as Port,
       ),
-    ).rejects.toThrow(/UTP_ECONNRESET/);
+    ).rejects.toThrow(networkErrors.ErrorConnectionStart);
     expect(receivedCount).toBe(2);
     // 502 Bad Gateway on HTTP Connect
     await expect(() =>
@@ -483,7 +484,7 @@ describe(Proxy.name, () => {
     // This is a TLS handshake failure
     await expect(() =>
       proxy.openConnectionForward(
-        nodeIdRandom,
+        [nodeIdRandom],
         utpSocketHost as Host,
         utpSocketPort as Port,
       ),
@@ -722,7 +723,7 @@ describe(Proxy.name, () => {
     expect(proxy.getConnectionForwardCount()).toBe(0);
     await expect(() =>
       proxy.openConnectionForward(
-        nodeIdRandom,
+        [nodeIdRandom],
         utpSocketHost as Host,
         utpSocketPort as Port,
       ),
@@ -983,7 +984,7 @@ describe(Proxy.name, () => {
     const utpSocketPort = utpSocket.address().port;
     expect(proxy.getConnectionForwardCount()).toBe(0);
     await proxy.openConnectionForward(
-      serverNodeId,
+      [serverNodeId],
       utpSocketHost as Host,
       utpSocketPort as Port,
     );
@@ -991,7 +992,7 @@ describe(Proxy.name, () => {
     await expect(remoteSecureP).resolves.toBeUndefined();
     // Opening a duplicate connection is noop
     await proxy.openConnectionForward(
-      serverNodeId,
+      [serverNodeId],
       utpSocketHost as Host,
       utpSocketPort as Port,
     );
@@ -1115,7 +1116,7 @@ describe(Proxy.name, () => {
     const utpSocketPort = utpSocket.address().port;
     expect(proxy.getConnectionForwardCount()).toBe(0);
     await proxy.openConnectionForward(
-      serverNodeId,
+      [serverNodeId],
       utpSocketHost as Host,
       utpSocketPort as Port,
     );
@@ -1123,7 +1124,7 @@ describe(Proxy.name, () => {
     await expect(remoteSecureP).resolves.toBeUndefined();
     // Opening a duplicate connection is noop
     await proxy.openConnectionForward(
-      serverNodeId,
+      [serverNodeId],
       utpSocketHost as Host,
       utpSocketPort as Port,
     );
@@ -1300,7 +1301,7 @@ describe(Proxy.name, () => {
     });
     // Opening a duplicate connection is noop
     await proxy.openConnectionForward(
-      serverNodeId,
+      [serverNodeId],
       utpSocketHost as Host,
       utpSocketPort as Port,
     );
@@ -1454,7 +1455,7 @@ describe(Proxy.name, () => {
     });
     // Opening a duplicate connection is noop
     await proxy.openConnectionForward(
-      serverNodeId,
+      [serverNodeId],
       utpSocketHost as Host,
       utpSocketPort as Port,
     );
@@ -1614,7 +1615,7 @@ describe(Proxy.name, () => {
     });
     // Opening a duplicate connection is noop
     await proxy.openConnectionForward(
-      serverNodeId,
+      [serverNodeId],
       utpSocketHost as Host,
       utpSocketPort as Port,
     );
@@ -1752,7 +1753,7 @@ describe(Proxy.name, () => {
     const utpSocketHost = utpSocket.address().address;
     const utpSocketPort = utpSocket.address().port;
     await proxy.openConnectionForward(
-      serverNodeId,
+      [serverNodeId],
       utpSocketHost as Host,
       utpSocketPort as Port,
     );
@@ -1888,7 +1889,7 @@ describe(Proxy.name, () => {
     const utpSocketPort = utpSocket.address().port;
     expect(proxy.getConnectionForwardCount()).toBe(0);
     await proxy.openConnectionForward(
-      serverNodeId,
+      [serverNodeId],
       utpSocketHost as Host,
       utpSocketPort as Port,
     );
@@ -2134,7 +2135,7 @@ describe(Proxy.name, () => {
     const utpSocketPort = utpSocket.address().port;
     expect(proxy.getConnectionForwardCount()).toBe(0);
     await proxy.openConnectionForward(
-      serverNodeId,
+      [serverNodeId],
       utpSocketHost as Host,
       utpSocketPort as Port,
     );
@@ -2285,12 +2286,12 @@ describe(Proxy.name, () => {
     const utpSocketPort2 = utpSocket2.address().port;
     expect(proxy.getConnectionForwardCount()).toBe(0);
     await proxy.openConnectionForward(
-      serverNodeId1,
+      [serverNodeId1],
       utpSocketHost1 as Host,
       utpSocketPort1 as Port,
     );
     await proxy.openConnectionForward(
-      serverNodeId2,
+      [serverNodeId2],
       utpSocketHost2 as Host,
       utpSocketPort2 as Port,
     );

--- a/tests/network/utils.test.ts
+++ b/tests/network/utils.test.ts
@@ -1,6 +1,5 @@
-import type { Host, Port } from '@/network/types';
+import type { Host, Hostname, Port } from '@/network/types';
 import * as networkUtils from '@/network/utils';
-import * as networkErrors from '@/network/errors';
 
 describe('utils', () => {
   test('building addresses', async () => {
@@ -25,12 +24,14 @@ describe('utils', () => {
   });
   test('resolving hostnames', async () => {
     await expect(
-      networkUtils.resolveHost('www.google.com' as Host),
+      networkUtils.resolveHostname('www.google.com' as Hostname),
     ).resolves.toBeDefined();
-    const host = await networkUtils.resolveHost('www.google.com' as Host);
-    expect(networkUtils.isHost(host)).toBeTruthy();
+    const hosts = await networkUtils.resolveHostname(
+      'www.google.com' as Hostname,
+    );
+    expect(hosts.length).toBeGreaterThan(0);
     await expect(
-      networkUtils.resolveHost('invalidHostname' as Host),
-    ).rejects.toThrow(networkErrors.ErrorHostnameResolutionFailed);
+      networkUtils.resolveHostname('invalidHostname' as Hostname),
+    ).resolves.toHaveLength(0);
   });
 });

--- a/tests/nodes/NodeConnection.test.ts
+++ b/tests/nodes/NodeConnection.test.ts
@@ -389,8 +389,6 @@ describe(`${NodeConnection.name} test`, () => {
       targetHost: localHost,
       targetPort: targetPort,
       proxy: clientProxy,
-      keyManager: clientKeyManager,
-      nodeConnectionManager: clientNodeConnectionManager,
       destroyCallback,
       logger: logger,
       clientFactory: (args) => GRPCClientAgent.createGRPCClientAgent(args),
@@ -413,8 +411,6 @@ describe(`${NodeConnection.name} test`, () => {
       targetHost: localHost,
       targetPort: targetPort,
       proxy: clientProxy,
-      keyManager: clientKeyManager,
-      nodeConnectionManager: clientNodeConnectionManager,
       destroyCallback,
       logger: logger,
       clientFactory: async (args) =>
@@ -453,8 +449,6 @@ describe(`${NodeConnection.name} test`, () => {
       targetHost: localHost,
       targetPort: targetPort,
       proxy: clientProxy,
-      keyManager: clientKeyManager,
-      nodeConnectionManager: clientNodeConnectionManager,
       destroyCallback,
       logger: logger,
       clientFactory: async (args) =>
@@ -502,9 +496,7 @@ describe(`${NodeConnection.name} test`, () => {
       nodeConnection = await NodeConnection.createNodeConnection(
         {
           proxy: clientProxy,
-          keyManager: clientKeyManager,
           logger: logger,
-          nodeConnectionManager: clientNodeConnectionManager,
           destroyCallback: killSelf,
           targetHost: polykeyAgent.proxy.getProxyHost(),
           targetNodeId: polykeyAgent.keyManager.getNodeId(),
@@ -539,8 +531,6 @@ describe(`${NodeConnection.name} test`, () => {
           targetHost: '128.0.0.1' as Host,
           targetPort: 12345 as Port,
           proxy: clientProxy,
-          keyManager: clientKeyManager,
-          nodeConnectionManager: clientNodeConnectionManager,
           destroyCallback,
           logger: logger,
           clientFactory: (args) => GRPCClientAgent.createGRPCClientAgent(args),
@@ -557,8 +547,6 @@ describe(`${NodeConnection.name} test`, () => {
         targetHost: localHost,
         targetPort: 55556 as Port,
         proxy: clientProxy,
-        keyManager: clientKeyManager,
-        nodeConnectionManager: clientNodeConnectionManager,
         destroyCallback,
         logger: logger,
         clientFactory: (args) => GRPCClientAgent.createGRPCClientAgent(args),
@@ -585,8 +573,6 @@ describe(`${NodeConnection.name} test`, () => {
         targetHost: localHost,
         targetPort: targetPort,
         proxy: clientProxy,
-        keyManager: clientKeyManager,
-        nodeConnectionManager: clientNodeConnectionManager,
         destroyCallback,
         logger: logger,
         clientFactory: async (args) =>
@@ -606,8 +592,6 @@ describe(`${NodeConnection.name} test`, () => {
         targetHost: localHost,
         targetPort: targetPort,
         proxy: clientProxy,
-        keyManager: clientKeyManager,
-        nodeConnectionManager: clientNodeConnectionManager,
         destroyCallback,
         logger: logger,
         clientFactory: async (args) =>
@@ -644,9 +628,7 @@ describe(`${NodeConnection.name} test`, () => {
       const nodeConnectionP = NodeConnection.createNodeConnection(
         {
           proxy: clientProxy,
-          keyManager: clientKeyManager,
           logger: logger,
-          nodeConnectionManager: clientNodeConnectionManager,
           destroyCallback: killSelf,
           targetHost: proxy.getProxyHost(),
           targetNodeId: targetNodeId,
@@ -689,9 +671,7 @@ describe(`${NodeConnection.name} test`, () => {
       const nodeConnectionP = NodeConnection.createNodeConnection(
         {
           proxy: clientProxy,
-          keyManager: clientKeyManager,
           logger: logger,
-          nodeConnectionManager: clientNodeConnectionManager,
           destroyCallback: killSelf,
           targetHost: proxy.getProxyHost(),
           targetNodeId: targetNodeId,
@@ -732,9 +712,7 @@ describe(`${NodeConnection.name} test`, () => {
       nodeConnection = await NodeConnection.createNodeConnection(
         {
           proxy: clientProxy,
-          keyManager: clientKeyManager,
           logger: logger,
-          nodeConnectionManager: clientNodeConnectionManager,
           destroyCallback: killSelf,
           targetHost: polykeyAgent.proxy.getProxyHost(),
           targetNodeId: polykeyAgent.keyManager.getNodeId(),
@@ -803,9 +781,7 @@ describe(`${NodeConnection.name} test`, () => {
         nodeConnection = await NodeConnection.createNodeConnection(
           {
             proxy: clientProxy,
-            keyManager: clientKeyManager,
             logger: logger,
-            nodeConnectionManager: clientNodeConnectionManager,
             destroyCallback: async () => {
               await killSelfCheck();
               killSelfP.resolveP(null);
@@ -882,9 +858,7 @@ describe(`${NodeConnection.name} test`, () => {
         nodeConnection = await NodeConnection.createNodeConnection(
           {
             proxy: clientProxy,
-            keyManager: clientKeyManager,
             logger: logger,
-            nodeConnectionManager: clientNodeConnectionManager,
             destroyCallback: async () => {
               await killSelfCheck();
               killSelfP.resolveP(null);
@@ -929,8 +903,6 @@ describe(`${NodeConnection.name} test`, () => {
           targetHost: localHost,
           targetPort: targetPort,
           proxy: clientProxy,
-          keyManager: clientKeyManager,
-          nodeConnectionManager: clientNodeConnectionManager,
           destroyCallback,
           logger: logger,
           clientFactory: async (args) =>
@@ -960,8 +932,6 @@ describe(`${NodeConnection.name} test`, () => {
           targetHost: localHost,
           targetPort: targetPort,
           proxy: clientProxy,
-          keyManager: clientKeyManager,
-          nodeConnectionManager: clientNodeConnectionManager,
           destroyCallback,
           logger: logger,
           clientFactory: async (args) =>
@@ -991,8 +961,6 @@ describe(`${NodeConnection.name} test`, () => {
           targetHost: localHost,
           targetPort: targetPort,
           proxy: clientProxy,
-          keyManager: clientKeyManager,
-          nodeConnectionManager: clientNodeConnectionManager,
           destroyCallback,
           logger: logger,
           clientFactory: async (args) =>
@@ -1022,8 +990,6 @@ describe(`${NodeConnection.name} test`, () => {
           targetHost: localHost,
           targetPort: targetPort,
           proxy: clientProxy,
-          keyManager: clientKeyManager,
-          nodeConnectionManager: clientNodeConnectionManager,
           destroyCallback,
           logger: logger,
           clientFactory: async (args) =>
@@ -1053,8 +1019,6 @@ describe(`${NodeConnection.name} test`, () => {
           targetHost: localHost,
           targetPort: targetPort,
           proxy: clientProxy,
-          keyManager: clientKeyManager,
-          nodeConnectionManager: clientNodeConnectionManager,
           destroyCallback,
           logger: logger,
           clientFactory: async (args) =>
@@ -1084,8 +1048,6 @@ describe(`${NodeConnection.name} test`, () => {
           targetHost: localHost,
           targetPort: targetPort,
           proxy: clientProxy,
-          keyManager: clientKeyManager,
-          nodeConnectionManager: clientNodeConnectionManager,
           destroyCallback,
           logger: logger,
           clientFactory: async (args) =>
@@ -1119,8 +1081,6 @@ describe(`${NodeConnection.name} test`, () => {
           targetHost: localHost,
           targetPort: targetPort,
           proxy: clientProxy,
-          keyManager: clientKeyManager,
-          nodeConnectionManager: clientNodeConnectionManager,
           destroyCallback,
           logger: logger,
           clientFactory: async (args) =>
@@ -1148,8 +1108,6 @@ describe(`${NodeConnection.name} test`, () => {
           targetHost: localHost,
           targetPort: targetPort,
           proxy: clientProxy,
-          keyManager: clientKeyManager,
-          nodeConnectionManager: clientNodeConnectionManager,
           destroyCallback,
           logger: logger,
           clientFactory: async (args) =>
@@ -1177,8 +1135,6 @@ describe(`${NodeConnection.name} test`, () => {
           targetHost: localHost,
           targetPort: targetPort,
           proxy: clientProxy,
-          keyManager: clientKeyManager,
-          nodeConnectionManager: clientNodeConnectionManager,
           destroyCallback,
           logger: logger,
           clientFactory: async (args) =>
@@ -1204,8 +1160,6 @@ describe(`${NodeConnection.name} test`, () => {
         targetHost: localHost,
         targetPort: targetPort,
         proxy: clientProxy,
-        keyManager: clientKeyManager,
-        nodeConnectionManager: clientNodeConnectionManager,
         destroyCallback,
         logger: logger,
         clientFactory: async (args) =>
@@ -1226,8 +1180,6 @@ describe(`${NodeConnection.name} test`, () => {
         targetHost: localHost,
         targetPort: targetPort,
         proxy: clientProxy,
-        keyManager: clientKeyManager,
-        nodeConnectionManager: clientNodeConnectionManager,
         destroyCallback,
         logger: logger,
         clientFactory: async (args) =>
@@ -1252,8 +1204,6 @@ describe(`${NodeConnection.name} test`, () => {
           targetHost: localHost,
           targetPort: targetPort,
           proxy: clientProxy,
-          keyManager: clientKeyManager,
-          nodeConnectionManager: clientNodeConnectionManager,
           destroyCallback,
           logger: logger,
           clientFactory: async (args) =>
@@ -1281,8 +1231,6 @@ describe(`${NodeConnection.name} test`, () => {
           targetHost: localHost,
           targetPort: targetPort,
           proxy: clientProxy,
-          keyManager: clientKeyManager,
-          nodeConnectionManager: clientNodeConnectionManager,
           destroyCallback,
           logger: logger,
           clientFactory: async (args) =>

--- a/tests/nodes/NodeConnectionManager.general.test.ts
+++ b/tests/nodes/NodeConnectionManager.general.test.ts
@@ -516,7 +516,10 @@ describe(`${NodeConnectionManager.name} general test`, () => {
       relayMessage.setSrcId(nodesUtils.encodeNodeId(sourceNodeId));
       relayMessage.setTargetId(nodesUtils.encodeNodeId(remoteNodeId1));
       relayMessage.setProxyAddress('');
-      await nodeConnectionManager.relaySignallingMessage(relayMessage);
+      await nodeConnectionManager.relaySignallingMessage(relayMessage, {
+        host: '' as Host,
+        port: 0 as Port,
+      });
 
       expect(mockedNodesHolePunchMessageSend).toHaveBeenCalled();
     } finally {

--- a/tests/nodes/NodeConnectionManager.general.test.ts
+++ b/tests/nodes/NodeConnectionManager.general.test.ts
@@ -476,7 +476,7 @@ describe(`${NodeConnectionManager.name} general test`, () => {
       // 3. check that the relevant call was made.
       const sourceNodeId = testNodesUtils.generateRandomNodeId();
       const targetNodeId = testNodesUtils.generateRandomNodeId();
-      await nodeConnectionManager.sendSignallingMessage(
+      await nodeConnectionManager.sendSignalingMessage(
         remoteNodeId1,
         sourceNodeId,
         targetNodeId,
@@ -516,7 +516,7 @@ describe(`${NodeConnectionManager.name} general test`, () => {
       relayMessage.setSrcId(nodesUtils.encodeNodeId(sourceNodeId));
       relayMessage.setTargetId(nodesUtils.encodeNodeId(remoteNodeId1));
       relayMessage.setProxyAddress('');
-      await nodeConnectionManager.relaySignallingMessage(relayMessage, {
+      await nodeConnectionManager.relaySignalingMessage(relayMessage, {
         host: '' as Host,
         port: 0 as Port,
       });

--- a/tests/nodes/NodeConnectionManager.seednodes.test.ts
+++ b/tests/nodes/NodeConnectionManager.seednodes.test.ts
@@ -453,8 +453,8 @@ describe(`${NodeConnectionManager.name} seed nodes test`, () => {
       await nodeConnectionManager.start({ nodeManager });
       await taskManager.startProcessing();
       // This should complete without error
-      await nodeManager.syncNodeGraph(true, 5000, {
-        timer: new Timer({ delay: 20000 }),
+      await nodeManager.syncNodeGraph(true, 2000, {
+        timer: new Timer({ delay: 15000 }),
       });
       // Information on remotes are found
       expect(await nodeGraph.getNode(nodeId1)).toBeDefined();

--- a/tests/nodes/NodeManager.test.ts
+++ b/tests/nodes/NodeManager.test.ts
@@ -51,14 +51,16 @@ describe(`${NodeManager.name} test`, () => {
   const serverPort = 0 as Port;
   const externalPort = 0 as Port;
   const mockedPingNode = jest.fn(); // Jest.spyOn(NodeManager.prototype, 'pingNode');
+  const mockedIsSeedNode = jest.fn();
   const dummyNodeConnectionManager = {
     connConnectTime: 5000,
     pingNode: mockedPingNode,
+    isSeedNode: mockedIsSeedNode,
   } as unknown as NodeConnectionManager;
 
   beforeEach(async () => {
-    mockedPingNode.mockClear();
     mockedPingNode.mockImplementation(async (_) => true);
+    mockedIsSeedNode.mockReturnValue(false);
 
     dataDir = await fs.promises.mkdtemp(
       path.join(os.tmpdir(), 'polykey-test-'),


### PR DESCRIPTION
### Description

This brings in `resolveHostname` that will resolve a hostname to multiple IPs including IPv4 and IPv6, and do a BFS over CNAMEs.

It uses the `dns.resolve*` functions instead of the lookup. This means it doesn't abide by the local OS's get name lookup. Which also means it cannot be affected by `/etc/hosts`. I didn't think `/etc/hosts` is useful here. This is also better our performance is better here. See: https://nodejs.org/api/dns.html#implementation-considerations

However it still uses the OS provided initial DNS server configuration. Which means local DNS servers are still used, and local resolvers can still cache the records.

In the future, we can add a flag to switch to using lookup for edge cases

### Issues Fixed

* Fixes MatrixAI/Polykey#484
* Fixes MatrixAI/Polykey#483

### Tasks

- [x] 1. Replace `resolveHost` with `resolveHostname`
- [x] 2. Add tests to `resolveHostname`, use common domains like `google.com` and `localhost`
- [x] 3. Fix up all usages of this in relation to MatrixAI/Polykey#483
- [x] 4. Test the timed and cancellable variants on this, you may need to pass a custom server set 

todo: 
1. [x] 1. improve logging for life cycle NCM and the creation/destruction flow of the node connections 
2. [x] 2. defence in depth for using our own nodeId in the node graph. We need to filter out our own nodeId from information when we receive it, resolve it or attempt to use it.
3. [x] 3. relaying nodes should reject requests from nodes to themselves. Should check the nodeId and the address.
4. [x] 4. Make the node connection creation for the multi-node resolving serial instead of concurrent. Need to double check the destroy callback logic here.
5. [x] 5. ICE needs to be extracted from the NC and done along side its creation instead.
6. [x] 6. Special case seed nodes to avoid TTL clean up on connections.
7. ~Any of the odd methods used within`syncNodeGraph` should be in-lined to avoid noise. Also add logging outlining the process of syncing the node graph.~ Anything I could in-line is used in multiple places.
8. [x] 8. Filter out any Ipv6 addresses when resolving hostnames.
9. [x] 9. Add key path to logger messages.
10. [x] 10. Add detailed logging to `syncNodeGraph`
11. [X] 11. Separate timeouts for each sub connection.
12. [x] 12. All nodes need to re-establish to connection seed nodes when they disconnect.
13. [x] 13. Serial connection establishment needs to be updated to work concurrently.
14. [x] 14. Proxy needs to cancel forward connection establishment if the underlying GRPC client connection is destroyed.
15. [x] 15. Special case GC of seed nodes in the NodeGraph.

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
