### PR TITLE
Preparing Polykey for Local Demo

### DIFF
--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -394,6 +394,9 @@ class PolykeyAgent {
           logger: logger.getChild(SessionManager.name),
           fresh,
         }));
+      // If a recovery code is provided then we reset any sessions in case the
+      //  password changed.
+      if (keyRingConfig.recoveryCode != null) await sessionManager.resetKey();
       grpcServerClient =
         grpcServerClient ??
         new GRPCServer({

--- a/src/bin/errors.ts
+++ b/src/bin/errors.ts
@@ -31,6 +31,11 @@ class ErrorCLIClientOptions<T> extends ErrorCLI<T> {
   exitCode = sysexits.USAGE;
 }
 
+class ErrorCLIPasswordWrong<T> extends ErrorCLI<T> {
+  static description = 'Wrong password, please try again';
+  exitCode = sysexits.USAGE;
+}
+
 class ErrorCLIPasswordMissing<T> extends ErrorCLI<T> {
   static description =
     'Password is necessary, provide it via --password-file, PK_PASSWORD or when prompted';
@@ -90,6 +95,7 @@ export {
   ErrorCLI,
   ErrorCLINodePath,
   ErrorCLIClientOptions,
+  ErrorCLIPasswordWrong,
   ErrorCLIPasswordMissing,
   ErrorCLIPasswordFileRead,
   ErrorCLIRecoveryCodeFileRead,

--- a/src/bin/identities/CommandAuthenticate.ts
+++ b/src/bin/identities/CommandAuthenticate.ts
@@ -16,15 +16,10 @@ class CommandAuthenticate extends CommandPolykey {
       'Name of the digital identity provider',
       parsers.parseProviderId,
     );
-    this.argument(
-      '<identityId>',
-      'Digital identity to authenticate',
-      parsers.parseIdentityId,
-    );
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
-    this.action(async (providerId, identityId, options) => {
+    this.action(async (providerId, options) => {
       const { default: PolykeyClient } = await import('../../PolykeyClient');
       const identitiesPB = await import(
         '../../proto/js/polykey/v1/identities/identities_pb'
@@ -59,7 +54,6 @@ class CommandAuthenticate extends CommandPolykey {
         });
         const providerMessage = new identitiesPB.Provider();
         providerMessage.setProviderId(providerId);
-        providerMessage.setIdentityId(identityId);
         await binUtils.retryAuthentication(async (auth) => {
           genReadable = pkClient.grpcClient.identitiesAuthenticate(
             providerMessage,
@@ -90,7 +84,7 @@ class CommandAuthenticate extends CommandPolykey {
               case identitiesPB.AuthenticationProcess.StepCase.RESPONSE: {
                 const authResponse = message.getResponse()!;
                 this.logger.info(
-                  `Authenticated digital identity provider ${providerId} with identity ${identityId}`,
+                  `Authenticated digital identity provider ${providerId}`,
                 );
                 process.stdout.write(
                   binUtils.outputFormatter({

--- a/src/bin/secrets/CommandGet.ts
+++ b/src/bin/secrets/CommandGet.ts
@@ -15,10 +15,6 @@ class CommandGet extends CommandPolykey {
       'Path to where the secret to be retrieved, specified as <vaultName>:<directoryPath>',
       parsers.parseSecretPath,
     );
-    this.option(
-      '-e, --env',
-      'Wrap the secret in an environment variable declaration',
-    );
     this.addOption(binOptions.nodeId);
     this.addOption(binOptions.clientHost);
     this.addOption(binOptions.clientPort);
@@ -54,7 +50,6 @@ class CommandGet extends CommandPolykey {
           port: clientOptions.clientPort,
           logger: this.logger.getChild(PolykeyClient.name),
         });
-        const isEnv: boolean = options.env ?? false;
         const secretMessage = new secretsPB.Secret();
         const vaultMessage = new vaultsPB.Vault();
         vaultMessage.setNameOrId(secretPath[0]);
@@ -64,29 +59,13 @@ class CommandGet extends CommandPolykey {
           (auth) => pkClient.grpcClient.vaultsSecretsGet(secretMessage, auth),
           meta,
         );
-        const secretContent = Buffer.from(response.getSecretContent_asU8())
-          .toString('utf-8')
-          .trim();
-        if (isEnv) {
-          process.stdout.write(
-            binUtils.outputFormatter({
-              type: options.format === 'json' ? 'json' : 'list',
-              data: [
-                `Export ${secretMessage
-                  .getSecretName()
-                  .toUpperCase()
-                  .replace('-', '_')}='${secretContent}'`,
-              ],
-            }),
-          );
-        } else {
-          process.stdout.write(
-            binUtils.outputFormatter({
-              type: options.format === 'json' ? 'json' : 'list',
-              data: [`${secretMessage.getSecretName()}: ${secretContent}`],
-            }),
-          );
-        }
+        const secretContent = response.getSecretContent_asU8();
+        process.stdout.write(
+          binUtils.outputFormatter({
+            type: 'raw',
+            data: secretContent,
+          }),
+        );
       } finally {
         if (pkClient! != null) await pkClient.stop();
       }

--- a/src/bin/secrets/CommandGet.ts
+++ b/src/bin/secrets/CommandGet.ts
@@ -64,6 +64,9 @@ class CommandGet extends CommandPolykey {
           (auth) => pkClient.grpcClient.vaultsSecretsGet(secretMessage, auth),
           meta,
         );
+        const secretContent = Buffer.from(response.getSecretContent_asU8())
+          .toString('utf-8')
+          .trim();
         if (isEnv) {
           process.stdout.write(
             binUtils.outputFormatter({
@@ -72,7 +75,7 @@ class CommandGet extends CommandPolykey {
                 `Export ${secretMessage
                   .getSecretName()
                   .toUpperCase()
-                  .replace('-', '_')}='${response.getSecretName()}`,
+                  .replace('-', '_')}='${secretContent}'`,
               ],
             }),
           );
@@ -80,9 +83,7 @@ class CommandGet extends CommandPolykey {
           process.stdout.write(
             binUtils.outputFormatter({
               type: options.format === 'json' ? 'json' : 'list',
-              data: [
-                `${secretMessage.getSecretName()}:\t\t${response.getSecretName()}`,
-              ],
+              data: [`${secretMessage.getSecretName()}: ${secretContent}`],
             }),
           );
         }

--- a/src/bin/utils/utils.ts
+++ b/src/bin/utils/utils.ts
@@ -27,6 +27,10 @@ function verboseToLogLevel(c: number = 0): LogLevel {
 
 type OutputObject =
   | {
+      type: 'raw';
+      data: string | Uint8Array;
+    }
+  | {
       type: 'list';
       data: Array<string>;
     }
@@ -47,9 +51,11 @@ type OutputObject =
       data: Error;
     };
 
-function outputFormatter(msg: OutputObject): string {
+function outputFormatter(msg: OutputObject): string | Uint8Array {
   let output = '';
-  if (msg.type === 'list') {
+  if (msg.type === 'raw') {
+    return msg.data;
+  } else if (msg.type === 'list') {
     for (let elem in msg.data) {
       // Empty string for null or undefined values
       if (elem == null) {

--- a/src/bin/utils/utils.ts
+++ b/src/bin/utils/utils.ts
@@ -127,8 +127,9 @@ function outputFormatter(msg: OutputObject): string {
           output += ` - ${currError.message}`;
         }
         output += '\n';
-        output += `${indent}exitCode\t${currError.exitCode}\n`;
-        output += `${indent}timestamp\t${currError.timestamp}\n`;
+        // Disabled to streamline output
+        // output += `${indent}exitCode\t${currError.exitCode}\n`;
+        // output += `${indent}timestamp\t${currError.timestamp}\n`;
         if (currError.data && !utils.isEmptyObject(currError.data)) {
           output += `${indent}data\t${JSON.stringify(currError.data)}\n`;
         }

--- a/src/identities/IdentitiesManager.ts
+++ b/src/identities/IdentitiesManager.ts
@@ -244,7 +244,7 @@ class IdentitiesManager {
     const identities = await provider.getAuthIdentityIds();
     if (!identities.includes(identityId)) {
       throw new identitiesErrors.ErrorProviderIdentityMissing(
-        `Authenticated identities: ${JSON.stringify(identities)}`
+        `Authenticated identities: ${JSON.stringify(identities)}`,
       );
     }
     // Create identity claim on our node
@@ -260,11 +260,11 @@ class IdentitiesManager {
         async (token) => {
           // Publishing in the callback to avoid adding bad claims
           const claim = token.toSigned();
-          const asd = await provider.publishClaim(
+          const identitySignedClaim = await provider.publishClaim(
             identityId,
             claim as SignedClaim<ClaimLinkIdentity>,
           );
-          publishedClaimProm.resolveP(asd);
+          publishedClaimProm.resolveP(identitySignedClaim);
           return token;
         },
         tran,

--- a/src/identities/IdentitiesManager.ts
+++ b/src/identities/IdentitiesManager.ts
@@ -243,7 +243,9 @@ class IdentitiesManager {
     }
     const identities = await provider.getAuthIdentityIds();
     if (!identities.includes(identityId)) {
-      throw new identitiesErrors.ErrorProviderUnauthenticated();
+      throw new identitiesErrors.ErrorProviderIdentityMissing(
+        `Authenticated identities: ${JSON.stringify(identities)}`
+      );
     }
     // Create identity claim on our node
     const publishedClaimProm = promise<IdentitySignedClaim>();

--- a/src/identities/errors.ts
+++ b/src/identities/errors.ts
@@ -38,6 +38,11 @@ class ErrorProviderUnauthenticated<T> extends ErrorIdentities<T> {
   exitCode = sysexits.NOPERM;
 }
 
+class ErrorProviderIdentityMissing<T> extends ErrorIdentities<T> {
+  static description = 'Identity is not authenticated with the provider';
+  exitCode = sysexits.NOPERM;
+}
+
 class ErrorProviderUnimplemented<T> extends ErrorIdentities<T> {
   static description = 'Functionality is unavailable';
   exitCode = sysexits.USAGE;
@@ -58,5 +63,6 @@ export {
   ErrorProviderAuthentication,
   ErrorProviderUnauthenticated,
   ErrorProviderUnimplemented,
+  ErrorProviderIdentityMissing,
   ErrorProviderMissing,
 };

--- a/src/keys/utils/symmetric.ts
+++ b/src/keys/utils/symmetric.ts
@@ -83,15 +83,21 @@ function decryptWithKey(
   const plainText = Buffer.allocUnsafeSlow(
     macAndCipherText.byteLength - macSize,
   );
-  // This returns the number of bytes that has been decrypted
-  const decrypted = sodium.crypto_aead_xchacha20poly1305_ietf_decrypt(
-    plainText,
-    null,
-    macAndCipherText,
-    additionalData,
-    nonce,
-    key,
-  );
+  let decrypted: number;
+  try {
+    // This returns the number of bytes that has been decrypted
+    // It will throw if the MAC cannot be authenticated
+    decrypted = sodium.crypto_aead_xchacha20poly1305_ietf_decrypt(
+      plainText,
+      null,
+      macAndCipherText,
+      additionalData,
+      nonce,
+      key,
+    );
+  } catch {
+    return;
+  }
   if (decrypted !== plainText.byteLength) {
     return;
   }

--- a/src/nodes/NodeManager.ts
+++ b/src/nodes/NodeManager.ts
@@ -144,7 +144,7 @@ class NodeManager {
     const seedNodes = this.nodeConnectionManager.getSeedNodes();
     const allInactive = !seedNodes
       .map((nodeId) => this.nodeConnectionManager.hasConnection(nodeId))
-      .reduce((a, b) => a || b);
+      .reduce((a, b) => a || b, false);
     try {
       if (allInactive) {
         this.logger.debug(

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -68,7 +68,7 @@ async function dirEmpty(fs: FileSystem, path): Promise<boolean> {
     return entries.length === 0;
   } catch (e) {
     if (e.code === 'ENOENT') {
-      return false;
+      return true;
     }
     throw e;
   }

--- a/tests/bin/secrets/secrets.test.ts
+++ b/tests/bin/secrets/secrets.test.ts
@@ -134,7 +134,7 @@ describe('CLI secrets', () => {
           env: {},
           cwd: dataDir,
         });
-        expect(result.stdout).toBe('MySecret: this is the secret\n')
+        expect(result.stdout).toBe('MySecret: this is the secret\n');
         expect(result.exitCode).toBe(0);
       },
     );

--- a/tests/bin/secrets/secrets.test.ts
+++ b/tests/bin/secrets/secrets.test.ts
@@ -134,6 +134,7 @@ describe('CLI secrets', () => {
           env: {},
           cwd: dataDir,
         });
+        expect(result.stdout).toBe('MySecret: this is the secret\n')
         expect(result.exitCode).toBe(0);
       },
     );

--- a/tests/bin/secrets/secrets.test.ts
+++ b/tests/bin/secrets/secrets.test.ts
@@ -134,7 +134,7 @@ describe('CLI secrets', () => {
           env: {},
           cwd: dataDir,
         });
-        expect(result.stdout).toBe('MySecret: this is the secret\n');
+        expect(result.stdout).toBe('this is the secret');
         expect(result.exitCode).toBe(0);
       },
     );


### PR DESCRIPTION
### Description

Working software trumps diagrams/presentations/talks. So we want a working demo with associated diagrams running right off staging branch atm.

The relevant commands that we need to see working are below.

For each of the commands we need:

1. Asciinema recording of the CLI execution
2. Diagram on excalidraw showing the control-flow and data-flow from the user's perspective having the components of: User, CLI, Agent, FileSystem, Identity Provider (any thing else that is relevant)
3. Fix up any bugs or minor usability issues here

### Agent Start

```sh
pk agent start
```

This command needs:

1. Bootstrap the `~/.local/share/polykey` if it doesn't exist.
2. Start the agent if the agent state already exists.
3. Ask you to setup a new password and provide you a recovery code if it doesn't exist.
4. Ask you enter the existing password or recovery code if it does exist.
5. Give you the current agent status once booted up.

### Agent Stop

```sh
pk agent stop
```

This command needs:

1. Shutdown the agent gracefully if it is running.
2. Do nothing if the agent is not running.

### Agent Status

```sh
pk agent status
```

This command needs:

1. Show the agent status when the agent is running.

### Vaults Create

```sh
pk vaults create myvault
```

This command needs:

1. Create the vault called `myvault`.

### Secrets Create

```sh
pk secrets create ./the-secret-file.txt myvault:the-secret-file.txt
```

This command needs:

1. Upload the secret file from `./the-secret-file.txt` into `myvault`.

### Secrets Get

```sh
pk secrets get myvault:the-secret-file.txt
```

This command needs:

1. Show the contents of `the-secret-file.txt` on the STDOUT of the CLI.

### Secrets Delete

```sh
pk secrets delete myvault:the-secret-file.txt
```

The command needs:

1. Delete the the file from `myvault`.

### Secrets Env

```sh
pk secrets env myvault:the-secret-file.txt bash
```

This command needs:

1. This needs to inject the value of the secret into the environment of the bash shell.
2. This is optional, it's a stretch goal.
3. Addresses MatrixAI/Polykey-CLI#31.

### Identities Authenticate

```sh
pk identities authenticate github.com cmcdragonkai
```

This command needs:

1. Authenticates with github, and store the provider token

### Identities Claim

```sh
pk identities claim github.com cmcdragonkai
```

This command needs:

1. Claim the identity on the cmcdragonkai gists: https://gist.github.com/CMCDragonkai, and post a cryptolink there

### Tasks

- [x] 1. `pk agent start`
- [x] 2. `pk agent stop`
- [x] 3. `pk agent status`
- [x] 4. `pk vaults create`
- [x] 5. `pk secrets create`
- [x] 6. `pk secrets get`
- [x] 7. `pk secrets delete`
- [ ] 8. `pk secrets env`
- [x] 9. `pk identities authenticate`
- [x] 10. `pk identities claim`

### Final checklist

* [x] Domain specific tests
* [ ] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build