### PR TITLE
feat: `pk secrets env` command

### DIFF
--- a/src/bin/secrets/CommandEnv.ts
+++ b/src/bin/secrets/CommandEnv.ts
@@ -7,15 +7,73 @@
 // import * as binUtils from '../utils';
 // import * as CLIErrors from '../errors';
 // import * as grpcErrors from '../../grpc/errors';
-
 // import CommandPolykey from '../CommandPolykey';
 // import * as binOptions from '../utils/options';
 
-// class CommandEnv extends CommandPolykey {
-//   constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
-//     super(...args);
-//     this.name('env');
-//     this.description('Secrets Env');
+import type PolykeyClient from '../../PolykeyClient';
+import type * as agentPB from '../../proto/js/polykey/v1/agent/agent_pb';
+import CommandPolykey from '../CommandPolykey';
+import * as binUtils from '../utils';
+import * as binOptions from '../utils/options';
+import * as binProcessors from '../utils/processors';
+
+class CommandEnv extends CommandPolykey {
+  constructor(...args: ConstructorParameters<typeof CommandPolykey>) {
+    super(...args);
+    this.name('env');
+    this.description('Run a program with secrets injected into its environment');
+    // this.argument(
+    //   '<directoryPath>',
+    //   'On disk path to the secret file with the contents of the new secret',
+    // );
+
+    this.option(
+      '-i, --ignore-environment',
+      'start with an empty environment',
+    );
+    this.option(
+      '-C, --chdir <dir>',
+      'change working directory',
+    );
+    this.argument(
+      '<[NAME=<vaultName>:<secretPath>]... <command> [arg]...>',
+      'List of secrets to inject and the command to run'
+    );
+    this.addOption(binOptions.nodeId);
+    this.addOption(binOptions.clientHost);
+    this.addOption(binOptions.clientPort);
+    this.action(async (args: Array<string>, options) => {
+      const secrets: Array<{
+        envName: string;
+        vaultName: string;
+        secretPath: string;
+      }> = [];
+      let argIndex = 0;
+      for (const arg of args) {
+        const secretMatches = arg.match(
+          /([A-Z]+)=([a-zA-Z0-9]+):([a-zA-Z0-9._\-\/\s]+)/
+        );
+        if (secretMatches != null) {
+          secrets.push({
+            envName: secretMatches[1],
+            vaultName: secretMatches[2],
+            secretPath: secretMatches[3],
+          });
+        } else {
+          break;
+        }
+        argIndex++;
+      }
+      console.log(secrets);
+      const commandArgs = args.slice(argIndex);
+      console.log(commandArgs);
+
+
+      // console.log(args);
+      // console.log(options);
+    });
+
+
 //     this.option(
 //       '--command <command>',
 //       'In the environment of the derivation, run the shell command cmd in an interactive shell (Use --run to use a non-interactive shell instead)',
@@ -24,17 +82,14 @@
 //       '--run <run>',
 //       'In the environment of the derivation, run the shell command cmd in a non-interactive shell, meaning (among other things) that if you hit Ctrl-C while the command is running, the shell exits (Use --command to use an interactive shell instead)',
 //     );
-//     this.arguments(
-//       "Secrets to inject into env, of the format '<vaultName>:<secretPath>[=<variableName>]', you can also control what the environment variable will be called using '[<variableName>]' (defaults to upper, snake case of the original secret name)",
-//     );
 //     this.addOption(binOptions.nodeId);
 //     this.addOption(binOptions.clientHost);
 //     this.addOption(binOptions.clientPort);
 //     this.action(async (options, command) => {
 
 //     });
-//   }
-// }
+  }
+}
 
 // export default CommandEnv;
 
@@ -176,4 +231,4 @@
 //   }
 // });
 
-// export default env;
+export default CommandEnv;

--- a/src/bin/secrets/CommandEnv.ts
+++ b/src/bin/secrets/CommandEnv.ts
@@ -22,18 +22,13 @@ class CommandEnv extends CommandPolykey {
     super(...args);
     this.name('env');
     this.description('Run a program with secrets injected into its environment');
-    // this.argument(
-    //   '<directoryPath>',
-    //   'On disk path to the secret file with the contents of the new secret',
-    // );
-
     this.option(
-      '-i, --ignore-environment',
-      'start with an empty environment',
+      '-ie, --ignore-environment',
+      'Start with an empty environment',
     );
     this.option(
-      '-C, --chdir <dir>',
-      'change working directory',
+      '-ee, --export-environment',
+      'Exports secrets into the shell',
     );
     this.argument(
       '<[NAME=<vaultName>:<secretPath>]... <command> [arg]...>',

--- a/src/bin/secrets/CommandSecrets.ts
+++ b/src/bin/secrets/CommandSecrets.ts
@@ -2,7 +2,7 @@ import CommandCreate from './CommandCreate';
 import CommandDelete from './CommandDelete';
 import CommandDir from './CommandDir';
 import CommandEdit from './CommandEdit';
-// Import CommandEnv from './CommandEnv';
+import CommandEnv from './CommandEnv';
 import CommandGet from './CommandGet';
 import CommandList from './CommandList';
 import CommandMkdir from './CommandMkdir';
@@ -20,7 +20,7 @@ class CommandSecrets extends CommandPolykey {
     this.addCommand(new CommandDelete(...args));
     this.addCommand(new CommandDir(...args));
     this.addCommand(new CommandEdit(...args));
-    // This.addCommand(new CommandEnv(...args));
+    this.addCommand(new CommandEnv(...args));
     this.addCommand(new CommandGet(...args));
     this.addCommand(new CommandList(...args));
     this.addCommand(new CommandMkdir(...args));

--- a/src/bin/utils/parsers.ts
+++ b/src/bin/utils/parsers.ts
@@ -78,18 +78,17 @@ function parseCoreCount(v: string): number | undefined {
   return parseInt(v);
 }
 
-function parseSecretPath(secretPath: string): [string, string, string?] {
+function parseSecretPath(secretAddress: string): [string, string] {
   // E.g. If 'vault1:a/b/c', ['vault1', 'a/b/c'] is returned
-  //      If 'vault1:a/b/c=VARIABLE', ['vault1, 'a/b/c', 'VARIABLE'] is returned
-  const secretPathRegex =
-    /^([\w-]+)(?::)([\w\-\\\/\.\$]+)(?:=)?([a-zA-Z_][\w]+)?$/;
-  if (!secretPathRegex.test(secretPath)) {
+  const secretAddressRegex = /^([a-zA-Z0-9-_]+):([\w\-\\\/\.\$]+)$/;
+  const matches = secretAddress.match(secretAddressRegex);
+  if (matches == null) {
     throw new commander.InvalidArgumentError(
-      `${secretPath} is not of the format <vaultName>:<directoryPath>`,
+      `${secretAddress} is not of the format <vaultName>:<secretPath>`,
     );
   }
-  const [, vaultName, directoryPath] = secretPath.match(secretPathRegex)!;
-  return [vaultName, directoryPath, undefined];
+  const [, vaultName, secretPath] = matches;
+  return [vaultName, secretPath];
 }
 
 export {


### PR DESCRIPTION
### Description

This introduces a prototype `pk secrets env` command to inject secrets into a command.

Right now we're going to do something simple as the kexec library is not ready (https://github.com/MatrixAI/Polykey-CLI/issues/31), and plus we would probably need to make it ourselves to ensure cross platform behaviour.

For demo purposes (#504) it's sufficient to just do a subprocess.

Some differences from MatrixAI/Polykey#265...

Instead of doing `vault:secretpath:name` we can do `name=vault:secretpath`.

This makes it closer to the behaviour of the `env` command.

We can add in flag `-i|--ignore-environment` and `-C|--chdir` like the `env` command too. Not sure if this fits our flag styles, since we would normally do `-ie` and `-cd`. 

### Issues Fixed

* Fixes MatrixAI/Polykey-CLI#31
* Supersedes MatrixAI/Polykey#265

### Tasks

- [ ] 1. All tasks from MatrixAI/Polykey-CLI#31

### Final checklist

* [ ] Domain specific tests
* [ ] Full tests
* [ ] Updated inline-comment documentation
* [ ] Lint fixed
* [ ] Squash and rebased
* [ ] Sanity check the final build
