### PR TITLE
RPC timeout implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
       "devDependencies": {
         "@babel/preset-env": "^7.13.10",
         "@fast-check/jest": "^1.1.0",
-        "@streamparser/json": "^0.0.12",
+        "@streamparser/json": "^0.0.13",
         "@swc/core": "^1.2.215",
         "@types/cross-spawn": "^6.0.2",
         "@types/google-protobuf": "^3.7.4",
@@ -3054,9 +3054,9 @@
       }
     },
     "node_modules/@streamparser/json": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.12.tgz",
-      "integrity": "sha512-+kmRpd+EeTFd3qNt1AoKphJqbAN26ZDsbiwqjBFeoAmdCyiUO19xMXPtYi9vovAj9a7OAJnvWtiHkwwjU2Fx4Q==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.13.tgz",
+      "integrity": "sha512-buWyDbFht82G2Dgt8yS1AiR12Y7uvgQv+wOY6X98Pattq95RyJp7wJp0zxDdI/6jqKSlHKwGJNX7KjrSnYHbOQ==",
       "dev": true
     },
     "node_modules/@swc/core": {
@@ -14357,9 +14357,9 @@
       }
     },
     "@streamparser/json": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.12.tgz",
-      "integrity": "sha512-+kmRpd+EeTFd3qNt1AoKphJqbAN26ZDsbiwqjBFeoAmdCyiUO19xMXPtYi9vovAj9a7OAJnvWtiHkwwjU2Fx4Q==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.13.tgz",
+      "integrity": "sha512-buWyDbFht82G2Dgt8yS1AiR12Y7uvgQv+wOY6X98Pattq95RyJp7wJp0zxDdI/6jqKSlHKwGJNX7KjrSnYHbOQ==",
       "dev": true
     },
     "@swc/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0",
       "dependencies": {
         "@grpc/grpc-js": "1.6.7",
-        "@matrixai/async-cancellable": "^1.0.2",
+        "@matrixai/async-cancellable": "^1.0.4",
         "@matrixai/async-init": "^1.8.2",
         "@matrixai/async-locks": "^3.2.0",
         "@matrixai/db": "^5.1.0",
@@ -18,7 +18,7 @@
         "@matrixai/id": "^3.3.3",
         "@matrixai/logger": "^3.1.0",
         "@matrixai/resources": "^1.1.4",
-        "@matrixai/timer": "^1.0.0",
+        "@matrixai/timer": "^1.1.0",
         "@matrixai/workers": "^1.3.6",
         "@peculiar/asn1-pkcs8": "^2.3.0",
         "@peculiar/asn1-schema": "^2.3.0",
@@ -2653,9 +2653,9 @@
       }
     },
     "node_modules/@matrixai/async-cancellable": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@matrixai/async-cancellable/-/async-cancellable-1.0.2.tgz",
-      "integrity": "sha512-ugMfKtp7MlhXfBP//jGEAEEDbkVlr1aw8pqe2NrEUyyfKrZlX2jib50YocQYf+CcP4XnFAEzBDIpTAmqjukCug=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@matrixai/async-cancellable/-/async-cancellable-1.0.4.tgz",
+      "integrity": "sha512-hWBvOjMxEd+/Y4zDGd8hSD2NND6M23Bp8WxjfRhdwRVJIBuq8ieb83jOlzfosTrirtTiJX+XsFf1hNw2MXjQPA=="
     },
     "node_modules/@matrixai/async-init": {
       "version": "1.8.2",
@@ -2724,11 +2724,11 @@
       "integrity": "sha512-YZSMtklbXah0+SxcKOVEm0ONQdWhlJecQ1COx6hg9Dl80WOybZjZ9A+N+OZfvWk9y25NuoIPzOsjhr8G1aTnIg=="
     },
     "node_modules/@matrixai/timer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@matrixai/timer/-/timer-1.0.0.tgz",
-      "integrity": "sha512-ZcsgIW+gMfoU206aryeDFPymSz/FVCY4w6Klw0CCQxSRpa20bdzFJ9UdCMJZzHiEBD1TSAdc2wPTqeXq5OUlPw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/timer/-/timer-1.1.0.tgz",
+      "integrity": "sha512-n9ulMGJhjQyu+fhRxvP5SwY57miOLbRE6gtIzTZD6x7wFL0k5sUBMnEQ6W4QkO1atZnxKMFigg4gt/0V4XlniA==",
       "dependencies": {
-        "@matrixai/async-cancellable": "^1.0.2"
+        "@matrixai/async-cancellable": "^1.0.4"
       }
     },
     "node_modules/@matrixai/workers": {
@@ -13994,9 +13994,9 @@
       }
     },
     "@matrixai/async-cancellable": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@matrixai/async-cancellable/-/async-cancellable-1.0.2.tgz",
-      "integrity": "sha512-ugMfKtp7MlhXfBP//jGEAEEDbkVlr1aw8pqe2NrEUyyfKrZlX2jib50YocQYf+CcP4XnFAEzBDIpTAmqjukCug=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@matrixai/async-cancellable/-/async-cancellable-1.0.4.tgz",
+      "integrity": "sha512-hWBvOjMxEd+/Y4zDGd8hSD2NND6M23Bp8WxjfRhdwRVJIBuq8ieb83jOlzfosTrirtTiJX+XsFf1hNw2MXjQPA=="
     },
     "@matrixai/async-init": {
       "version": "1.8.2",
@@ -14060,11 +14060,11 @@
       "integrity": "sha512-YZSMtklbXah0+SxcKOVEm0ONQdWhlJecQ1COx6hg9Dl80WOybZjZ9A+N+OZfvWk9y25NuoIPzOsjhr8G1aTnIg=="
     },
     "@matrixai/timer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@matrixai/timer/-/timer-1.0.0.tgz",
-      "integrity": "sha512-ZcsgIW+gMfoU206aryeDFPymSz/FVCY4w6Klw0CCQxSRpa20bdzFJ9UdCMJZzHiEBD1TSAdc2wPTqeXq5OUlPw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/timer/-/timer-1.1.0.tgz",
+      "integrity": "sha512-n9ulMGJhjQyu+fhRxvP5SwY57miOLbRE6gtIzTZD6x7wFL0k5sUBMnEQ6W4QkO1atZnxKMFigg4gt/0V4XlniA==",
       "requires": {
-        "@matrixai/async-cancellable": "^1.0.2"
+        "@matrixai/async-cancellable": "^1.0.4"
       }
     },
     "@matrixai/workers": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "1.6.7",
-    "@matrixai/async-cancellable": "^1.0.2",
+    "@matrixai/async-cancellable": "^1.0.4",
     "@matrixai/async-init": "^1.8.2",
     "@matrixai/async-locks": "^3.2.0",
     "@matrixai/db": "^5.1.0",
@@ -88,7 +88,7 @@
     "@matrixai/id": "^3.3.3",
     "@matrixai/logger": "^3.1.0",
     "@matrixai/resources": "^1.1.4",
-    "@matrixai/timer": "^1.0.0",
+    "@matrixai/timer": "^1.1.0",
     "@matrixai/workers": "^1.3.6",
     "@peculiar/asn1-pkcs8": "^2.3.0",
     "@peculiar/asn1-schema": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.13.10",
     "@fast-check/jest": "^1.1.0",
-    "@streamparser/json": "^0.0.12",
+    "@streamparser/json": "^0.0.13",
     "@swc/core": "^1.2.215",
     "@types/cross-spawn": "^6.0.2",
     "@types/google-protobuf": "^3.7.4",

--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -57,9 +57,9 @@ type NetworkConfig = {
   clientHost?: Host;
   clientPort?: Port;
   maxReadBufferBytes?: number;
-  idleTimeout?: number;
-  pingInterval?: number;
-  pingTimeout?: number;
+  idleTimeoutTime?: number;
+  pingIntervalTime?: number;
+  pingTimeoutTime?: number;
 };
 
 interface PolykeyAgent extends CreateDestroyStartStop {}
@@ -193,7 +193,7 @@ class PolykeyAgent {
       ...config.defaults.nodeConnectionManagerConfig,
       ...utils.filterEmptyObject(nodeConnectionManagerConfig),
     };
-    const _networkConfig = {
+    const networkConfig_ = {
       ...config.defaults.networkConfig,
       ...utils.filterEmptyObject(networkConfig),
     };
@@ -454,13 +454,13 @@ class PolykeyAgent {
           connectionCallback: (streamPair) =>
             rpcServerClient!.handleStream(streamPair, {}),
           fs,
-          host: _networkConfig.clientHost,
-          port: _networkConfig.clientPort,
+          host: networkConfig_.clientHost,
+          port: networkConfig_.clientPort,
           tlsConfig,
-          maxReadBufferBytes: _networkConfig.maxReadBufferBytes,
-          idleTimeout: _networkConfig.idleTimeout,
-          pingInterval: _networkConfig.pingInterval,
-          pingTimeout: _networkConfig.pingTimeout,
+          maxReadableStreamBytes: networkConfig_.maxReadBufferBytes,
+          connectionIdleTimeoutTime: networkConfig_.idleTimeout,
+          pingIntervalTime: networkConfig_.pingIntervalTime,
+          pingTimeoutTime: networkConfig_.pingTimeoutTime,
           logger: logger.getChild('WebSocketServer'),
         }));
       grpcServerAgent =

--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -452,7 +452,7 @@ class PolykeyAgent {
         webSocketServerClient ??
         (await WebSocketServer.createWebSocketServer({
           connectionCallback: (streamPair) =>
-            rpcServerClient!.handleStream(streamPair, {}),
+            rpcServerClient!.handleStream(streamPair),
           fs,
           host: networkConfig_.clientHost,
           port: networkConfig_.clientPort,
@@ -775,7 +775,7 @@ class PolykeyAgent {
         host: _networkConfig.clientHost,
         port: _networkConfig.clientPort,
         connectionCallback: (streamPair) =>
-          this.rpcServerClient.handleStream(streamPair, {}),
+          this.rpcServerClient.handleStream(streamPair),
       });
       // Agent server
       await this.grpcServerAgent.start({

--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -12,8 +12,8 @@ import { DB } from '@matrixai/db';
 import { CreateDestroyStartStop } from '@matrixai/async-init/dist/CreateDestroyStartStop';
 import RPCServer from './rpc/RPCServer';
 import WebSocketServer from './websockets/WebSocketServer';
-import * as rpcMiddlewareUtils from './rpc/utils/middleware';
-import * as clientMiddleware from './client/utils/middleware';
+import * as rpcUtilsMiddleware from './rpc/utils/middleware';
+import * as clientUtilsMiddleware from './client/utils/middleware';
 import { WorkerManager } from './workers';
 import * as networkUtils from './network/utils';
 import KeyRing from './keys/KeyRing';
@@ -437,8 +437,8 @@ class PolykeyAgent {
             sessionManager: sessionManager,
             vaultManager: vaultManager,
           }),
-          middlewareFactory: rpcMiddlewareUtils.defaultServerMiddlewareWrapper(
-            clientMiddleware.middlewareServer(sessionManager, keyRing),
+          middlewareFactory: rpcUtilsMiddleware.defaultServerMiddlewareWrapper(
+            clientUtilsMiddleware.middlewareServer(sessionManager, keyRing),
           ),
           sensitive: false,
           logger: logger.getChild('RPCServerClient'),

--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -12,8 +12,8 @@ import { DB } from '@matrixai/db';
 import { CreateDestroyStartStop } from '@matrixai/async-init/dist/CreateDestroyStartStop';
 import RPCServer from './rpc/RPCServer';
 import WebSocketServer from './websockets/WebSocketServer';
-import * as middlewareUtils from './rpc/utils/middleware';
-import * as authMiddleware from './client/utils/authenticationMiddleware';
+import * as rpcMiddlewareUtils from './rpc/utils/middleware';
+import * as clientMiddleware from './client/utils/middleware';
 import { WorkerManager } from './workers';
 import * as networkUtils from './network/utils';
 import KeyRing from './keys/KeyRing';
@@ -437,11 +437,8 @@ class PolykeyAgent {
             sessionManager: sessionManager,
             vaultManager: vaultManager,
           }),
-          middlewareFactory: middlewareUtils.defaultServerMiddlewareWrapper(
-            authMiddleware.authenticationMiddlewareServer(
-              sessionManager,
-              keyRing,
-            ),
+          middlewareFactory: rpcMiddlewareUtils.defaultServerMiddlewareWrapper(
+            clientMiddleware.middlewareServer(sessionManager, keyRing),
           ),
           sensitive: false,
           logger: logger.getChild('RPCServerClient'),

--- a/src/PolykeyClient.ts
+++ b/src/PolykeyClient.ts
@@ -4,8 +4,8 @@ import path from 'path';
 import Logger from '@matrixai/logger';
 import { CreateDestroyStartStop } from '@matrixai/async-init/dist/CreateDestroyStartStop';
 import RPCClient from './rpc/RPCClient';
-import * as middlewareUtils from './rpc/utils/middleware';
-import * as authMiddleware from './client/utils/authenticationMiddleware';
+import * as rpcMiddlewareUtils from './rpc/utils/middleware';
+import * as clientMiddleware from './client/utils/middleware';
 import { Session } from './sessions';
 import * as errors from './errors';
 import * as utils from './utils';
@@ -60,9 +60,10 @@ class PolykeyClient<M extends ClientManifest> {
         : await RPCClient.createRPCClient<M>({
             manifest,
             streamFactory,
-            middlewareFactory: middlewareUtils.defaultClientMiddlewareWrapper(
-              authMiddleware.authenticationMiddlewareClient(session),
-            ),
+            middlewareFactory:
+              rpcMiddlewareUtils.defaultClientMiddlewareWrapper(
+                clientMiddleware.middlewareClient(session),
+              ),
             logger: logger.getChild(RPCClient.name),
           });
     const pkClient = new this({

--- a/src/PolykeyClient.ts
+++ b/src/PolykeyClient.ts
@@ -29,6 +29,8 @@ class PolykeyClient<M extends ClientManifest> {
     session,
     manifest,
     streamFactory,
+    streamKeepAliveTimeoutTime,
+    parserBufferByteLimit,
     fs = require('fs'),
     logger = new Logger(this.name),
     fresh = false,
@@ -37,6 +39,8 @@ class PolykeyClient<M extends ClientManifest> {
     session?: Session;
     manifest: RPCClient<M> | M;
     streamFactory: StreamFactory;
+    streamKeepAliveTimeoutTime?: number;
+    parserBufferByteLimit?: number;
     fs?: FileSystem;
     logger?: Logger;
     fresh?: boolean;
@@ -63,7 +67,9 @@ class PolykeyClient<M extends ClientManifest> {
             middlewareFactory:
               rpcUtilsMiddleware.defaultClientMiddlewareWrapper(
                 clientUtilsMiddleware.middlewareClient(session),
+                parserBufferByteLimit,
               ),
+            streamKeepAliveTimeoutTime,
             logger: logger.getChild(RPCClient.name),
           });
     const pkClient = new this({

--- a/src/PolykeyClient.ts
+++ b/src/PolykeyClient.ts
@@ -4,8 +4,8 @@ import path from 'path';
 import Logger from '@matrixai/logger';
 import { CreateDestroyStartStop } from '@matrixai/async-init/dist/CreateDestroyStartStop';
 import RPCClient from './rpc/RPCClient';
-import * as rpcMiddlewareUtils from './rpc/utils/middleware';
-import * as clientMiddleware from './client/utils/middleware';
+import * as rpcUtilsMiddleware from './rpc/utils/middleware';
+import * as clientUtilsMiddleware from './client/utils/middleware';
 import { Session } from './sessions';
 import * as errors from './errors';
 import * as utils from './utils';
@@ -61,8 +61,8 @@ class PolykeyClient<M extends ClientManifest> {
             manifest,
             streamFactory,
             middlewareFactory:
-              rpcMiddlewareUtils.defaultClientMiddlewareWrapper(
-                clientMiddleware.middlewareClient(session),
+              rpcUtilsMiddleware.defaultClientMiddlewareWrapper(
+                clientUtilsMiddleware.middlewareClient(session),
               ),
             logger: logger.getChild(RPCClient.name),
           });

--- a/src/bin/agent/CommandLockAll.ts
+++ b/src/bin/agent/CommandLockAll.ts
@@ -58,7 +58,7 @@ class CommandLockAll extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/agent/CommandStatus.ts
+++ b/src/bin/agent/CommandStatus.ts
@@ -63,7 +63,7 @@ class CommandStatus extends CommandPolykey {
             logger: this.logger.getChild(WebSocketClient.name),
           });
           pkClient = await PolykeyClient.createPolykeyClient({
-            streamFactory: () => webSocketClient.startConnection(),
+            streamFactory: (ctx) => webSocketClient.startConnection(ctx),
             nodePath: options.nodePath,
             manifest: clientManifest,
             logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/agent/CommandStop.ts
+++ b/src/bin/agent/CommandStop.ts
@@ -60,7 +60,7 @@ class CommandStop extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/agent/CommandUnlock.ts
+++ b/src/bin/agent/CommandUnlock.ts
@@ -47,7 +47,7 @@ class CommandUnlock extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/identities/CommandAllow.ts
+++ b/src/bin/identities/CommandAllow.ts
@@ -61,7 +61,7 @@ class CommandAllow extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/identities/CommandAuthenticate.ts
+++ b/src/bin/identities/CommandAuthenticate.ts
@@ -58,7 +58,7 @@ class CommandAuthenticate extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/identities/CommandAuthenticated.ts
+++ b/src/bin/identities/CommandAuthenticated.ts
@@ -53,7 +53,7 @@ class CommandAuthenticated extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/identities/CommandClaim.ts
+++ b/src/bin/identities/CommandClaim.ts
@@ -58,7 +58,7 @@ class CommandClaim extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/identities/CommandDisallow.ts
+++ b/src/bin/identities/CommandDisallow.ts
@@ -61,7 +61,7 @@ class CommandDisallow extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/identities/CommandDiscover.ts
+++ b/src/bin/identities/CommandDiscover.ts
@@ -56,7 +56,7 @@ class CommandDiscover extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/identities/CommandGet.ts
+++ b/src/bin/identities/CommandGet.ts
@@ -59,7 +59,7 @@ class CommandGet extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/identities/CommandInvite.ts
+++ b/src/bin/identities/CommandInvite.ts
@@ -55,7 +55,7 @@ class CommandClaim extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/identities/CommandList.ts
+++ b/src/bin/identities/CommandList.ts
@@ -47,7 +47,7 @@ class CommandList extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/identities/CommandPermissions.ts
+++ b/src/bin/identities/CommandPermissions.ts
@@ -56,7 +56,7 @@ class CommandPermissions extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/identities/CommandSearch.ts
+++ b/src/bin/identities/CommandSearch.ts
@@ -78,7 +78,7 @@ class CommandSearch extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/identities/CommandTrust.ts
+++ b/src/bin/identities/CommandTrust.ts
@@ -56,7 +56,7 @@ class CommandTrust extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/identities/CommandUntrust.ts
+++ b/src/bin/identities/CommandUntrust.ts
@@ -56,7 +56,7 @@ class CommandUntrust extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/keys/CommandCert.ts
+++ b/src/bin/keys/CommandCert.ts
@@ -47,7 +47,7 @@ class CommandCert extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/keys/CommandCertchain.ts
+++ b/src/bin/keys/CommandCertchain.ts
@@ -47,7 +47,7 @@ class CommandsCertchain extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/keys/CommandDecrypt.ts
+++ b/src/bin/keys/CommandDecrypt.ts
@@ -52,7 +52,7 @@ class CommandDecrypt extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/keys/CommandEncrypt.ts
+++ b/src/bin/keys/CommandEncrypt.ts
@@ -56,7 +56,7 @@ class CommandEncypt extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/keys/CommandPair.ts
+++ b/src/bin/keys/CommandPair.ts
@@ -55,7 +55,7 @@ class CommandKeypair extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/keys/CommandPassword.ts
+++ b/src/bin/keys/CommandPassword.ts
@@ -53,7 +53,7 @@ class CommandPassword extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/keys/CommandPrivate.ts
+++ b/src/bin/keys/CommandPrivate.ts
@@ -53,7 +53,7 @@ class CommandPrivate extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/keys/CommandPublic.ts
+++ b/src/bin/keys/CommandPublic.ts
@@ -47,7 +47,7 @@ class CommandPublic extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/keys/CommandRenew.ts
+++ b/src/bin/keys/CommandRenew.ts
@@ -53,7 +53,7 @@ class CommandRenew extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/keys/CommandReset.ts
+++ b/src/bin/keys/CommandReset.ts
@@ -53,7 +53,7 @@ class CommandReset extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/keys/CommandSign.ts
+++ b/src/bin/keys/CommandSign.ts
@@ -52,7 +52,7 @@ class CommandSign extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/keys/CommandVerify.ts
+++ b/src/bin/keys/CommandVerify.ts
@@ -60,7 +60,7 @@ class CommandVerify extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/nodes/CommandAdd.ts
+++ b/src/bin/nodes/CommandAdd.ts
@@ -56,7 +56,7 @@ class CommandAdd extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/nodes/CommandClaim.ts
+++ b/src/bin/nodes/CommandClaim.ts
@@ -59,7 +59,7 @@ class CommandClaim extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/nodes/CommandConnections.ts
+++ b/src/bin/nodes/CommandConnections.ts
@@ -44,7 +44,7 @@ class CommandAdd extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/nodes/CommandFind.ts
+++ b/src/bin/nodes/CommandFind.ts
@@ -55,7 +55,7 @@ class CommandFind extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/nodes/CommandGetAll.ts
+++ b/src/bin/nodes/CommandGetAll.ts
@@ -47,7 +47,7 @@ class CommandGetAll extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/nodes/CommandPing.ts
+++ b/src/bin/nodes/CommandPing.ts
@@ -52,7 +52,7 @@ class CommandPing extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/notifications/CommandClear.ts
+++ b/src/bin/notifications/CommandClear.ts
@@ -47,7 +47,7 @@ class CommandClear extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/notifications/CommandRead.ts
+++ b/src/bin/notifications/CommandRead.ts
@@ -63,7 +63,7 @@ class CommandRead extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/notifications/CommandSend.ts
+++ b/src/bin/notifications/CommandSend.ts
@@ -56,7 +56,7 @@ class CommandSend extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/secrets/CommandCreate.ts
+++ b/src/bin/secrets/CommandCreate.ts
@@ -58,7 +58,7 @@ class CommandCreate extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/secrets/CommandDelete.ts
+++ b/src/bin/secrets/CommandDelete.ts
@@ -54,7 +54,7 @@ class CommandDelete extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/secrets/CommandDir.ts
+++ b/src/bin/secrets/CommandDir.ts
@@ -52,7 +52,7 @@ class CommandDir extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/secrets/CommandEdit.ts
+++ b/src/bin/secrets/CommandEdit.ts
@@ -56,7 +56,7 @@ class CommandEdit extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/secrets/CommandGet.ts
+++ b/src/bin/secrets/CommandGet.ts
@@ -53,7 +53,7 @@ class CommandGet extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/secrets/CommandList.ts
+++ b/src/bin/secrets/CommandList.ts
@@ -49,7 +49,7 @@ class CommandList extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/secrets/CommandMkdir.ts
+++ b/src/bin/secrets/CommandMkdir.ts
@@ -54,7 +54,7 @@ class CommandMkdir extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/secrets/CommandRename.ts
+++ b/src/bin/secrets/CommandRename.ts
@@ -54,7 +54,7 @@ class CommandRename extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/secrets/CommandStat.ts
+++ b/src/bin/secrets/CommandStat.ts
@@ -53,7 +53,7 @@ class CommandStat extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/secrets/CommandUpdate.ts
+++ b/src/bin/secrets/CommandUpdate.ts
@@ -58,7 +58,7 @@ class CommandUpdate extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/utils/utils.ts
+++ b/src/bin/utils/utils.ts
@@ -112,10 +112,7 @@ function outputFormatter(msg: OutputObject): string | Uint8Array {
     let currError = msg.data;
     let indent = '  ';
     while (currError != null) {
-      if (
-        currError instanceof grpcErrors.ErrorPolykeyRemoteOLD ||
-        currError instanceof rpcErrors.ErrorPolykeyRemote
-      ) {
+      if (currError instanceof grpcErrors.ErrorPolykeyRemoteOLD) {
         output += `${currError.name}: ${currError.description}`;
         if (currError.message && currError.message !== '') {
           output += ` - ${currError.message}`;
@@ -127,6 +124,20 @@ function outputFormatter(msg: OutputObject): string | Uint8Array {
         )}\n`;
         output += `${indent}host\t${currError.metadata.host}\n`;
         output += `${indent}port\t${currError.metadata.port}\n`;
+        output += `${indent}timestamp\t${currError.timestamp}\n`;
+        output += `${indent}cause: `;
+        currError = currError.cause;
+      } else if (currError instanceof rpcErrors.ErrorPolykeyRemote) {
+        output += `${currError.name}: ${currError.description}`;
+        if (currError.message && currError.message !== '') {
+          output += ` - ${currError.message}`;
+        }
+        if (currError.metadata != null) {
+          output += '\n';
+          for (const [key, value] of Object.entries(currError.metadata)) {
+            output += `${indent}${key}\t${value}\n`;
+          }
+        }
         output += `${indent}timestamp\t${currError.timestamp}\n`;
         output += `${indent}cause: `;
         currError = currError.cause;

--- a/src/bin/vaults/CommandClone.ts
+++ b/src/bin/vaults/CommandClone.ts
@@ -56,7 +56,7 @@ class CommandClone extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/vaults/CommandCreate.ts
+++ b/src/bin/vaults/CommandCreate.ts
@@ -49,7 +49,7 @@ class CommandCreate extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/vaults/CommandDelete.ts
+++ b/src/bin/vaults/CommandDelete.ts
@@ -48,7 +48,7 @@ class CommandDelete extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/vaults/CommandList.ts
+++ b/src/bin/vaults/CommandList.ts
@@ -47,7 +47,7 @@ class CommandList extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/vaults/CommandLog.ts
+++ b/src/bin/vaults/CommandLog.ts
@@ -50,7 +50,7 @@ class CommandLog extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/vaults/CommandPermissions.ts
+++ b/src/bin/vaults/CommandPermissions.ts
@@ -49,7 +49,7 @@ class CommandPermissions extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/vaults/CommandPull.ts
+++ b/src/bin/vaults/CommandPull.ts
@@ -58,7 +58,7 @@ class CommandPull extends CommandPolykey {
             logger: this.logger.getChild(WebSocketClient.name),
           });
           pkClient = await PolykeyClient.createPolykeyClient({
-            streamFactory: () => webSocketClient.startConnection(),
+            streamFactory: (ctx) => webSocketClient.startConnection(ctx),
             nodePath: options.nodePath,
             manifest: clientManifest,
             logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/vaults/CommandRename.ts
+++ b/src/bin/vaults/CommandRename.ts
@@ -49,7 +49,7 @@ class CommandRename extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/vaults/CommandScan.ts
+++ b/src/bin/vaults/CommandScan.ts
@@ -48,7 +48,7 @@ class CommandScan extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/vaults/CommandShare.ts
+++ b/src/bin/vaults/CommandShare.ts
@@ -56,7 +56,7 @@ class CommandShare extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/vaults/CommandUnshare.ts
+++ b/src/bin/vaults/CommandUnshare.ts
@@ -56,7 +56,7 @@ class CommandUnshare extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/bin/vaults/CommandVersion.ts
+++ b/src/bin/vaults/CommandVersion.ts
@@ -49,7 +49,7 @@ class CommandVersion extends CommandPolykey {
           logger: this.logger.getChild(WebSocketClient.name),
         });
         pkClient = await PolykeyClient.createPolykeyClient({
-          streamFactory: () => webSocketClient.startConnection(),
+          streamFactory: (ctx) => webSocketClient.startConnection(ctx),
           nodePath: options.nodePath,
           manifest: clientManifest,
           logger: this.logger.getChild(PolykeyClient.name),

--- a/src/client/handlers/gestaltsGestaltList.ts
+++ b/src/client/handlers/gestaltsGestaltList.ts
@@ -22,8 +22,8 @@ class GestaltsGestaltListHandler extends ServerHandler<
     yield* db.withTransactionG(async function* (
       tran,
     ): AsyncGenerator<ClientRPCResponseResult<GestaltMessage>> {
+      if (ctx.signal.aborted) throw ctx.signal.reason;
       for await (const gestalt of gestaltGraph.getGestalts(tran)) {
-        if (ctx.signal.aborted) throw ctx.signal.reason;
         const gestaltMessage: GestaltMessage = {
           gestalt: {
             matrix: {},
@@ -35,13 +35,11 @@ class GestaltsGestaltListHandler extends ServerHandler<
         const newGestalt = gestaltMessage.gestalt;
         newGestalt.identities = gestalt.identities;
         for (const [key, value] of Object.entries(gestalt.nodes)) {
-          if (ctx.signal.aborted) throw ctx.signal.reason;
           newGestalt.nodes[key] = {
             nodeId: nodesUtils.encodeNodeId(value.nodeId),
           };
         }
         for (const keyA of Object.keys(gestalt.matrix)) {
-          if (ctx.signal.aborted) throw ctx.signal.reason;
           let record = newGestalt.matrix[keyA];
           if (record == null) {
             record = {};
@@ -51,6 +49,7 @@ class GestaltsGestaltListHandler extends ServerHandler<
             record[keyB] = null;
           }
         }
+        if (ctx.signal.aborted) throw ctx.signal.reason;
         yield gestaltMessage;
       }
     });

--- a/src/client/handlers/gestaltsGestaltList.ts
+++ b/src/client/handlers/gestaltsGestaltList.ts
@@ -14,8 +14,8 @@ class GestaltsGestaltListHandler extends ServerHandler<
   ClientRPCResponseResult<GestaltMessage>
 > {
   public async *handle(
-    input_,
-    connectionInfo_,
+    _input,
+    _connectionInfo,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<GestaltMessage>> {
     const { db, gestaltGraph } = this.container;

--- a/src/client/handlers/gestaltsGestaltList.ts
+++ b/src/client/handlers/gestaltsGestaltList.ts
@@ -15,7 +15,8 @@ class GestaltsGestaltListHandler extends ServerHandler<
 > {
   public async *handle(
     _input,
-    _connectionInfo,
+    _cancel,
+    _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<GestaltMessage>> {
     const { db, gestaltGraph } = this.container;

--- a/src/client/handlers/identitiesAuthenticate.ts
+++ b/src/client/handlers/identitiesAuthenticate.ts
@@ -24,6 +24,7 @@ class IdentitiesAuthenticateHandler extends ServerHandler<
     _,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<AuthProcessMessage>> {
+    if (ctx.signal.aborted) throw ctx.signal.reason;
     const { identitiesManager } = this.container;
     const {
       providerId,
@@ -44,24 +45,23 @@ class IdentitiesAuthenticateHandler extends ServerHandler<
     if (provider == null) {
       throw new identitiesErrors.ErrorProviderMissing();
     }
-    if (ctx.signal.aborted) throw ctx.signal.reason;
     const authFlow = provider.authenticate(ctx.timer.getTimeout());
-    if (ctx.signal.aborted) throw ctx.signal.reason;
     let authFlowResult = await authFlow.next();
     if (authFlowResult.done) {
       never();
     }
+    if (ctx.signal.aborted) throw ctx.signal.reason;
     yield {
       request: {
         url: authFlowResult.value.url,
         dataMap: authFlowResult.value.data,
       },
     };
-    if (ctx.signal.aborted) throw ctx.signal.reason;
     authFlowResult = await authFlow.next();
     if (!authFlowResult.done) {
       never();
     }
+    if (ctx.signal.aborted) throw ctx.signal.reason;
     yield {
       response: {
         identityId: authFlowResult.value,

--- a/src/client/handlers/identitiesAuthenticate.ts
+++ b/src/client/handlers/identitiesAuthenticate.ts
@@ -21,7 +21,8 @@ class IdentitiesAuthenticateHandler extends ServerHandler<
     input: ClientRPCRequestParams<{
       providerId: string;
     }>,
-    _,
+    _cancel,
+    _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<AuthProcessMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;

--- a/src/client/handlers/identitiesAuthenticatedGet.ts
+++ b/src/client/handlers/identitiesAuthenticatedGet.ts
@@ -20,7 +20,8 @@ class IdentitiesAuthenticatedGetHandler extends ServerHandler<
     input: ClientRPCRequestParams<{
       providerId?: string;
     }>,
-    _,
+    _cancel,
+    _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<IdentityMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;

--- a/src/client/handlers/identitiesAuthenticatedGet.ts
+++ b/src/client/handlers/identitiesAuthenticatedGet.ts
@@ -20,6 +20,8 @@ class IdentitiesAuthenticatedGetHandler extends ServerHandler<
     input: ClientRPCRequestParams<{
       providerId?: string;
     }>,
+    _,
+    ctx,
   ): AsyncGenerator<ClientRPCResponseResult<IdentityMessage>> {
     const { identitiesManager } = this.container;
     let providerId: ProviderId | undefined;
@@ -41,12 +43,14 @@ class IdentitiesAuthenticatedGetHandler extends ServerHandler<
         ? (Object.keys(identitiesManager.getProviders()) as Array<ProviderId>)
         : [providerId];
     for (const providerId of providerIds) {
+      if (ctx.signal.aborted) throw ctx.signal.reason;
       const provider = identitiesManager.getProvider(providerId);
       if (provider == null) {
         continue;
       }
       const identities = await provider.getAuthIdentityIds();
       for (const identityId of identities) {
+        if (ctx.signal.aborted) throw ctx.signal.reason;
         yield {
           providerId: provider.id,
           identityId: identityId,

--- a/src/client/handlers/identitiesAuthenticatedGet.ts
+++ b/src/client/handlers/identitiesAuthenticatedGet.ts
@@ -23,6 +23,7 @@ class IdentitiesAuthenticatedGetHandler extends ServerHandler<
     _,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<IdentityMessage>> {
+    if (ctx.signal.aborted) throw ctx.signal.reason;
     const { identitiesManager } = this.container;
     let providerId: ProviderId | undefined;
     if (input.providerId != null) {
@@ -43,7 +44,6 @@ class IdentitiesAuthenticatedGetHandler extends ServerHandler<
         ? (Object.keys(identitiesManager.getProviders()) as Array<ProviderId>)
         : [providerId];
     for (const providerId of providerIds) {
-      if (ctx.signal.aborted) throw ctx.signal.reason;
       const provider = identitiesManager.getProvider(providerId);
       if (provider == null) {
         continue;

--- a/src/client/handlers/identitiesInfoConnectedGet.ts
+++ b/src/client/handlers/identitiesInfoConnectedGet.ts
@@ -18,6 +18,8 @@ class IdentitiesInfoConnectedGetHandler extends ServerHandler<
 > {
   public async *handle(
     input: ClientRPCRequestParams<ProviderSearchMessage>,
+    _,
+    ctx,
   ): AsyncGenerator<ClientRPCResponseResult<IdentityInfoMessage>> {
     const { identitiesManager } = this.container;
     const {
@@ -62,6 +64,7 @@ class IdentitiesInfoConnectedGetHandler extends ServerHandler<
     }
     const identities: Array<AsyncGenerator<IdentityData>> = [];
     for (const providerId of providerIds) {
+      if (ctx.signal.aborted) throw ctx.signal.reason;
       // Get provider from id
       const provider = identitiesManager.getProvider(providerId);
       if (provider === undefined) {
@@ -85,6 +88,7 @@ class IdentitiesInfoConnectedGetHandler extends ServerHandler<
     let count = 0;
     for (const gen of identities) {
       for await (const identity of gen) {
+        if (ctx.signal.aborted) throw ctx.signal.reason;
         if (input.limit !== undefined && count >= input.limit) break;
         yield {
           providerId: identity.providerId,

--- a/src/client/handlers/identitiesInfoConnectedGet.ts
+++ b/src/client/handlers/identitiesInfoConnectedGet.ts
@@ -21,6 +21,7 @@ class IdentitiesInfoConnectedGetHandler extends ServerHandler<
     _,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<IdentityInfoMessage>> {
+    if (ctx.signal.aborted) throw ctx.signal.reason;
     const { identitiesManager } = this.container;
     const {
       providerIds,
@@ -64,7 +65,6 @@ class IdentitiesInfoConnectedGetHandler extends ServerHandler<
     }
     const identities: Array<AsyncGenerator<IdentityData>> = [];
     for (const providerId of providerIds) {
-      if (ctx.signal.aborted) throw ctx.signal.reason;
       // Get provider from id
       const provider = identitiesManager.getProvider(providerId);
       if (provider === undefined) {

--- a/src/client/handlers/identitiesInfoConnectedGet.ts
+++ b/src/client/handlers/identitiesInfoConnectedGet.ts
@@ -18,7 +18,8 @@ class IdentitiesInfoConnectedGetHandler extends ServerHandler<
 > {
   public async *handle(
     input: ClientRPCRequestParams<ProviderSearchMessage>,
-    _,
+    _cancel,
+    _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<IdentityInfoMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;

--- a/src/client/handlers/identitiesInfoGet.ts
+++ b/src/client/handlers/identitiesInfoGet.ts
@@ -19,7 +19,8 @@ class IdentitiesInfoGetHandler extends ServerHandler<
 > {
   public async *handle(
     input: ClientRPCRequestParams<ProviderSearchMessage>,
-    _,
+    _cancel,
+    _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<IdentityInfoMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;

--- a/src/client/handlers/identitiesInfoGet.ts
+++ b/src/client/handlers/identitiesInfoGet.ts
@@ -22,6 +22,7 @@ class IdentitiesInfoGetHandler extends ServerHandler<
     _,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<IdentityInfoMessage>> {
+    if (ctx.signal.aborted) throw ctx.signal.reason;
     const { identitiesManager } = this.container;
     const {
       providerIds,
@@ -57,7 +58,6 @@ class IdentitiesInfoGetHandler extends ServerHandler<
     }
     const identities: Array<IdentityData | undefined> = [];
     for (const providerId of providerIds) {
-      if (ctx.signal.aborted) throw ctx.signal.reason;
       // Get provider from id
       const provider = identitiesManager.getProvider(providerId);
       if (provider === undefined) {

--- a/src/client/handlers/identitiesInfoGet.ts
+++ b/src/client/handlers/identitiesInfoGet.ts
@@ -19,6 +19,8 @@ class IdentitiesInfoGetHandler extends ServerHandler<
 > {
   public async *handle(
     input: ClientRPCRequestParams<ProviderSearchMessage>,
+    _,
+    ctx,
   ): AsyncGenerator<ClientRPCResponseResult<IdentityInfoMessage>> {
     const { identitiesManager } = this.container;
     const {
@@ -55,6 +57,7 @@ class IdentitiesInfoGetHandler extends ServerHandler<
     }
     const identities: Array<IdentityData | undefined> = [];
     for (const providerId of providerIds) {
+      if (ctx.signal.aborted) throw ctx.signal.reason;
       // Get provider from id
       const provider = identitiesManager.getProvider(providerId);
       if (provider === undefined) {
@@ -77,6 +80,7 @@ class IdentitiesInfoGetHandler extends ServerHandler<
       input.limit = identities.length;
     }
     for (let i = 0; i < input.limit; i++) {
+      if (ctx.signal.aborted) throw ctx.signal.reason;
       const identity = identities[i];
       if (identity !== undefined) {
         if (identitiesUtils.matchIdentityData(identity, searchTerms)) {

--- a/src/client/handlers/keysCertsChainGet.ts
+++ b/src/client/handlers/keysCertsChainGet.ts
@@ -10,9 +10,14 @@ class KeysCertsChainGetHandler extends ServerHandler<
   ClientRPCRequestParams,
   ClientRPCResponseResult<CertMessage>
 > {
-  public async *handle(): AsyncGenerator<ClientRPCResponseResult<CertMessage>> {
+  public async *handle(
+    input_,
+    connectionInfo_,
+    ctx,
+  ): AsyncGenerator<ClientRPCResponseResult<CertMessage>> {
     const { certManager } = this.container;
     for (const certPEM of await certManager.getCertPEMsChain()) {
+      if (ctx.signal.aborted) throw ctx.signal.reason;
       yield {
         cert: certPEM,
       };

--- a/src/client/handlers/keysCertsChainGet.ts
+++ b/src/client/handlers/keysCertsChainGet.ts
@@ -11,8 +11,8 @@ class KeysCertsChainGetHandler extends ServerHandler<
   ClientRPCResponseResult<CertMessage>
 > {
   public async *handle(
-    input_,
-    connectionInfo_,
+    _input,
+    _connectionInfo,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<CertMessage>> {
     const { certManager } = this.container;

--- a/src/client/handlers/keysCertsChainGet.ts
+++ b/src/client/handlers/keysCertsChainGet.ts
@@ -12,7 +12,8 @@ class KeysCertsChainGetHandler extends ServerHandler<
 > {
   public async *handle(
     _input,
-    _connectionInfo,
+    _cancel,
+    _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<CertMessage>> {
     const { certManager } = this.container;

--- a/src/client/handlers/nodesGetAll.ts
+++ b/src/client/handlers/nodesGetAll.ts
@@ -20,13 +20,11 @@ class NodesGetAllHandler extends ServerHandler<
     _connectionUInfo,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<NodesGetMessage>> {
+    if (ctx.signal.aborted) throw ctx.signal.reason;
     const { nodeGraph, keyRing } = this.container;
-
     for await (const bucket of nodeGraph.getBuckets()) {
-      if (ctx.signal.aborted) throw ctx.signal.reason;
       let index;
       for (const id of Object.keys(bucket)) {
-        if (ctx.signal.aborted) throw ctx.signal.reason;
         const encodedId = nodesUtils.encodeNodeId(
           IdInternal.fromString<NodeId>(id),
         );
@@ -37,6 +35,7 @@ class NodesGetAllHandler extends ServerHandler<
             IdInternal.fromString<NodeId>(id),
           );
         }
+        if (ctx.signal.aborted) throw ctx.signal.reason;
         yield {
           bucketIndex: index,
           nodeIdEncoded: encodedId,

--- a/src/client/handlers/nodesGetAll.ts
+++ b/src/client/handlers/nodesGetAll.ts
@@ -17,7 +17,8 @@ class NodesGetAllHandler extends ServerHandler<
 > {
   public async *handle(
     _input,
-    _connectionUInfo,
+    _cancel,
+    _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<NodesGetMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;

--- a/src/client/handlers/nodesGetAll.ts
+++ b/src/client/handlers/nodesGetAll.ts
@@ -15,14 +15,18 @@ class NodesGetAllHandler extends ServerHandler<
   ClientRPCRequestParams,
   ClientRPCResponseResult<NodesGetMessage>
 > {
-  public async *handle(): AsyncGenerator<
-    ClientRPCResponseResult<NodesGetMessage>
-  > {
+  public async *handle(
+    input_,
+    connectionUInfo_,
+    ctx,
+  ): AsyncGenerator<ClientRPCResponseResult<NodesGetMessage>> {
     const { nodeGraph, keyRing } = this.container;
 
     for await (const bucket of nodeGraph.getBuckets()) {
+      if (ctx.signal.aborted) throw ctx.signal.reason;
       let index;
       for (const id of Object.keys(bucket)) {
+        if (ctx.signal.aborted) throw ctx.signal.reason;
         const encodedId = nodesUtils.encodeNodeId(
           IdInternal.fromString<NodeId>(id),
         );

--- a/src/client/handlers/nodesGetAll.ts
+++ b/src/client/handlers/nodesGetAll.ts
@@ -16,8 +16,8 @@ class NodesGetAllHandler extends ServerHandler<
   ClientRPCResponseResult<NodesGetMessage>
 > {
   public async *handle(
-    input_,
-    connectionUInfo_,
+    _input,
+    _connectionUInfo,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<NodesGetMessage>> {
     const { nodeGraph, keyRing } = this.container;

--- a/src/client/handlers/nodesListConnections.ts
+++ b/src/client/handlers/nodesListConnections.ts
@@ -12,8 +12,8 @@ class NodesListConnectionsHandler extends ServerHandler<
   ClientRPCResponseResult<NodeConnectionMessage>
 > {
   public async *handle(
-    input_,
-    connectionInfo_,
+    _input,
+    _connectionInfo,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<NodeConnectionMessage>> {
     const { nodeConnectionManager } = this.container;

--- a/src/client/handlers/nodesListConnections.ts
+++ b/src/client/handlers/nodesListConnections.ts
@@ -13,7 +13,8 @@ class NodesListConnectionsHandler extends ServerHandler<
 > {
   public async *handle(
     _input,
-    _connectionInfo,
+    _cancel,
+    _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<NodeConnectionMessage>> {
     const { nodeConnectionManager } = this.container;

--- a/src/client/handlers/nodesListConnections.ts
+++ b/src/client/handlers/nodesListConnections.ts
@@ -11,12 +11,15 @@ class NodesListConnectionsHandler extends ServerHandler<
   ClientRPCRequestParams,
   ClientRPCResponseResult<NodeConnectionMessage>
 > {
-  public async *handle(): AsyncGenerator<
-    ClientRPCResponseResult<NodeConnectionMessage>
-  > {
+  public async *handle(
+    input_,
+    connectionInfo_,
+    ctx,
+  ): AsyncGenerator<ClientRPCResponseResult<NodeConnectionMessage>> {
     const { nodeConnectionManager } = this.container;
     const connections = nodeConnectionManager.listConnections();
     for (const connection of connections) {
+      if (ctx.signal.aborted) throw ctx.signal.reason;
       yield {
         host: connection.address.host,
         hostname: connection.address.hostname ?? '',

--- a/src/client/handlers/notificationsRead.ts
+++ b/src/client/handlers/notificationsRead.ts
@@ -17,8 +17,8 @@ class NotificationsReadHandler extends ServerHandler<
     _,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<NotificationMessage>> {
+    if (ctx.signal.aborted) throw ctx.signal.reason;
     const { db, notificationsManager } = this.container;
-
     const notifications = await db.withTransactionF((tran) =>
       notificationsManager.readNotifications({
         unread: input.unread,

--- a/src/client/handlers/notificationsRead.ts
+++ b/src/client/handlers/notificationsRead.ts
@@ -14,7 +14,8 @@ class NotificationsReadHandler extends ServerHandler<
 > {
   public async *handle(
     input: ClientRPCRequestParams<NotificationReadMessage>,
-    _,
+    _cancel,
+    _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<NotificationMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;

--- a/src/client/handlers/notificationsRead.ts
+++ b/src/client/handlers/notificationsRead.ts
@@ -14,6 +14,8 @@ class NotificationsReadHandler extends ServerHandler<
 > {
   public async *handle(
     input: ClientRPCRequestParams<NotificationReadMessage>,
+    _,
+    ctx,
   ): AsyncGenerator<ClientRPCResponseResult<NotificationMessage>> {
     const { db, notificationsManager } = this.container;
 
@@ -26,6 +28,7 @@ class NotificationsReadHandler extends ServerHandler<
       }),
     );
     for (const notification of notifications) {
+      if (ctx.signal.aborted) throw ctx.signal.reason;
       yield {
         notification: notification,
       };

--- a/src/client/handlers/serverManifest.ts
+++ b/src/client/handlers/serverManifest.ts
@@ -15,7 +15,7 @@ import type NodeGraph from '../../nodes/NodeGraph';
 import type VaultManager from '../../vaults/VaultManager';
 import type { FileSystem } from '../../types';
 import { VaultsCloneHandler } from './vaultsClone';
-import { VaultsCreatehandler } from './vaultsCreate';
+import { VaultsCreateHandler } from './vaultsCreate';
 import { VaultsDeleteHandler } from './vaultsDelete';
 import { VaultsListHandler } from './vaultsList';
 import { VaultsLogHandler } from './vaultsLog';
@@ -171,7 +171,7 @@ const serverManifest = (container: {
     notificationsRead: new NotificationsReadHandler(container),
     notificationsSend: new NotificationsSendHandler(container),
     vaultsClone: new VaultsCloneHandler(container),
-    vaultsCreate: new VaultsCreatehandler(container),
+    vaultsCreate: new VaultsCreateHandler(container),
     vaultsDelete: new VaultsDeleteHandler(container),
     vaultsList: new VaultsListHandler(container),
     vaultsLog: new VaultsLogHandler(container),

--- a/src/client/handlers/vaultsCreate.ts
+++ b/src/client/handlers/vaultsCreate.ts
@@ -5,7 +5,7 @@ import type { VaultIdMessage, VaultNameMessage } from './types';
 import * as vaultsUtils from '../../vaults/utils';
 import { UnaryHandler } from '../../rpc/handlers';
 
-class VaultsCreatehandler extends UnaryHandler<
+class VaultsCreateHandler extends UnaryHandler<
   {
     db: DB;
     vaultManager: VaultManager;
@@ -28,4 +28,4 @@ class VaultsCreatehandler extends UnaryHandler<
   }
 }
 
-export { VaultsCreatehandler };
+export { VaultsCreateHandler };

--- a/src/client/handlers/vaultsList.ts
+++ b/src/client/handlers/vaultsList.ts
@@ -14,8 +14,8 @@ class VaultsListHandler extends ServerHandler<
   ClientRPCResponseResult<VaultListMessage>
 > {
   public async *handle(
-    input_,
-    connectionInfo_,
+    _input,
+    _connectionInfo,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<VaultListMessage>> {
     const { db, vaultManager } = this.container;

--- a/src/client/handlers/vaultsList.ts
+++ b/src/client/handlers/vaultsList.ts
@@ -18,6 +18,7 @@ class VaultsListHandler extends ServerHandler<
     _connectionInfo,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<VaultListMessage>> {
+    if (ctx.signal.aborted) throw ctx.signal.reason;
     const { db, vaultManager } = this.container;
     const vaults = await db.withTransactionF((tran) =>
       vaultManager.listVaults(tran),

--- a/src/client/handlers/vaultsList.ts
+++ b/src/client/handlers/vaultsList.ts
@@ -13,14 +13,17 @@ class VaultsListHandler extends ServerHandler<
   ClientRPCRequestParams,
   ClientRPCResponseResult<VaultListMessage>
 > {
-  public async *handle(): AsyncGenerator<
-    ClientRPCResponseResult<VaultListMessage>
-  > {
+  public async *handle(
+    input_,
+    connectionInfo_,
+    ctx,
+  ): AsyncGenerator<ClientRPCResponseResult<VaultListMessage>> {
     const { db, vaultManager } = this.container;
     const vaults = await db.withTransactionF((tran) =>
       vaultManager.listVaults(tran),
     );
     for await (const [vaultName, vaultId] of vaults) {
+      if (ctx.signal.aborted) throw ctx.signal.reason;
       yield {
         vaultName,
         vaultIdEncoded: vaultsUtils.encodeVaultId(vaultId),

--- a/src/client/handlers/vaultsList.ts
+++ b/src/client/handlers/vaultsList.ts
@@ -15,7 +15,8 @@ class VaultsListHandler extends ServerHandler<
 > {
   public async *handle(
     _input,
-    _connectionInfo,
+    _cancel,
+    _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<VaultListMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;

--- a/src/client/handlers/vaultsLog.ts
+++ b/src/client/handlers/vaultsLog.ts
@@ -17,7 +17,8 @@ class VaultsLogHandler extends ServerHandler<
 > {
   public async *handle(
     input: ClientRPCRequestParams<VaultsLogMessage>,
-    _connectionInfo,
+    _cancel,
+    _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<LogEntryMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;

--- a/src/client/handlers/vaultsLog.ts
+++ b/src/client/handlers/vaultsLog.ts
@@ -20,6 +20,7 @@ class VaultsLogHandler extends ServerHandler<
     _connectionInfo,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<LogEntryMessage>> {
+    if (ctx.signal.aborted) throw ctx.signal.reason;
     const { db, vaultManager } = this.container;
     const log = await db.withTransactionF(async (tran) => {
       const vaultIdFromName = await vaultManager.getVaultId(

--- a/src/client/handlers/vaultsLog.ts
+++ b/src/client/handlers/vaultsLog.ts
@@ -17,7 +17,7 @@ class VaultsLogHandler extends ServerHandler<
 > {
   public async *handle(
     input: ClientRPCRequestParams<VaultsLogMessage>,
-    connectionInfo_,
+    _connectionInfo,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<LogEntryMessage>> {
     const { db, vaultManager } = this.container;

--- a/src/client/handlers/vaultsLog.ts
+++ b/src/client/handlers/vaultsLog.ts
@@ -17,6 +17,8 @@ class VaultsLogHandler extends ServerHandler<
 > {
   public async *handle(
     input: ClientRPCRequestParams<VaultsLogMessage>,
+    connectionInfo_,
+    ctx,
   ): AsyncGenerator<ClientRPCResponseResult<LogEntryMessage>> {
     const { db, vaultManager } = this.container;
     const log = await db.withTransactionF(async (tran) => {
@@ -39,6 +41,7 @@ class VaultsLogHandler extends ServerHandler<
       );
     });
     for (const entry of log) {
+      if (ctx.signal.aborted) throw ctx.signal.reason;
       yield {
         commitId: entry.commitId,
         committer: entry.committer.name,

--- a/src/client/handlers/vaultsPermissionGet.ts
+++ b/src/client/handlers/vaultsPermissionGet.ts
@@ -22,6 +22,8 @@ class VaultsPermissionGetHandler extends ServerHandler<
 > {
   public async *handle(
     input: ClientRPCRequestParams<VaultIdentifierMessage>,
+    _,
+    ctx,
   ): AsyncGenerator<ClientRPCResponseResult<VaultPermissionMessage>> {
     const { db, vaultManager, acl } = this.container;
     const [rawPermissions, vaultId] = await db.withTransactionF(
@@ -42,10 +44,12 @@ class VaultsPermissionGetHandler extends ServerHandler<
     const permissionList: Record<NodeIdEncoded, VaultActions> = {};
     // Getting the relevant information
     for (const nodeId in rawPermissions) {
+      if (ctx.signal.aborted) throw ctx.signal.reason;
       permissionList[nodeId] = rawPermissions[nodeId].vaults[vaultId];
     }
     // Constructing the message
     for (const nodeIdString in permissionList) {
+      if (ctx.signal.aborted) throw ctx.signal.reason;
       const nodeId = IdInternal.fromString<NodeId>(nodeIdString);
       const actions = Object.keys(
         permissionList[nodeIdString],

--- a/src/client/handlers/vaultsPermissionGet.ts
+++ b/src/client/handlers/vaultsPermissionGet.ts
@@ -22,7 +22,8 @@ class VaultsPermissionGetHandler extends ServerHandler<
 > {
   public async *handle(
     input: ClientRPCRequestParams<VaultIdentifierMessage>,
-    _,
+    _cancel,
+    _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<VaultPermissionMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;

--- a/src/client/handlers/vaultsScan.ts
+++ b/src/client/handlers/vaultsScan.ts
@@ -16,6 +16,8 @@ class VaultsScanHandler extends ServerHandler<
 > {
   public async *handle(
     input: ClientRPCRequestParams<NodeIdMessage>,
+    _,
+    ctx,
   ): AsyncGenerator<ClientRPCResponseResult<VaultsScanMessage>> {
     const { vaultManager } = this.container;
     const {
@@ -38,6 +40,7 @@ class VaultsScanHandler extends ServerHandler<
       vaultName,
       vaultPermissions,
     } of vaultManager.scanVaults(nodeId)) {
+      if (ctx.signal.aborted) throw ctx.signal.reason;
       yield {
         vaultName,
         vaultIdEncoded,

--- a/src/client/handlers/vaultsScan.ts
+++ b/src/client/handlers/vaultsScan.ts
@@ -16,7 +16,8 @@ class VaultsScanHandler extends ServerHandler<
 > {
   public async *handle(
     input: ClientRPCRequestParams<NodeIdMessage>,
-    _,
+    _cancel,
+    _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<VaultsScanMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;

--- a/src/client/handlers/vaultsScan.ts
+++ b/src/client/handlers/vaultsScan.ts
@@ -19,6 +19,7 @@ class VaultsScanHandler extends ServerHandler<
     _,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<VaultsScanMessage>> {
+    if (ctx.signal.aborted) throw ctx.signal.reason;
     const { vaultManager } = this.container;
     const {
       nodeId,

--- a/src/client/handlers/vaultsSecretsList.ts
+++ b/src/client/handlers/vaultsSecretsList.ts
@@ -20,6 +20,7 @@ class VaultsSecretsListHandler extends ServerHandler<
     _,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<SecretNameMessage>> {
+    if (ctx.signal.aborted) throw ctx.signal.reason;
     const { vaultManager, db } = this.container;
     const secrets = await db.withTransactionF(async (tran) => {
       const vaultIdFromName = await vaultManager.getVaultId(

--- a/src/client/handlers/vaultsSecretsList.ts
+++ b/src/client/handlers/vaultsSecretsList.ts
@@ -17,7 +17,8 @@ class VaultsSecretsListHandler extends ServerHandler<
 > {
   public async *handle(
     input: ClientRPCRequestParams<VaultIdentifierMessage>,
-    _,
+    _cancel,
+    _meta,
     ctx,
   ): AsyncGenerator<ClientRPCResponseResult<SecretNameMessage>> {
     if (ctx.signal.aborted) throw ctx.signal.reason;

--- a/src/client/handlers/vaultsSecretsList.ts
+++ b/src/client/handlers/vaultsSecretsList.ts
@@ -17,6 +17,8 @@ class VaultsSecretsListHandler extends ServerHandler<
 > {
   public async *handle(
     input: ClientRPCRequestParams<VaultIdentifierMessage>,
+    _,
+    ctx,
   ): AsyncGenerator<ClientRPCResponseResult<SecretNameMessage>> {
     const { vaultManager, db } = this.container;
     const secrets = await db.withTransactionF(async (tran) => {
@@ -38,6 +40,7 @@ class VaultsSecretsListHandler extends ServerHandler<
       );
     });
     for (const secret of secrets) {
+      if (ctx.signal.aborted) throw ctx.signal.reason;
       yield {
         secretName: secret,
       };

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -6,13 +6,19 @@ type NoData = {};
 type ClientRPCRequestParams<T extends Record<string, JSONValue> = NoData> = {
   metadata?: {
     [Key: string]: JSONValue;
-  } & Partial<{ authorization: string }>;
+  } & Partial<{
+    authorization: string;
+    timeout: number;
+  }>;
 } & Omit<T, 'metadata'>;
 
 type ClientRPCResponseResult<T extends Record<string, JSONValue> = NoData> = {
   metadata?: {
     [Key: string]: JSONValue;
-  } & Partial<{ authorization: string }>;
+  } & Partial<{
+    authorization: string;
+    timeout: number;
+  }>;
 } & Omit<T, 'metadata'>;
 
 export type { ClientRPCRequestParams, ClientRPCResponseResult, NoData };

--- a/src/client/utils/authenticationMiddleware.ts
+++ b/src/client/utils/authenticationMiddleware.ts
@@ -24,6 +24,7 @@ function authenticationMiddlewareServer(
   JSONRPCResponse<ClientRPCResponseResult>
 > {
   return () => {
+    // Flag for tracking if the first message has been processed
     let forwardFirst = true;
     let reverseController;
     let outgoingToken: string | null = null;
@@ -92,6 +93,7 @@ function authenticationMiddlewareClient(
   JSONRPCResponse<ClientRPCResponseResult>
 > {
   return () => {
+    // Flag for tracking if the first message has been processed
     let forwardFirst = true;
     return {
       forward: new TransformStream<

--- a/src/client/utils/authenticationMiddleware.ts
+++ b/src/client/utils/authenticationMiddleware.ts
@@ -41,7 +41,7 @@ function authenticationMiddlewareServer(
                 chunk,
               );
             } catch (e) {
-              controller.terminate();
+              controller.error(e);
               const rpcError: JSONRPCError = {
                 code: e.exitCode ?? sysexits.UNKNOWN,
                 message: e.description ?? '',
@@ -53,7 +53,7 @@ function authenticationMiddlewareServer(
                 id: null,
               };
               reverseController.enqueue(rpcErrorMessage);
-              reverseController.end();
+              reverseController.error(e);
               return;
             }
           }

--- a/src/client/utils/index.ts
+++ b/src/client/utils/index.ts
@@ -1,2 +1,4 @@
 export * from './authenticationMiddleware';
+export * from './timeoutMiddleware';
+export * from './middleware';
 export * from './utils';

--- a/src/client/utils/middleware.ts
+++ b/src/client/utils/middleware.ts
@@ -24,10 +24,13 @@ function middlewareServer(
       sessionManager,
       keyRing,
     );
-  return (ctx) => {
-    const authMiddleware = authMiddlewareFactory(ctx);
-    const timeoutMiddleware =
-      timeoutMiddlewareUtils.timeoutMiddlewareServer(ctx);
+  return (ctx, cancel, meta) => {
+    const authMiddleware = authMiddlewareFactory(ctx, cancel, meta);
+    const timeoutMiddleware = timeoutMiddlewareUtils.timeoutMiddlewareServer(
+      ctx,
+      cancel,
+      meta,
+    );
     // Order is auth -> timeout
     return {
       forward: {
@@ -56,10 +59,13 @@ function middlewareClient(
 > {
   const authMiddlewareFactory =
     authenticationMiddlewareUtils.authenticationMiddlewareClient(session);
-  return (ctx) => {
-    const authMiddleware = authMiddlewareFactory(ctx);
-    const timeoutMiddleware =
-      timeoutMiddlewareUtils.timeoutMiddlewareClient(ctx);
+  return (ctx, cancel, meta) => {
+    const authMiddleware = authMiddlewareFactory(ctx, cancel, meta);
+    const timeoutMiddleware = timeoutMiddlewareUtils.timeoutMiddlewareClient(
+      ctx,
+      cancel,
+      meta,
+    );
     // Order is timeout -> auth
     return {
       forward: {

--- a/src/client/utils/middleware.ts
+++ b/src/client/utils/middleware.ts
@@ -1,0 +1,81 @@
+import type { ClientRPCRequestParams, ClientRPCResponseResult } from '../types';
+import type { Session } from '../../sessions';
+import type {
+  JSONRPCRequest,
+  JSONRPCResponse,
+  MiddlewareFactory,
+} from '../../rpc/types';
+import type SessionManager from '../../sessions/SessionManager';
+import type KeyRing from '../../keys/KeyRing';
+import * as authenticationMiddlewareUtils from './authenticationMiddleware';
+import * as timeoutMiddlewareUtils from './timeoutMiddleware';
+
+function middlewareServer(
+  sessionManager: SessionManager,
+  keyRing: KeyRing,
+): MiddlewareFactory<
+  JSONRPCRequest<ClientRPCRequestParams>,
+  JSONRPCRequest<ClientRPCRequestParams>,
+  JSONRPCResponse<ClientRPCResponseResult>,
+  JSONRPCResponse<ClientRPCResponseResult>
+> {
+  const authMiddlewareFactory =
+    authenticationMiddlewareUtils.authenticationMiddlewareServer(
+      sessionManager,
+      keyRing,
+    );
+  return (ctx) => {
+    const authMiddleware = authMiddlewareFactory(ctx);
+    const timeoutMiddleware =
+      timeoutMiddlewareUtils.timeoutMiddlewareServer(ctx);
+    // Order is auth -> timeout
+    return {
+      forward: {
+        writable: authMiddleware.forward.writable,
+        readable: authMiddleware.forward.readable.pipeThrough(
+          timeoutMiddleware.forward,
+        ),
+      },
+      reverse: {
+        writable: timeoutMiddleware.reverse.writable,
+        readable: timeoutMiddleware.reverse.readable.pipeThrough(
+          authMiddleware.reverse,
+        ),
+      },
+    };
+  };
+}
+
+function middlewareClient(
+  session: Session,
+): MiddlewareFactory<
+  JSONRPCRequest<ClientRPCRequestParams>,
+  JSONRPCRequest<ClientRPCRequestParams>,
+  JSONRPCResponse<ClientRPCResponseResult>,
+  JSONRPCResponse<ClientRPCResponseResult>
+> {
+  const authMiddlewareFactory =
+    authenticationMiddlewareUtils.authenticationMiddlewareClient(session);
+  return (ctx) => {
+    const authMiddleware = authMiddlewareFactory(ctx);
+    const timeoutMiddleware =
+      timeoutMiddlewareUtils.timeoutMiddlewareClient(ctx);
+    // Order is timeout -> auth
+    return {
+      forward: {
+        writable: timeoutMiddleware.forward.writable,
+        readable: timeoutMiddleware.forward.readable.pipeThrough(
+          authMiddleware.forward,
+        ),
+      },
+      reverse: {
+        writable: authMiddleware.reverse.writable,
+        readable: authMiddleware.reverse.readable.pipeThrough(
+          timeoutMiddleware.reverse,
+        ),
+      },
+    };
+  };
+}
+
+export { middlewareServer, middlewareClient };

--- a/src/client/utils/timeoutMiddleware.ts
+++ b/src/client/utils/timeoutMiddleware.ts
@@ -9,6 +9,7 @@ import { TransformStream } from 'stream/web';
  */
 function timeoutMiddlewareServer(ctx: ContextTimed) {
   const currentTimeout = ctx.timer.delay;
+  // Flags for tracking if the first message has been processed
   let forwardFirst = true;
   let reverseFirst = true;
   return {
@@ -52,6 +53,7 @@ function timeoutMiddlewareServer(ctx: ContextTimed) {
  */
 function timeoutMiddlewareClient(ctx: ContextTimed) {
   const currentTimeout = ctx.timer.delay;
+  // Flags for tracking if the first message has been processed
   let forwardFirst = true;
   let reverseFirst = true;
   return {

--- a/src/client/utils/timeoutMiddleware.ts
+++ b/src/client/utils/timeoutMiddleware.ts
@@ -1,13 +1,18 @@
 import type { JSONRPCRequest, JSONRPCResponse } from '../../rpc/types';
 import type { ClientRPCRequestParams, ClientRPCResponseResult } from '../types';
 import type { ContextTimed } from '../../contexts/types';
+import type { JSONValue } from '../../types';
 import { TransformStream } from 'stream/web';
 
 /**
  * This adds its timeout to the reverse metadata and updates it's timeout based
  * on the forward metadata.
  */
-function timeoutMiddlewareServer(ctx: ContextTimed) {
+function timeoutMiddlewareServer(
+  ctx: ContextTimed,
+  _cancel: (reason?: any) => void,
+  _meta: Record<string, JSONValue> | undefined,
+) {
   const currentTimeout = ctx.timer.delay;
   // Flags for tracking if the first message has been processed
   let forwardFirst = true;
@@ -50,8 +55,14 @@ function timeoutMiddlewareServer(ctx: ContextTimed) {
  * This adds its own timeout to the forward metadata and updates it's timeout
  * based on the reverse metadata.
  * @param ctx
+ * @param _cancel
+ * @param _meta
  */
-function timeoutMiddlewareClient(ctx: ContextTimed) {
+function timeoutMiddlewareClient(
+  ctx: ContextTimed,
+  _cancel: (reason?: any) => void,
+  _meta: Record<string, JSONValue> | undefined,
+) {
   const currentTimeout = ctx.timer.delay;
   // Flags for tracking if the first message has been processed
   let forwardFirst = true;

--- a/src/client/utils/timeoutMiddleware.ts
+++ b/src/client/utils/timeoutMiddleware.ts
@@ -1,0 +1,91 @@
+import type { JSONRPCRequest, JSONRPCResponse } from '../../rpc/types';
+import type { ClientRPCRequestParams, ClientRPCResponseResult } from '../types';
+import type { ContextTimed } from '../../contexts/types';
+import { TransformStream } from 'stream/web';
+
+/**
+ * This adds its timeout to the reverse metadata and updates it's timeout based
+ * on the forward metadata.
+ */
+function timeoutMiddlewareServer(ctx: ContextTimed) {
+  const currentTimeout = ctx.timer.delay;
+  let forwardFirst = true;
+  let reverseFirst = true;
+  return {
+    forward: new TransformStream<
+      JSONRPCRequest<ClientRPCRequestParams>,
+      JSONRPCRequest<ClientRPCRequestParams>
+    >({
+      transform: (chunk, controller) => {
+        controller.enqueue(chunk);
+        if (forwardFirst) {
+          forwardFirst = false;
+          const clientTimeout = chunk.params?.metadata?.timeout;
+
+          if (clientTimeout == null) return;
+          if (clientTimeout < currentTimeout) ctx.timer.reset(clientTimeout);
+        }
+      },
+    }),
+    reverse: new TransformStream<
+      JSONRPCResponse<ClientRPCResponseResult>,
+      JSONRPCResponse<ClientRPCResponseResult>
+    >({
+      transform: (chunk, controller) => {
+        if (reverseFirst) {
+          reverseFirst = false;
+          if ('result' in chunk) {
+            if (chunk.result.metadata == null) chunk.result.metadata = {};
+            chunk.result.metadata.timeout = currentTimeout;
+          }
+        }
+        controller.enqueue(chunk);
+      },
+    }),
+  };
+}
+
+/**
+ * This adds its own timeout to the forward metadata and updates it's timeout
+ * based on the reverse metadata.
+ * @param ctx
+ */
+function timeoutMiddlewareClient(ctx: ContextTimed) {
+  const currentTimeout = ctx.timer.delay;
+  let forwardFirst = true;
+  let reverseFirst = true;
+  return {
+    forward: new TransformStream<
+      JSONRPCRequest<ClientRPCRequestParams>,
+      JSONRPCRequest<ClientRPCRequestParams>
+    >({
+      transform: (chunk, controller) => {
+        if (forwardFirst) {
+          forwardFirst = false;
+          if (chunk.params == null) chunk.params = {};
+          if (chunk.params.metadata == null) chunk.params.metadata = {};
+          chunk.params.metadata.timeout = currentTimeout;
+        }
+        controller.enqueue(chunk);
+      },
+    }),
+    reverse: new TransformStream<
+      JSONRPCResponse<ClientRPCResponseResult>,
+      JSONRPCResponse<ClientRPCResponseResult>
+    >({
+      transform: (chunk, controller) => {
+        controller.enqueue(chunk);
+        if (reverseFirst) {
+          reverseFirst = false;
+          if ('result' in chunk) {
+            const clientTimeout = chunk.result?.metadata?.timeout;
+            if (clientTimeout == null) return;
+            if (clientTimeout < currentTimeout) ctx.timer.reset(clientTimeout);
+          }
+        }
+      },
+    }),
+  };
+}
+
+export { timeoutMiddlewareServer, timeoutMiddlewareClient };

--- a/src/config.ts
+++ b/src/config.ts
@@ -102,8 +102,8 @@ const config = {
       clientHost: '127.0.0.1' as Host,
       clientPort: 0 as Port,
       maxReadBufferBytes: 1_000_000_000, // About 1 GB
-      pingInterval: 1_000, // 1 second
-      pingTimeout: 10_000, // 10 seconds
+      pingIntervalTime: 1_000, // 1 second
+      pingTimeoutTime: 10_000, // 10 seconds
     },
     proxyConfig: {
       connConnectTime: 2000,

--- a/src/config.ts
+++ b/src/config.ts
@@ -98,12 +98,17 @@ const config = {
       // GRPCServer for agent service
       agentHost: '127.0.0.1' as Host,
       agentPort: 0 as Port,
-      // GRPCServer for client service
+      // RPCServer for client service
       clientHost: '127.0.0.1' as Host,
       clientPort: 0 as Port,
-      maxReadBufferBytes: 1_000_000_000, // About 1 GB
+      // Times and limits for client communication
+      connectionIdleTimeoutTime: 120, // 2 minutes
       pingIntervalTime: 1_000, // 1 second
       pingTimeoutTime: 10_000, // 10 seconds
+      handlerTimeoutTime: 60_000, // 1 minute
+      handlerTimeoutGraceTime: 2_000, // 2 seconds
+      maxReadableStreamBytes: 1_000_000_000, // About 1 GB
+      clientParserBufferByteLimit: 1_000_000, // About 1MB
     },
     proxyConfig: {
       connConnectTime: 2000,

--- a/src/rpc/RPCClient.ts
+++ b/src/rpc/RPCClient.ts
@@ -283,7 +283,7 @@ class RPCClient<M extends ClientManifest> {
       if (ctx.timer == null) timer.cancel(Error('TMP Clean up reason'));
       signal.removeEventListener('abort', abortHandler);
     };
-    const timeoutError = new rpcErrors.ErrorRpcTimedOut();
+    const timeoutError = new rpcErrors.ErrorRPCTimedOut();
     void timer.then(
       () => {
         abortController.abort(timeoutError);
@@ -386,7 +386,7 @@ class RPCClient<M extends ClientManifest> {
       if (ctx.timer == null) timer.cancel(Error('TMP Clean up reason'));
       signal.removeEventListener('abort', abortHandler);
     };
-    const timeoutError = new rpcErrors.ErrorRpcTimedOut();
+    const timeoutError = new rpcErrors.ErrorRPCTimedOut();
     void timer.then(
       () => {
         abortController.abort(timeoutError);

--- a/src/rpc/RPCClient.ts
+++ b/src/rpc/RPCClient.ts
@@ -376,6 +376,7 @@ class RPCClient<M extends ClientManifest> {
     const signal = abortController.signal;
     // A promise that will reject if there is an abort signal or timeout
     const abortRaceProm = promise<never>();
+    // Prevent unhandled rejection when we're don with the promise
     abortRaceProm.p.catch(() => {});
     let abortHandler: () => void;
     if (ctx.signal != null) {

--- a/src/rpc/RPCClient.ts
+++ b/src/rpc/RPCClient.ts
@@ -17,13 +17,16 @@ import type {
   MapCallers,
 } from './types';
 import type { NodeId } from 'ids/index';
+import type { ContextTimed } from '../contexts/types';
+import { TransformStream } from 'stream/web';
 import { CreateDestroy, ready } from '@matrixai/async-init/dist/CreateDestroy';
 import Logger from '@matrixai/logger';
 import { IdInternal } from '@matrixai/id';
+import { Timer } from '@matrixai/timer';
 import * as middlewareUtils from './utils/middleware';
 import * as rpcErrors from './errors';
 import * as rpcUtils from './utils/utils';
-import { never } from '../utils';
+import { never, promise } from '../utils';
 
 // eslint-disable-next-line
 interface RPCClient<M extends ClientManifest> extends CreateDestroy {}
@@ -39,12 +42,15 @@ class RPCClient<M extends ClientManifest> {
    * The middlewareFactory needs to be a function that creates a pair of
    * transform streams that convert `JSONRPCRequest` to `Uint8Array` on the forward
    * path and `Uint8Array` to `JSONRPCResponse` on the reverse path.
+   * @param obj.defaultTimeout - default timeout to be used if none is provided
+   * for a client call.
    * @param obj.logger
    */
   static async createRPCClient<M extends ClientManifest>({
     manifest,
     streamFactory,
     middlewareFactory = middlewareUtils.defaultClientMiddlewareWrapper(),
+    defaultTimeout = 60_000, // 1 minuet
     logger = new Logger(this.name),
   }: {
     manifest: M;
@@ -55,6 +61,7 @@ class RPCClient<M extends ClientManifest> {
       JSONRPCResponse,
       Uint8Array
     >;
+    defaultTimeout?: number;
     logger?: Logger;
   }) {
     logger.info(`Creating ${this.name}`);
@@ -62,6 +69,7 @@ class RPCClient<M extends ClientManifest> {
       manifest,
       streamFactory,
       middlewareFactory,
+      defaultTimeout,
       logger,
     });
     logger.info(`Created ${this.name}`);
@@ -78,6 +86,7 @@ class RPCClient<M extends ClientManifest> {
   >;
   protected callerTypes: Record<string, HandlerType>;
   // Method proxies
+  public readonly defaultTimeout: number;
   public readonly methodsProxy = new Proxy(
     {},
     {
@@ -85,15 +94,16 @@ class RPCClient<M extends ClientManifest> {
         if (typeof method === 'symbol') throw never();
         switch (this.callerTypes[method]) {
           case 'UNARY':
-            return (params) => this.unaryCaller(method, params);
+            return (params, ctx) => this.unaryCaller(method, params, ctx);
           case 'SERVER':
-            return (params) => this.serverStreamCaller(method, params);
+            return (params, ctx) =>
+              this.serverStreamCaller(method, params, ctx);
           case 'CLIENT':
-            return () => this.clientStreamCaller(method);
+            return (ctx) => this.clientStreamCaller(method, ctx);
           case 'DUPLEX':
-            return () => this.duplexStreamCaller(method);
+            return (ctx) => this.duplexStreamCaller(method, ctx);
           case 'RAW':
-            return (header) => this.rawStreamCaller(method, header);
+            return (header, ctx) => this.rawStreamCaller(method, header, ctx);
           default:
             return;
         }
@@ -105,6 +115,7 @@ class RPCClient<M extends ClientManifest> {
     manifest,
     streamFactory,
     middlewareFactory,
+    defaultTimeout,
     logger,
   }: {
     manifest: M;
@@ -115,11 +126,13 @@ class RPCClient<M extends ClientManifest> {
       JSONRPCResponse,
       Uint8Array
     >;
+    defaultTimeout: number;
     logger: Logger;
   }) {
     this.callerTypes = rpcUtils.getHandlerTypes(manifest);
     this.streamFactory = streamFactory;
     this.middlewareFactory = middlewareFactory;
+    this.defaultTimeout = defaultTimeout;
     this.logger = logger;
   }
 
@@ -137,8 +150,9 @@ class RPCClient<M extends ClientManifest> {
   public async unaryCaller<I extends JSONValue, O extends JSONValue>(
     method: string,
     parameters: I,
+    ctx: Partial<ContextTimed> = {},
   ): Promise<O> {
-    const callerInterface = await this.duplexStreamCaller<I, O>(method);
+    const callerInterface = await this.duplexStreamCaller<I, O>(method, ctx);
     const reader = callerInterface.readable.getReader();
     const writer = callerInterface.writable.getWriter();
     await writer.write(parameters);
@@ -155,8 +169,9 @@ class RPCClient<M extends ClientManifest> {
   public async serverStreamCaller<I extends JSONValue, O extends JSONValue>(
     method: string,
     parameters: I,
+    ctx: Partial<ContextTimed> = {},
   ): Promise<ReadableStream<O>> {
-    const callerInterface = await this.duplexStreamCaller<I, O>(method);
+    const callerInterface = await this.duplexStreamCaller<I, O>(method, ctx);
     const writer = callerInterface.writable.getWriter();
     await writer.write(parameters);
     await writer.close();
@@ -167,11 +182,12 @@ class RPCClient<M extends ClientManifest> {
   @ready(new rpcErrors.ErrorRPCDestroyed())
   public async clientStreamCaller<I extends JSONValue, O extends JSONValue>(
     method: string,
+    ctx: Partial<ContextTimed> = {},
   ): Promise<{
     output: Promise<O>;
     writable: WritableStream<I>;
   }> {
-    const callerInterface = await this.duplexStreamCaller<I, O>(method);
+    const callerInterface = await this.duplexStreamCaller<I, O>(method, ctx);
     const reader = callerInterface.readable.getReader();
     const output = reader.read().then(({ value, done }) => {
       if (done) {
@@ -188,28 +204,84 @@ class RPCClient<M extends ClientManifest> {
   @ready(new rpcErrors.ErrorRPCDestroyed())
   public async duplexStreamCaller<I extends JSONValue, O extends JSONValue>(
     method: string,
+    ctx: Partial<ContextTimed> = {},
   ): Promise<ReadableWritablePair<O, I>> {
+    const abortController = new AbortController();
+    const signal = abortController.signal;
+    // A promise that will reject if there is an abort signal or timeout
+    const abortRaceProm = promise<never>();
+    abortRaceProm.p.catch(() => {});
+    let abortHandler: () => void;
+    if (ctx.signal != null) {
+      // Propagate signal events
+      abortHandler = () => {
+        abortController.abort(ctx.signal?.reason);
+        abortRaceProm.rejectP(ctx.signal?.reason);
+      };
+      if (ctx.signal.aborted) abortHandler();
+      ctx.signal.addEventListener('abort', abortHandler);
+    }
+    const timer =
+      ctx.timer ??
+      new Timer({
+        delay: this.defaultTimeout,
+      });
+    const cleanUp = () => {
+      // Clean up the timer and signal
+      if (ctx.timer == null) timer.cancel(Error('TMP Clean up reason'));
+      signal.removeEventListener('abort', abortHandler);
+    };
+    const timeoutError = new rpcErrors.ErrorRpcTimedOut();
+    void timer.then(
+      () => {
+        abortController.abort(timeoutError);
+        abortRaceProm.rejectP(timeoutError);
+      },
+      () => {},
+    );
+    // Deciding if we want to allow refreshing
+    // We want to refresh timer if none was provided
+    const refreshingTimer: Timer | undefined =
+      ctx.timer == null ? timer : undefined;
     // Providing empty metadata here. we don't support it yet.
     const outputMessageTransformStream =
-      rpcUtils.clientOutputTransformStream<O>({
-        nodeId: IdInternal.fromBuffer<NodeId>(Buffer.alloc(32, 0)), // FIXME
-        host: '',
-        port: 0,
-        command: method,
-      });
-    const inputMessageTransformStream =
-      rpcUtils.clientInputTransformStream<I>(method);
-    const middleware = this.middlewareFactory();
+      rpcUtils.clientOutputTransformStream<O>(
+        {
+          nodeId: IdInternal.fromBuffer<NodeId>(Buffer.alloc(32, 0)), // FIXME
+          host: '',
+          port: 0,
+          command: method,
+        },
+        refreshingTimer,
+      );
+    const inputMessageTransformStream = rpcUtils.clientInputTransformStream<I>(
+      method,
+      refreshingTimer,
+    );
+    const middleware = this.middlewareFactory({ signal, timer });
     // Hooking up agnostic stream side
-    const streamPair = await this.streamFactory();
-    void streamPair.readable
-      .pipeThrough(middleware.reverse)
-      .pipeTo(outputMessageTransformStream.writable)
-      .catch(() => {});
-    void inputMessageTransformStream.readable
-      .pipeThrough(middleware.forward)
-      .pipeTo(streamPair.writable)
-      .catch(() => {});
+    let streamPair: ReadableWritablePair<Uint8Array, Uint8Array>;
+    try {
+      streamPair = await Promise.race([
+        this.streamFactory({ signal, timer }),
+        abortRaceProm.p,
+      ]);
+    } catch (e) {
+      cleanUp();
+      throw e;
+    }
+    void Promise.allSettled([
+      streamPair.readable
+        .pipeThrough(middleware.reverse)
+        .pipeTo(outputMessageTransformStream.writable)
+        .catch(() => {}),
+      inputMessageTransformStream.readable
+        .pipeThrough(middleware.forward)
+        .pipeTo(streamPair.writable)
+        .catch(() => {}),
+    ]).finally(() => {
+      cleanUp();
+    });
 
     // Returning interface
     return {
@@ -222,18 +294,77 @@ class RPCClient<M extends ClientManifest> {
   public async rawStreamCaller(
     method: string,
     headerParams: JSONValue,
+    ctx: Partial<ContextTimed> = {},
   ): Promise<ReadableWritablePair<Uint8Array, Uint8Array>> {
-    const streamPair = await this.streamFactory();
-    const tempWriter = streamPair.writable.getWriter();
-    const header: JSONRPCRequestMessage = {
-      jsonrpc: '2.0',
-      method,
-      params: headerParams,
-      id: null,
+    const abortController = new AbortController();
+    const signal = abortController.signal;
+    // A promise that will reject if there is an abort signal or timeout
+    const abortRaceProm = promise<never>();
+    abortRaceProm.p.catch(() => {});
+    let abortHandler: () => void;
+    if (ctx.signal != null) {
+      // Propagate signal events
+      abortHandler = () => {
+        abortController.abort(ctx.signal?.reason);
+        abortRaceProm.rejectP(ctx.signal?.reason);
+      };
+      if (ctx.signal.aborted) abortHandler();
+      ctx.signal.addEventListener('abort', abortHandler);
+    }
+    const timer =
+      ctx.timer ??
+      new Timer({
+        delay: this.defaultTimeout,
+      });
+    // Ignore unhandled rejections
+    const cleanUp = () => {
+      // Clean up the timer and signal
+      if (ctx.timer == null) timer.cancel(Error('TMP Clean up reason'));
+      signal.removeEventListener('abort', abortHandler);
     };
-    await tempWriter.write(Buffer.from(JSON.stringify(header)));
-    tempWriter.releaseLock();
-    return streamPair;
+    const timeoutError = new rpcErrors.ErrorRpcTimedOut();
+    void timer.then(
+      () => {
+        abortController.abort(timeoutError);
+        abortRaceProm.rejectP(timeoutError);
+      },
+      () => {},
+    );
+    let streamPair: ReadableWritablePair<Uint8Array, Uint8Array>;
+    const setupStream = async () => {
+      const streamPair = await this.streamFactory({ signal, timer });
+      const tempWriter = streamPair.writable.getWriter();
+      const header: JSONRPCRequestMessage = {
+        jsonrpc: '2.0',
+        method,
+        params: headerParams,
+        id: null,
+      };
+      await tempWriter.write(Buffer.from(JSON.stringify(header)));
+      tempWriter.releaseLock();
+      return streamPair;
+    };
+    try {
+      streamPair = await Promise.race([setupStream(), abortRaceProm.p]);
+    } catch (e) {
+      cleanUp();
+      throw e;
+    }
+    // Need to tell when a stream has ended to clean up the timer
+    const forwardStream = new TransformStream<Uint8Array, Uint8Array>();
+    const reverseStream = new TransformStream<Uint8Array, Uint8Array>();
+
+    void Promise.all([
+      streamPair.readable.pipeTo(reverseStream.writable),
+      forwardStream.readable.pipeTo(streamPair.writable),
+    ]).finally(() => {
+      cleanUp();
+    });
+
+    return {
+      writable: forwardStream.writable,
+      readable: reverseStream.readable,
+    };
   }
 }
 

--- a/src/rpc/RPCClient.ts
+++ b/src/rpc/RPCClient.ts
@@ -201,11 +201,12 @@ class RPCClient<M extends ClientManifest> {
     try {
       await writer.write(parameters);
       await writer.close();
-      return callerInterface.readable;
-    } finally {
+    } catch (e) {
       // Clean up if any problems, ignore errors if already closed
-      await writer.close().catch(() => {});
+      await callerInterface.readable.cancel(e);
+      throw e;
     }
+    return callerInterface.readable;
   }
 
   /**

--- a/src/rpc/RPCClient.ts
+++ b/src/rpc/RPCClient.ts
@@ -23,7 +23,7 @@ import { CreateDestroy, ready } from '@matrixai/async-init/dist/CreateDestroy';
 import Logger from '@matrixai/logger';
 import { IdInternal } from '@matrixai/id';
 import { Timer } from '@matrixai/timer';
-import * as middlewareUtils from './utils/middleware';
+import * as rpcUtilsMiddleware from './utils/middleware';
 import * as rpcErrors from './errors';
 import * as rpcUtils from './utils/utils';
 import { never, promise } from '../utils';
@@ -50,7 +50,7 @@ class RPCClient<M extends ClientManifest> {
   static async createRPCClient<M extends ClientManifest>({
     manifest,
     streamFactory,
-    middlewareFactory = middlewareUtils.defaultClientMiddlewareWrapper(),
+    middlewareFactory = rpcUtilsMiddleware.defaultClientMiddlewareWrapper(),
     streamKeepAliveTimeoutTime = 60_000, // 1 minute
     logger = new Logger(this.name),
   }: {

--- a/src/rpc/RPCClient.ts
+++ b/src/rpc/RPCClient.ts
@@ -206,6 +206,7 @@ class RPCClient<M extends ClientManifest> {
       // Clean up if any problems, ignore errors if already closed
       await callerInterface.readable.cancel(e);
       throw e;
+
     }
     return callerInterface.readable;
   }

--- a/src/rpc/RPCServer.ts
+++ b/src/rpc/RPCServer.ts
@@ -123,6 +123,7 @@ class RPCServer extends EventTarget {
     logger,
   }: {
     manifest: ServerManifest;
+
     middlewareFactory: MiddlewareFactory<
       JSONRPCRequest,
       Uint8Array,
@@ -157,7 +158,7 @@ class RPCServer extends EventTarget {
           key,
           manifestItem.handle.bind(manifestItem),
           manifestItem.timeout,
-        );
+       );
         continue;
       }
       if (manifestItem instanceof ClientHandler) {

--- a/src/rpc/RPCServer.ts
+++ b/src/rpc/RPCServer.ts
@@ -239,7 +239,7 @@ class RPCServer extends EventTarget {
       });
       const signal = abortController.signal;
       // Setting up middleware
-      const middleware = this.middlewareFactory();
+      const middleware = this.middlewareFactory(ctx);
       // Forward from the client to the server
       // Transparent TransformStream that re-inserts the header message into the
       // stream.

--- a/src/rpc/RPCServer.ts
+++ b/src/rpc/RPCServer.ts
@@ -415,7 +415,7 @@ class RPCServer extends EventTarget {
     const timer = new Timer({
       delay: this.streamKeepAliveTimeoutTime,
       handler: (signal) => {
-        abortController.abort(new rpcErrors.ErrorRpcTimedOut());
+        abortController.abort(new rpcErrors.ErrorRPCTimedOut());
         if (signal.aborted) return;
         // Grace timer for force ending stream
         const graceTimer = new Timer({
@@ -516,7 +516,7 @@ class RPCServer extends EventTarget {
       await Promise.allSettled([inputStreamEndProm, outputStreamEndProm]);
       // Cleaning up abort and timer
       timer.cancel(cleanupReason);
-      abortController.abort(new rpcErrors.ErrorRpcStreamEnded());
+      abortController.abort(new rpcErrors.ErrorRPCStreamEnded());
     })();
     const handlerProm = PromiseCancellable.from(prom, abortController).finally(
       () => this.activeStreams.delete(handlerProm),

--- a/src/rpc/RPCServer.ts
+++ b/src/rpc/RPCServer.ts
@@ -207,6 +207,12 @@ class RPCServer extends EventTarget {
     this.logger.info(`Destroyed ${this.constructor.name}`);
   }
 
+  /**
+   * Registers a raw stream handler. This is the basis for all handlers as
+   * handling the streams is done with raw streams only.
+   * The raw streams do not automatically refresh the timeout timer when
+   * messages are sent or received.
+   */
   protected registerRawStreamHandler(
     method: string,
     handler: RawHandlerImplementation,

--- a/src/rpc/RPCServer.ts
+++ b/src/rpc/RPCServer.ts
@@ -335,6 +335,7 @@ class RPCServer extends EventTarget {
           await outputGenerator.return(undefined);
         },
       });
+      // Ignore any errors here, it should propagate to the ends of the stream
       void reverseMiddlewareStream.pipeTo(reverseStream).catch(() => {});
       return middleware.reverse.readable;
     };
@@ -515,7 +516,7 @@ class RPCServer extends EventTarget {
       );
       const outputStreamEndProm = outputStream
         .pipeTo(rpcStream.writable)
-        .catch(() => {});
+        .catch(() => {}); // Ignore any errors, we only care that it finished
       await Promise.allSettled([inputStreamEndProm, outputStreamEndProm]);
       // Cleaning up abort and timer
       timer.cancel(cleanupReason);

--- a/src/rpc/RPCServer.ts
+++ b/src/rpc/RPCServer.ts
@@ -30,7 +30,7 @@ import {
 import * as rpcEvents from './events';
 import * as rpcUtils from './utils/utils';
 import * as rpcErrors from './errors';
-import * as middlewareUtils from './utils/middleware';
+import * as rpcUtilsMiddleware from './utils/middleware';
 import { never } from '../utils/utils';
 import { sysexits } from '../errors';
 
@@ -69,7 +69,7 @@ class RPCServer extends EventTarget {
    */
   public static async createRPCServer({
     manifest,
-    middlewareFactory = middlewareUtils.defaultServerMiddlewareWrapper(),
+    middlewareFactory = rpcUtilsMiddleware.defaultServerMiddlewareWrapper(),
     sensitive = false,
     streamKeepAliveTimeoutTime = 60_000, // 1 minute
     timeoutForceCloseTime = 2_000, // 2 seconds
@@ -435,7 +435,7 @@ class RPCServer extends EventTarget {
     });
 
     const prom = (async () => {
-      const headTransformStream = middlewareUtils.binaryToJsonMessageStream(
+      const headTransformStream = rpcUtilsMiddleware.binaryToJsonMessageStream(
         rpcUtils.parseJSONRPCRequest,
       );
       // Transparent transform used as a point to cancel the input stream from

--- a/src/rpc/errors.ts
+++ b/src/rpc/errors.ts
@@ -1,5 +1,6 @@
 import type { Class } from '@matrixai/errors';
 import type { ClientMetadata } from './types';
+import type { JSONValue } from '../types';
 import * as nodesUtils from '../nodes/utils';
 import { ErrorPolykey, sysexits } from '../errors';
 
@@ -46,9 +47,9 @@ class ErrorRPCOutputStreamError<T> extends ErrorRPC<T> {
 class ErrorPolykeyRemote<T> extends ErrorPolykey<T> {
   static description = 'Remote error from RPC call';
   exitCode: number = sysexits.UNAVAILABLE;
-  metadata: ClientMetadata;
+  metadata: JSONValue | undefined;
 
-  constructor(metadata: ClientMetadata, message?: string, options?) {
+  constructor(metadata?: JSONValue, message?: string, options?) {
     super(message, options);
     this.metadata = metadata;
   }
@@ -86,10 +87,7 @@ class ErrorPolykeyRemote<T> extends ErrorPolykey<T> {
 
   public toJSON(): any {
     const json = super.toJSON();
-    json.data.metadata = {
-      ...this.metadata,
-      nodeId: nodesUtils.encodeNodeId(this.metadata.nodeId),
-    };
+    json.data.metadata = this.metadata;
     return json;
   }
 }

--- a/src/rpc/errors.ts
+++ b/src/rpc/errors.ts
@@ -94,6 +94,16 @@ class ErrorPolykeyRemote<T> extends ErrorPolykey<T> {
   }
 }
 
+class ErrorRpcStreamEnded<T> extends ErrorRPC<T> {
+  static description = 'Handled stream has ended';
+  exitCode = sysexits.NOINPUT;
+}
+
+class ErrorRpcTimedOut<T> extends ErrorRPC<T> {
+  static description = 'RPC handler has timed out';
+  exitCode = sysexits.UNAVAILABLE;
+}
+
 export {
   ErrorRPC,
   ErrorRPCDestroyed,
@@ -104,4 +114,6 @@ export {
   ErrorRPCMissingResponse,
   ErrorRPCOutputStreamError,
   ErrorPolykeyRemote,
+  ErrorRpcStreamEnded,
+  ErrorRpcTimedOut,
 };

--- a/src/rpc/errors.ts
+++ b/src/rpc/errors.ts
@@ -94,12 +94,12 @@ class ErrorPolykeyRemote<T> extends ErrorPolykey<T> {
   }
 }
 
-class ErrorRpcStreamEnded<T> extends ErrorRPC<T> {
+class ErrorRPCStreamEnded<T> extends ErrorRPC<T> {
   static description = 'Handled stream has ended';
   exitCode = sysexits.NOINPUT;
 }
 
-class ErrorRpcTimedOut<T> extends ErrorRPC<T> {
+class ErrorRPCTimedOut<T> extends ErrorRPC<T> {
   static description = 'RPC handler has timed out';
   exitCode = sysexits.UNAVAILABLE;
 }
@@ -114,6 +114,6 @@ export {
   ErrorRPCMissingResponse,
   ErrorRPCOutputStreamError,
   ErrorPolykeyRemote,
-  ErrorRpcStreamEnded,
-  ErrorRpcTimedOut,
+  ErrorRPCStreamEnded,
+  ErrorRPCTimedOut,
 };

--- a/src/rpc/handlers.ts
+++ b/src/rpc/handlers.ts
@@ -9,8 +9,14 @@ abstract class Handler<
   Input extends JSONValue = JSONValue,
   Output extends JSONValue = JSONValue,
 > {
+  // These are used to distinguish the handlers in the type system.
+  // Without these the map types can't tell the types of handlers apart.
   protected _inputType: Input;
   protected _outputType: Output;
+  /**
+   * This is the timeout used for the handler.
+   * If it is not set then the default timeout time for the `RPCServer` is used.
+   */
   public timeout?: number;
 
   constructor(protected container: Container) {}

--- a/src/rpc/handlers.ts
+++ b/src/rpc/handlers.ts
@@ -3,7 +3,7 @@ import type { ContainerType } from 'rpc/types';
 import type { ReadableStream } from 'stream/web';
 import type { JSONRPCRequest } from 'rpc/types';
 import type { ConnectionInfo } from './types';
-import type { ContextCancellable } from '../contexts/types';
+import type { ContextTimed } from '../contexts/types';
 
 abstract class Handler<
   Container extends ContainerType = ContainerType,
@@ -12,6 +12,7 @@ abstract class Handler<
 > {
   protected _inputType: Input;
   protected _outputType: Output;
+  public timeout?: number;
 
   constructor(protected container: Container) {}
 }
@@ -22,7 +23,7 @@ abstract class RawHandler<
   abstract handle(
     input: [JSONRPCRequest, ReadableStream<Uint8Array>],
     connectionInfo: ConnectionInfo,
-    ctx: ContextCancellable,
+    ctx: ContextTimed,
   ): ReadableStream<Uint8Array>;
 }
 
@@ -39,7 +40,7 @@ abstract class DuplexHandler<
   abstract handle(
     input: AsyncIterable<Input>,
     connectionInfo: ConnectionInfo,
-    ctx: ContextCancellable,
+    ctx: ContextTimed,
   ): AsyncIterable<Output>;
 }
 
@@ -51,7 +52,7 @@ abstract class ServerHandler<
   abstract handle(
     input: Input,
     connectionInfo: ConnectionInfo,
-    ctx: ContextCancellable,
+    ctx: ContextTimed,
   ): AsyncIterable<Output>;
 }
 
@@ -63,7 +64,7 @@ abstract class ClientHandler<
   abstract handle(
     input: AsyncIterable<Input>,
     connectionInfo: ConnectionInfo,
-    ctx: ContextCancellable,
+    ctx: ContextTimed,
   ): Promise<Output>;
 }
 
@@ -75,7 +76,7 @@ abstract class UnaryHandler<
   abstract handle(
     input: Input,
     connectionInfo: ConnectionInfo,
-    ctx: ContextCancellable,
+    ctx: ContextTimed,
   ): Promise<Output>;
 }
 

--- a/src/rpc/handlers.ts
+++ b/src/rpc/handlers.ts
@@ -2,7 +2,6 @@ import type { JSONValue } from 'types';
 import type { ContainerType } from 'rpc/types';
 import type { ReadableStream } from 'stream/web';
 import type { JSONRPCRequest } from 'rpc/types';
-import type { ConnectionInfo } from './types';
 import type { ContextTimed } from '../contexts/types';
 
 abstract class Handler<
@@ -22,7 +21,8 @@ abstract class RawHandler<
 > extends Handler<Container> {
   abstract handle(
     input: [JSONRPCRequest, ReadableStream<Uint8Array>],
-    connectionInfo: ConnectionInfo,
+    cancel: (reason?: any) => void,
+    meta: Record<string, JSONValue> | undefined,
     ctx: ContextTimed,
   ): ReadableStream<Uint8Array>;
 }
@@ -39,7 +39,8 @@ abstract class DuplexHandler<
    */
   abstract handle(
     input: AsyncIterable<Input>,
-    connectionInfo: ConnectionInfo,
+    cancel: (reason?: any) => void,
+    meta: Record<string, JSONValue> | undefined,
     ctx: ContextTimed,
   ): AsyncIterable<Output>;
 }
@@ -51,7 +52,8 @@ abstract class ServerHandler<
 > extends Handler<Container, Input, Output> {
   abstract handle(
     input: Input,
-    connectionInfo: ConnectionInfo,
+    cancel: (reason?: any) => void,
+    meta: Record<string, JSONValue> | undefined,
     ctx: ContextTimed,
   ): AsyncIterable<Output>;
 }
@@ -63,7 +65,8 @@ abstract class ClientHandler<
 > extends Handler<Container, Input, Output> {
   abstract handle(
     input: AsyncIterable<Input>,
-    connectionInfo: ConnectionInfo,
+    cancel: (reason?: any) => void,
+    meta: Record<string, JSONValue> | undefined,
     ctx: ContextTimed,
   ): Promise<Output>;
 }
@@ -75,7 +78,8 @@ abstract class UnaryHandler<
 > extends Handler<Container, Input, Output> {
   abstract handle(
     input: Input,
-    connectionInfo: ConnectionInfo,
+    cancel: (reason?: any) => void,
+    meta: Record<string, JSONValue> | undefined,
     ctx: ContextTimed,
   ): Promise<Output>;
 }

--- a/src/rpc/types.ts
+++ b/src/rpc/types.ts
@@ -1,7 +1,7 @@
+import type { JSONValue } from '../types';
+import type { ContextTimed } from '../contexts/types';
 import type { ReadableStream, ReadableWritablePair } from 'stream/web';
 import type { Handler } from './handlers';
-import type { ContextCancellable } from '../contexts/types';
-import type { JSONValue } from '../types';
 import type {
   Caller,
   RawCaller,
@@ -178,7 +178,7 @@ type ConnectionInfo = Partial<{
 type HandlerImplementation<I, O> = (
   input: I,
   connectionInfo: ConnectionInfo,
-  ctx: ContextCancellable,
+  ctx: ContextTimed,
 ) => O;
 
 type RawHandlerImplementation = HandlerImplementation<

--- a/src/rpc/types.ts
+++ b/src/rpc/types.ts
@@ -208,9 +208,9 @@ type UnaryHandlerImplementation<
 
 type ContainerType = Record<string, any>;
 
-type StreamFactory = () => Promise<
-  ReadableWritablePair<Uint8Array, Uint8Array>
->;
+type StreamFactory = (
+  ctx: ContextTimed,
+) => Promise<ReadableWritablePair<Uint8Array, Uint8Array>>;
 
 /**
  * Middleware factory creates middlewares.
@@ -223,7 +223,7 @@ type StreamFactory = () => Promise<
  * FW -> FR is the direction of data flow from client to server.
  * RW -> RR is the direction of data flow from server to client.
  */
-type MiddlewareFactory<FR, FW, RR, RW> = () => {
+type MiddlewareFactory<FR, FW, RR, RW> = (ctx: ContextTimed) => {
   forward: ReadableWritablePair<FR, FW>;
   reverse: ReadableWritablePair<RR, RW>;
 };
@@ -233,25 +233,28 @@ type MiddlewareFactory<FR, FW, RR, RW> = () => {
 type UnaryCallerImplementation<
   I extends JSONValue = JSONValue,
   O extends JSONValue = JSONValue,
-> = (parameters: I) => Promise<O>;
+> = (parameters: I, ctx?: Partial<ContextTimed>) => Promise<O>;
 
 type ServerCallerImplementation<
   I extends JSONValue = JSONValue,
   O extends JSONValue = JSONValue,
-> = (parameters: I) => Promise<ReadableStream<O>>;
+> = (parameters: I, ctx?: Partial<ContextTimed>) => Promise<ReadableStream<O>>;
 
 type ClientCallerImplementation<
   I extends JSONValue = JSONValue,
   O extends JSONValue = JSONValue,
-> = () => Promise<{ output: Promise<O>; writable: WritableStream<I> }>;
+> = (
+  ctx?: Partial<ContextTimed>,
+) => Promise<{ output: Promise<O>; writable: WritableStream<I> }>;
 
 type DuplexCallerImplementation<
   I extends JSONValue = JSONValue,
   O extends JSONValue = JSONValue,
-> = () => Promise<ReadableWritablePair<O, I>>;
+> = (ctx?: Partial<ContextTimed>) => Promise<ReadableWritablePair<O, I>>;
 
 type RawCallerImplementation = (
   headerParams: JSONValue,
+  ctx?: Partial<ContextTimed>,
 ) => Promise<ReadableWritablePair<Uint8Array, Uint8Array>>;
 
 type ConvertDuplexCaller<T> = T extends DuplexCaller<infer I, infer O>

--- a/src/rpc/utils/middleware.ts
+++ b/src/rpc/utils/middleware.ts
@@ -95,7 +95,6 @@ function defaultMiddleware() {
  * The reverse path will pipe the output stream through the provided middleware
  * and then transform it back to a binary stream.
  * @param middlewareFactory - The provided middleware
- * @param ctx
  */
 function defaultServerMiddlewareWrapper(
   middlewareFactory: MiddlewareFactory<

--- a/src/rpc/utils/middleware.ts
+++ b/src/rpc/utils/middleware.ts
@@ -6,10 +6,10 @@ import type {
   MiddlewareFactory,
 } from '../types';
 import { TransformStream } from 'stream/web';
+import { JSONParser } from '@streamparser/json';
 import * as rpcUtils from './utils';
 import * as rpcErrors from '../errors';
 import { promise } from '../../utils/index';
-const jsonStreamParsers = require('@streamparser/json');
 
 /**
  * This function is a factory to create a TransformStream that will
@@ -25,7 +25,7 @@ function binaryToJsonMessageStream<T extends JSONRPCMessage>(
   messageParser: (message: unknown) => T,
   byteLimit: number = 1024 * 1024,
 ): TransformStream<Uint8Array, T> {
-  const parser = new jsonStreamParsers.JSONParser({
+  const parser = new JSONParser({
     separator: '',
     paths: ['$'],
   });

--- a/src/rpc/utils/middleware.ts
+++ b/src/rpc/utils/middleware.ts
@@ -105,7 +105,7 @@ function defaultServerMiddlewareWrapper(
     JSONRPCResponse
   > = defaultMiddleware,
 ): MiddlewareFactory<JSONRPCRequest, Uint8Array, Uint8Array, JSONRPCResponse> {
-  return (ctx) => {
+  return (ctx, cancel, meta) => {
     const inputTransformStream = binaryToJsonMessageStream(
       rpcUtils.parseJSONRPCRequest,
     );
@@ -114,7 +114,7 @@ function defaultServerMiddlewareWrapper(
       JSONRPCResponseResult
     >();
 
-    const middleMiddleware = middlewareFactory(ctx);
+    const middleMiddleware = middlewareFactory(ctx, cancel, meta);
 
     const forwardReadable = inputTransformStream.readable.pipeThrough(
       middleMiddleware.forward,
@@ -158,7 +158,7 @@ const defaultClientMiddlewareWrapper = (
   JSONRPCResponse,
   Uint8Array
 > => {
-  return (ctx) => {
+  return (ctx, cancel, meta) => {
     const outputTransformStream = binaryToJsonMessageStream(
       rpcUtils.parseJSONRPCResponse,
       // Undefined,
@@ -168,7 +168,7 @@ const defaultClientMiddlewareWrapper = (
       JSONRPCRequest
     >();
 
-    const middleMiddleware = middleware(ctx);
+    const middleMiddleware = middleware(ctx, cancel, meta);
     const forwardReadable = inputTransformStream.readable
       .pipeThrough(middleMiddleware.forward) // Usual middleware here
       .pipeThrough(jsonMessageToBinaryStream());

--- a/src/rpc/utils/utils.ts
+++ b/src/rpc/utils/utils.ts
@@ -1,6 +1,5 @@
 import type {
   ClientManifest,
-  ClientMetadata,
   HandlerType,
   JSONRPCError,
   JSONRPCMessage,
@@ -351,7 +350,7 @@ function reviver(key: string, value: any): any {
 
 function toError(
   errorData,
-  metadata: ClientMetadata,
+  metadata?: JSONValue,
 ): rpcErrors.ErrorPolykeyRemote<unknown> {
   if (errorData == null) {
     return new rpcErrors.ErrorPolykeyRemote(metadata);
@@ -405,7 +404,7 @@ function clientInputTransformStream<I extends JSONValue>(
  * @param timer - Timer that gets refreshed each time a message is provided.
  */
 function clientOutputTransformStream<O extends JSONValue>(
-  clientMetadata: ClientMetadata,
+  clientMetadata?: JSONValue,
   timer?: Timer,
 ): TransformStream<JSONRPCResponse<O>, O> {
   return new TransformStream<JSONRPCResponse<O>, O>({

--- a/src/websockets/WebSocketClient.ts
+++ b/src/websockets/WebSocketClient.ts
@@ -467,7 +467,7 @@ class WebSocketStreamClientInternal extends WebSocketStream {
     }
     // Then close the websocket
     if (!this._webSocketEnded) {
-      this.ws.close(4001, 'Ending connection');
+      this.ws.close(4000, 'Ending connection');
       this.signalWebSocketEnd(err);
     }
   }

--- a/src/websockets/WebSocketServer.ts
+++ b/src/websockets/WebSocketServer.ts
@@ -416,7 +416,7 @@ class WebSocketStreamServerInternal extends WebSocketStream {
         if (this._readableEnded && !this._webSocketEnded) {
           writableLogger.debug('Ending socket');
           this.signalWebSocketEnd(reason);
-          ws.end(4001, 'ABORTED');
+          ws.end(4000, 'Aborting connection');
         }
       },
     });
@@ -448,7 +448,7 @@ class WebSocketStreamServerInternal extends WebSocketStream {
               const err = new webSocketErrors.ErrorServerReadableBufferLimit();
               if (!this._webSocketEnded) {
                 this.signalWebSocketEnd(err);
-                ws.end(4001, 'Read stream buffer full');
+                ws.end(4000, 'Read stream buffer full');
               }
               controller.error(err);
             }
@@ -527,7 +527,7 @@ class WebSocketStreamServerInternal extends WebSocketStream {
     }
     // Then close the websocket
     if (!this._webSocketEnded) {
-      this.ws.end(4001, 'Ending connection');
+      this.ws.end(4000, 'Ending connection');
       this.signalWebSocketEnd(err);
     }
   }

--- a/src/websockets/WebSocketServer.ts
+++ b/src/websockets/WebSocketServer.ts
@@ -394,9 +394,9 @@ class WebSocketStreamServerInternal extends WebSocketStream {
       },
       close: () => {
         writableLogger.info('Closed, sending null message');
-        if (!this.webSocketEnded_) ws.send(Buffer.from([]), true);
+        if (!this._webSocketEnded) ws.send(Buffer.from([]), true);
         this.signalWritableEnd();
-        if (this.readableEnded_ && !this.webSocketEnded_) {
+        if (this._readableEnded && !this._webSocketEnded) {
           writableLogger.debug('Ending socket');
           this.signalWebSocketEnd();
           ws.end();
@@ -404,7 +404,7 @@ class WebSocketStreamServerInternal extends WebSocketStream {
       },
       abort: (reason) => {
         writableLogger.info('Aborted');
-        if (this.readableEnded_ && !this.webSocketEnded_) {
+        if (this._readableEnded && !this._webSocketEnded) {
           writableLogger.debug('Ending socket');
           this.signalWebSocketEnd(reason);
           ws.end(4001, 'ABORTED');
@@ -421,11 +421,11 @@ class WebSocketStreamServerInternal extends WebSocketStream {
             readableLogger.debug(`Received ${messageBuffer.toString()}`);
             if (message.byteLength === 0) {
               readableLogger.debug('Null message received');
-              if (!this.readableEnded_) {
+              if (!this._readableEnded) {
                 readableLogger.debug('Closing');
                 this.signalReadableEnd();
                 controller.close();
-                if (this.writableEnded_ && !this.webSocketEnded_) {
+                if (this._writableEnded && !this._webSocketEnded) {
                   readableLogger.debug('Ending socket');
                   this.signalWebSocketEnd();
                   ws.end();
@@ -437,7 +437,7 @@ class WebSocketStreamServerInternal extends WebSocketStream {
             if (controller.desiredSize != null && controller.desiredSize < 0) {
               readableLogger.error('Read stream buffer full');
               const err = new webSocketErrors.ErrorServerReadableBufferLimit();
-              if (!this.webSocketEnded_) {
+              if (!this._webSocketEnded) {
                 this.signalWebSocketEnd(err);
                 ws.end(4001, 'Read stream buffer full');
               }
@@ -447,7 +447,7 @@ class WebSocketStreamServerInternal extends WebSocketStream {
         },
         cancel: (reason) => {
           this.signalReadableEnd(reason);
-          if (this.writableEnded_ && !this.webSocketEnded_) {
+          if (this._writableEnded && !this._webSocketEnded) {
             readableLogger.debug('Ending socket');
             this.signalWebSocketEnd();
             ws.end();
@@ -481,12 +481,12 @@ class WebSocketStreamServerInternal extends WebSocketStream {
       // Closing streams
       logger.debug('Cleaning streams');
       const err = new webSocketErrors.ErrorServerConnectionEndedEarly();
-      if (!this.readableEnded_) {
+      if (!this._readableEnded) {
         readableLogger.debug('Closing');
         this.signalReadableEnd(err);
         readableController?.error(err);
       }
-      if (!this.writableEnded_) {
+      if (!this._writableEnded) {
         writableLogger.debug('Closing');
         this.signalWritableEnd(err);
         writableController?.error(err);

--- a/src/websockets/WebSocketServer.ts
+++ b/src/websockets/WebSocketServer.ts
@@ -222,7 +222,8 @@ class WebSocketServer extends EventTarget {
     }
     // Wait for all active websockets to close
     for (const webSocketStream of this.activeSockets) {
-      webSocketStream.endedProm.catch(() => {}); // Ignore errors
+      // Ignore errors, we only care that it finished
+      webSocketStream.endedProm.catch(() => {});
     }
     if (this.connectionEventHandler != null) {
       this.removeEventListener('connection', this.connectionEventHandler);
@@ -303,7 +304,8 @@ class WebSocketServer extends EventTarget {
     // Adding socket to the active sockets map
     this.activeSockets.add(webSocketStream);
     webSocketStream.endedProm
-      .catch(() => {}) // Ignore errors here
+      // Ignore errors, we only care that it finished
+      .catch(() => {})
       .finally(() => {
         this.activeSockets.delete(webSocketStream);
       });

--- a/src/websockets/WebSocketStream.ts
+++ b/src/websockets/WebSocketStream.ts
@@ -91,39 +91,39 @@ abstract class WebSocketStream
   /**
    * Forces the active stream to end early
    */
-  abstract end(e?: Error): void;
+  abstract cancel(reason?: any): void;
 
   /**
    * Signals the end of the ReadableStream. to be used with the extended class
    * to track the streams state.
    */
-  protected signalReadableEnd(e?: Error) {
+  protected signalReadableEnd(reason?: any) {
     if (this._readableEnded) return;
     this._readableEnded = true;
-    if (e == null) this._readableEndedProm.resolveP();
-    else this._readableEndedProm.rejectP(e);
+    if (reason == null) this._readableEndedProm.resolveP();
+    else this._readableEndedProm.rejectP(reason);
   }
 
   /**
    * Signals the end of the WritableStream. to be used with the extended class
    * to track the streams state.
    */
-  protected signalWritableEnd(e?: Error) {
+  protected signalWritableEnd(reason?: any) {
     if (this._writableEnded) return;
     this._writableEnded = true;
-    if (e == null) this._writableEndedProm.resolveP();
-    else this._writableEndedProm.rejectP(e);
+    if (reason == null) this._writableEndedProm.resolveP();
+    else this._writableEndedProm.rejectP(reason);
   }
 
   /**
    * Signals the end of the WebSocket. to be used with the extended class
    * to track the streams state.
    */
-  protected signalWebSocketEnd(e?: Error) {
+  protected signalWebSocketEnd(reason?: any) {
     if (this._webSocketEnded) return;
     this._webSocketEnded = true;
-    if (e == null) this._webSocketEndedProm.resolveP();
-    else this._webSocketEndedProm.rejectP(e);
+    if (reason == null) this._webSocketEndedProm.resolveP();
+    else this._webSocketEndedProm.rejectP(reason);
   }
 }
 

--- a/src/websockets/WebSocketStream.ts
+++ b/src/websockets/WebSocketStream.ts
@@ -11,24 +11,24 @@ abstract class WebSocketStream
   public readable: ReadableStream;
   public writable: WritableStream;
 
-  protected readableEnded_ = false;
-  protected readableEndedProm_ = promise();
-  protected writableEnded_ = false;
-  protected writableEndedProm_ = promise();
-  protected webSocketEnded_ = false;
-  protected webSocketEndedProm_ = promise();
-  protected endedProm_: Promise<void>;
+  protected _readableEnded = false;
+  protected _readableEndedProm = promise();
+  protected _writableEnded = false;
+  protected _writableEndedProm = promise();
+  protected _webSocketEnded = false;
+  protected _webSocketEndedProm = promise();
+  protected _endedProm: Promise<void>;
 
   protected constructor() {
     // Sanitise promises so they don't result in unhandled rejections
-    this.readableEndedProm_.p.catch(() => {});
-    this.writableEndedProm_.p.catch(() => {});
-    this.webSocketEndedProm_.p.catch(() => {});
+    this._readableEndedProm.p.catch(() => {});
+    this._writableEndedProm.p.catch(() => {});
+    this._webSocketEndedProm.p.catch(() => {});
     // Creating the endedPromise
-    this.endedProm_ = Promise.allSettled([
-      this.readableEndedProm_.p,
-      this.writableEndedProm_.p,
-      this.webSocketEndedProm_.p,
+    this._endedProm = Promise.allSettled([
+      this._readableEndedProm.p,
+      this._writableEndedProm.p,
+      this._webSocketEndedProm.p,
     ]).then((result) => {
       if (
         result[0].status === 'rejected' ||
@@ -41,51 +41,51 @@ abstract class WebSocketStream
       // Otherwise return nothing
     });
     // Ignore errors if it's never used
-    this.endedProm_.catch(() => {});
+    this._endedProm.catch(() => {});
   }
 
   get readableEnded() {
-    return this.readableEnded_;
+    return this._readableEnded;
   }
 
   /**
    * Resolves when the readable has ended and rejects with any errors.
    */
   get readableEndedProm() {
-    return this.readableEndedProm_.p;
+    return this._readableEndedProm.p;
   }
 
   get writableEnded() {
-    return this.writableEnded_;
+    return this._writableEnded;
   }
 
   /**
    * Resolves when the writable has ended and rejects with any errors.
    */
   get writableEndedProm() {
-    return this.writableEndedProm_.p;
+    return this._writableEndedProm.p;
   }
 
   get webSocketEnded() {
-    return this.webSocketEnded_;
+    return this._webSocketEnded;
   }
 
   /**
    * Resolves when the webSocket has ended and rejects with any errors.
    */
   get webSocketEndedProm() {
-    return this.webSocketEndedProm_.p;
+    return this._webSocketEndedProm.p;
   }
 
   get ended() {
-    return this.readableEnded_ && this.writableEnded_;
+    return this._readableEnded && this._writableEnded;
   }
 
   /**
    * Resolves when the stream has fully closed
    */
   get endedProm(): Promise<void> {
-    return this.endedProm_;
+    return this._endedProm;
   }
 
   /**
@@ -98,10 +98,10 @@ abstract class WebSocketStream
    * to track the streams state.
    */
   protected signalReadableEnd(e?: Error) {
-    if (this.readableEnded_) return;
-    this.readableEnded_ = true;
-    if (e == null) this.readableEndedProm_.resolveP();
-    else this.readableEndedProm_.rejectP(e);
+    if (this._readableEnded) return;
+    this._readableEnded = true;
+    if (e == null) this._readableEndedProm.resolveP();
+    else this._readableEndedProm.rejectP(e);
   }
 
   /**
@@ -109,10 +109,10 @@ abstract class WebSocketStream
    * to track the streams state.
    */
   protected signalWritableEnd(e?: Error) {
-    if (this.writableEnded_) return;
-    this.writableEnded_ = true;
-    if (e == null) this.writableEndedProm_.resolveP();
-    else this.writableEndedProm_.rejectP(e);
+    if (this._writableEnded) return;
+    this._writableEnded = true;
+    if (e == null) this._writableEndedProm.resolveP();
+    else this._writableEndedProm.rejectP(e);
   }
 
   /**
@@ -120,10 +120,10 @@ abstract class WebSocketStream
    * to track the streams state.
    */
   protected signalWebSocketEnd(e?: Error) {
-    if (this.webSocketEnded_) return;
-    this.webSocketEnded_ = true;
-    if (e == null) this.webSocketEndedProm_.resolveP();
-    else this.webSocketEndedProm_.rejectP(e);
+    if (this._webSocketEnded) return;
+    this._webSocketEnded = true;
+    if (e == null) this._webSocketEndedProm.resolveP();
+    else this._webSocketEndedProm.rejectP(e);
   }
 }
 

--- a/src/websockets/WebSocketStream.ts
+++ b/src/websockets/WebSocketStream.ts
@@ -91,7 +91,7 @@ abstract class WebSocketStream
   /**
    * Forces the active stream to end early
    */
-  abstract end(): void;
+  abstract end(e?: Error): void;
 
   /**
    * Signals the end of the ReadableStream. to be used with the extended class

--- a/src/websockets/errors.ts
+++ b/src/websockets/errors.ts
@@ -29,6 +29,16 @@ class ErrorClientConnectionEndedEarly<T> extends ErrorWebSocketClient<T> {
   exitCode = sysexits.UNAVAILABLE;
 }
 
+class ErrorClientStreamAborted<T> extends ErrorWebSocketClient<T> {
+  static description = 'Stream was ended early with an abort signal';
+  exitCode = sysexits.USAGE;
+}
+
+class ErrorClientEndingConnections<T> extends ErrorWebSocketClient<T> {
+  static description = 'WebSocketClient is ending active connections';
+  exitCode = sysexits.USAGE;
+}
+
 class ErrorWebSocketServer<T> extends ErrorWebSocket<T> {}
 
 class ErrorWebSocketServerNotRunning<T> extends ErrorWebSocketServer<T> {
@@ -108,6 +118,8 @@ export {
   ErrorClientConnectionFailed,
   ErrorClientConnectionTimedOut,
   ErrorClientConnectionEndedEarly,
+  ErrorClientStreamAborted,
+  ErrorClientEndingConnections,
   ErrorWebSocketServer,
   ErrorWebSocketServerNotRunning,
   ErrorServerPortUnavailable,

--- a/src/websockets/events.ts
+++ b/src/websockets/events.ts
@@ -1,5 +1,4 @@
 import type WebSocketStream from 'websockets/WebSocketStream';
-import type { ConnectionInfo } from 'rpc/types';
 
 class StartEvent extends Event {
   public detail: {
@@ -28,13 +27,11 @@ class StopEvent extends Event {
 class ConnectionEvent extends Event {
   public detail: {
     webSocketStream: WebSocketStream;
-    connectionInfo: ConnectionInfo;
   };
   constructor(
     options: EventInit & {
       detail: {
         webSocketStream: WebSocketStream;
-        connectionInfo: ConnectionInfo;
       };
     },
   ) {

--- a/tests/PolykeyClient.test.ts
+++ b/tests/PolykeyClient.test.ts
@@ -55,7 +55,7 @@ describe('PolykeyClient', () => {
       logger,
     });
     const pkClient = await PolykeyClient.createPolykeyClient({
-      streamFactory: () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       nodePath,
       fs,
       logger,

--- a/tests/client/authenticationMiddleware.test.ts
+++ b/tests/client/authenticationMiddleware.test.ts
@@ -19,7 +19,7 @@ import * as clientRPCUtils from '@/client/utils';
 import * as authMiddleware from '@/client/utils/authenticationMiddleware';
 import { UnaryCaller } from '@/rpc/callers';
 import { UnaryHandler } from '@/rpc/handlers';
-import * as middlewareUtils from '@/rpc/utils/middleware';
+import * as rpcUtilsMiddleware from '@/rpc/utils/middleware';
 import WebSocketServer from '@/websockets/WebSocketServer';
 import WebSocketClient from '@/websockets/WebSocketClient';
 import * as testsUtils from '../utils';
@@ -107,7 +107,7 @@ describe('authenticationMiddleware', () => {
       manifest: {
         testHandler: new EchoHandler({ logger }),
       },
-      middlewareFactory: middlewareUtils.defaultServerMiddlewareWrapper(
+      middlewareFactory: rpcUtilsMiddleware.defaultServerMiddlewareWrapper(
         authMiddleware.authenticationMiddlewareServer(sessionManager, keyRing),
       ),
       logger,
@@ -134,7 +134,7 @@ describe('authenticationMiddleware', () => {
         >(),
       },
       streamFactory: async () => clientClient.startConnection(),
-      middlewareFactory: middlewareUtils.defaultClientMiddlewareWrapper(
+      middlewareFactory: rpcUtilsMiddleware.defaultClientMiddlewareWrapper(
         authMiddleware.authenticationMiddlewareClient(session),
       ),
       logger,

--- a/tests/client/authenticationMiddleware.test.ts
+++ b/tests/client/authenticationMiddleware.test.ts
@@ -113,8 +113,8 @@ describe('authenticationMiddleware', () => {
       logger,
     });
     clientServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) => {
-        rpcServer.handleStream(streamPair, connectionInfo);
+      connectionCallback: (streamPair) => {
+        rpcServer.handleStream(streamPair);
       },
       host,
       tlsConfig,

--- a/tests/client/handlers/agentLockAll.test.ts
+++ b/tests/client/handlers/agentLockAll.test.ts
@@ -70,7 +70,7 @@ describe('agentLockAll', () => {
       recursive: true,
     });
   });
-  test('Locks all current sessions', async () => {
+  test('locks all current sessions', async () => {
     // Setup
     const rpcServer = await RPCServer.createRPCServer({
       manifest: {

--- a/tests/client/handlers/agentLockAll.test.ts
+++ b/tests/client/handlers/agentLockAll.test.ts
@@ -98,7 +98,7 @@ describe('agentLockAll', () => {
       manifest: {
         agentLockAll,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/agentLockAll.test.ts
+++ b/tests/client/handlers/agentLockAll.test.ts
@@ -82,8 +82,7 @@ describe('agentLockAll', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/agentStatus.test.ts
+++ b/tests/client/handlers/agentStatus.test.ts
@@ -58,8 +58,8 @@ describe('agentStatus', () => {
       logger: logger.getChild('RPCServer'),
     });
     clientServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) => {
-        rpcServer.handleStream(streamPair, connectionInfo);
+      connectionCallback: (streamPair) => {
+        rpcServer.handleStream(streamPair);
       },
       host,
       tlsConfig,

--- a/tests/client/handlers/agentStop.test.ts
+++ b/tests/client/handlers/agentStop.test.ts
@@ -80,7 +80,7 @@ describe('agentStop', () => {
       recursive: true,
     });
   });
-  test('Stops the agent', async () => {
+  test('stops the agent', async () => {
     // Setup
     const rpcServer = await RPCServer.createRPCServer({
       manifest: {

--- a/tests/client/handlers/agentStop.test.ts
+++ b/tests/client/handlers/agentStop.test.ts
@@ -91,8 +91,7 @@ describe('agentStop', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/agentStop.test.ts
+++ b/tests/client/handlers/agentStop.test.ts
@@ -107,7 +107,7 @@ describe('agentStop', () => {
       manifest: {
         agentStop,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/agentUnlock.test.ts
+++ b/tests/client/handlers/agentUnlock.test.ts
@@ -13,8 +13,8 @@ import { AgentUnlockHandler } from '@/client/handlers/agentUnlock';
 import RPCClient from '@/rpc/RPCClient';
 import { Session, SessionManager } from '@/sessions';
 import * as clientUtils from '@/client/utils';
-import * as authMiddleware from '@/client/utils/authenticationMiddleware';
-import * as middlewareUtils from '@/rpc/utils/middleware';
+import * as clientUtilsAuthMiddleware from '@/client/utils/authenticationMiddleware';
+import * as rpcUtilsMiddleware from '@/rpc/utils/middleware';
 import WebSocketServer from '@/websockets/WebSocketServer';
 import WebSocketClient from '@/websockets/WebSocketClient';
 import { agentUnlock } from '@/client';
@@ -92,8 +92,11 @@ describe('agentUnlock', () => {
       manifest: {
         agentUnlock: new AgentUnlockHandler({}),
       },
-      middlewareFactory: middlewareUtils.defaultServerMiddlewareWrapper(
-        authMiddleware.authenticationMiddlewareServer(sessionManager, keyRing),
+      middlewareFactory: rpcUtilsMiddleware.defaultServerMiddlewareWrapper(
+        clientUtilsAuthMiddleware.authenticationMiddlewareServer(
+          sessionManager,
+          keyRing,
+        ),
       ),
       logger,
     });
@@ -115,8 +118,8 @@ describe('agentUnlock', () => {
         agentUnlock,
       },
       streamFactory: async () => clientClient.startConnection(),
-      middlewareFactory: middlewareUtils.defaultClientMiddlewareWrapper(
-        authMiddleware.authenticationMiddlewareClient(session),
+      middlewareFactory: rpcUtilsMiddleware.defaultClientMiddlewareWrapper(
+        clientUtilsAuthMiddleware.authenticationMiddlewareClient(session),
       ),
       logger,
     });

--- a/tests/client/handlers/agentUnlock.test.ts
+++ b/tests/client/handlers/agentUnlock.test.ts
@@ -101,8 +101,7 @@ describe('agentUnlock', () => {
       logger,
     });
     clientServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger,

--- a/tests/client/handlers/gestaltsActionsSetUnsetGetByIdentity.test.ts
+++ b/tests/client/handlers/gestaltsActionsSetUnsetGetByIdentity.test.ts
@@ -134,7 +134,7 @@ describe('gestaltsActionsByIdentity', () => {
         gestaltsActionsSetByIdentity,
         gestaltsActionsUnsetByIdentity,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/gestaltsActionsSetUnsetGetByIdentity.test.ts
+++ b/tests/client/handlers/gestaltsActionsSetUnsetGetByIdentity.test.ts
@@ -116,8 +116,7 @@ describe('gestaltsActionsByIdentity', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/gestaltsActionsSetUnsetGetByNode.test.ts
+++ b/tests/client/handlers/gestaltsActionsSetUnsetGetByNode.test.ts
@@ -124,7 +124,7 @@ describe('gestaltsActionsByNode', () => {
         gestaltsActionsSetByNode,
         gestaltsActionsUnsetByNode,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/gestaltsActionsSetUnsetGetByNode.test.ts
+++ b/tests/client/handlers/gestaltsActionsSetUnsetGetByNode.test.ts
@@ -106,8 +106,7 @@ describe('gestaltsActionsByNode', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/gestaltsDiscoveryByIdentity.test.ts
+++ b/tests/client/handlers/gestaltsDiscoveryByIdentity.test.ts
@@ -177,8 +177,7 @@ describe('gestaltsDiscoverByIdentity', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/gestaltsDiscoveryByIdentity.test.ts
+++ b/tests/client/handlers/gestaltsDiscoveryByIdentity.test.ts
@@ -193,7 +193,7 @@ describe('gestaltsDiscoverByIdentity', () => {
       manifest: {
         gestaltsDiscoveryByIdentity,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/gestaltsDiscoveryByNode.test.ts
+++ b/tests/client/handlers/gestaltsDiscoveryByNode.test.ts
@@ -193,7 +193,7 @@ describe('gestaltsDiscoverByNode', () => {
       manifest: {
         gestaltsDiscoveryByNode,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/gestaltsDiscoveryByNode.test.ts
+++ b/tests/client/handlers/gestaltsDiscoveryByNode.test.ts
@@ -177,8 +177,7 @@ describe('gestaltsDiscoverByNode', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/gestaltsGestaltGetByIdentity.test.ts
+++ b/tests/client/handlers/gestaltsGestaltGetByIdentity.test.ts
@@ -90,7 +90,7 @@ describe('gestaltsGestaltGetByIdentity', () => {
       recursive: true,
     });
   });
-  test('getys gestalt by identity', async () => {
+  test('gets gestalt by identity', async () => {
     // Setup
     const rpcServer = await RPCServer.createRPCServer({
       manifest: {

--- a/tests/client/handlers/gestaltsGestaltGetByIdentity.test.ts
+++ b/tests/client/handlers/gestaltsGestaltGetByIdentity.test.ts
@@ -102,8 +102,7 @@ describe('gestaltsGestaltGetByIdentity', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/gestaltsGestaltGetByIdentity.test.ts
+++ b/tests/client/handlers/gestaltsGestaltGetByIdentity.test.ts
@@ -118,7 +118,7 @@ describe('gestaltsGestaltGetByIdentity', () => {
       manifest: {
         gestaltsGestaltGetByIdentity,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/gestaltsGestaltGetByNode.test.ts
+++ b/tests/client/handlers/gestaltsGestaltGetByNode.test.ts
@@ -102,8 +102,7 @@ describe('gestaltsGestaltGetByNode', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/gestaltsGestaltGetByNode.test.ts
+++ b/tests/client/handlers/gestaltsGestaltGetByNode.test.ts
@@ -118,7 +118,7 @@ describe('gestaltsGestaltGetByNode', () => {
       manifest: {
         gestaltsGestaltGetByNode,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/gestaltsGestaltList.test.ts
+++ b/tests/client/handlers/gestaltsGestaltList.test.ts
@@ -110,7 +110,7 @@ describe('gestaltsGestaltList', () => {
       manifest: {
         gestaltsGestaltList,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/gestaltsGestaltList.test.ts
+++ b/tests/client/handlers/gestaltsGestaltList.test.ts
@@ -94,8 +94,7 @@ describe('gestaltsGestaltList', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/gestaltsGestaltTrustByIdentity.test.ts
+++ b/tests/client/handlers/gestaltsGestaltTrustByIdentity.test.ts
@@ -210,8 +210,7 @@ describe('gestaltsGestaltTrustByIdentity', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -273,8 +272,7 @@ describe('gestaltsGestaltTrustByIdentity', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -333,8 +331,7 @@ describe('gestaltsGestaltTrustByIdentity', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -385,8 +382,7 @@ describe('gestaltsGestaltTrustByIdentity', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -452,8 +448,7 @@ describe('gestaltsGestaltTrustByIdentity', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/gestaltsGestaltTrustByIdentity.test.ts
+++ b/tests/client/handlers/gestaltsGestaltTrustByIdentity.test.ts
@@ -226,7 +226,7 @@ describe('gestaltsGestaltTrustByIdentity', () => {
       manifest: {
         gestaltsGestaltTrustByIdentity,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -289,7 +289,7 @@ describe('gestaltsGestaltTrustByIdentity', () => {
       manifest: {
         gestaltsGestaltTrustByIdentity,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -349,7 +349,7 @@ describe('gestaltsGestaltTrustByIdentity', () => {
       manifest: {
         gestaltsGestaltTrustByIdentity,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -401,7 +401,7 @@ describe('gestaltsGestaltTrustByIdentity', () => {
       manifest: {
         gestaltsGestaltTrustByIdentity,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -468,7 +468,7 @@ describe('gestaltsGestaltTrustByIdentity', () => {
       manifest: {
         gestaltsGestaltTrustByIdentity,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/gestaltsGestaltTrustByNode.test.ts
+++ b/tests/client/handlers/gestaltsGestaltTrustByNode.test.ts
@@ -249,8 +249,7 @@ describe('gestaltsGestaltTrustByNode', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -294,8 +293,7 @@ describe('gestaltsGestaltTrustByNode', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -338,8 +336,7 @@ describe('gestaltsGestaltTrustByNode', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/gestaltsGestaltTrustByNode.test.ts
+++ b/tests/client/handlers/gestaltsGestaltTrustByNode.test.ts
@@ -265,7 +265,7 @@ describe('gestaltsGestaltTrustByNode', () => {
       manifest: {
         gestaltsGestaltTrustByNode,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -310,7 +310,7 @@ describe('gestaltsGestaltTrustByNode', () => {
       manifest: {
         gestaltsGestaltTrustByNode,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -354,7 +354,7 @@ describe('gestaltsGestaltTrustByNode', () => {
       manifest: {
         gestaltsGestaltTrustByNode,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/identitiesAuthenticate.test.ts
+++ b/tests/client/handlers/identitiesAuthenticate.test.ts
@@ -112,7 +112,7 @@ describe('identitiesAuthenticate', () => {
       manifest: {
         identitiesAuthenticate,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -177,7 +177,7 @@ describe('identitiesAuthenticate', () => {
       manifest: {
         identitiesAuthenticate,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/identitiesAuthenticate.test.ts
+++ b/tests/client/handlers/identitiesAuthenticate.test.ts
@@ -96,8 +96,7 @@ describe('identitiesAuthenticate', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -161,8 +160,7 @@ describe('identitiesAuthenticate', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/identitiesAuthenticatedGet.test.ts
+++ b/tests/client/handlers/identitiesAuthenticatedGet.test.ts
@@ -88,8 +88,7 @@ describe('identitiesClaim', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -141,8 +140,7 @@ describe('identitiesClaim', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -194,8 +192,7 @@ describe('identitiesClaim', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -271,8 +268,7 @@ describe('identitiesClaim', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/identitiesAuthenticatedGet.test.ts
+++ b/tests/client/handlers/identitiesAuthenticatedGet.test.ts
@@ -104,7 +104,7 @@ describe('identitiesClaim', () => {
       manifest: {
         identitiesAuthenticatedGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -157,7 +157,7 @@ describe('identitiesClaim', () => {
       manifest: {
         identitiesAuthenticatedGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -210,7 +210,7 @@ describe('identitiesClaim', () => {
       manifest: {
         identitiesAuthenticatedGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -287,7 +287,7 @@ describe('identitiesClaim', () => {
       manifest: {
         identitiesAuthenticatedGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/identitiesClaim.test.ts
+++ b/tests/client/handlers/identitiesClaim.test.ts
@@ -141,8 +141,7 @@ describe('identitiesClaim', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -188,8 +187,7 @@ describe('identitiesClaim', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/identitiesClaim.test.ts
+++ b/tests/client/handlers/identitiesClaim.test.ts
@@ -157,7 +157,7 @@ describe('identitiesClaim', () => {
       manifest: {
         identitiesClaim,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -204,7 +204,7 @@ describe('identitiesClaim', () => {
       manifest: {
         identitiesClaim,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/identitiesInfoConnectedGet.test.ts
+++ b/tests/client/handlers/identitiesInfoConnectedGet.test.ts
@@ -95,8 +95,7 @@ describe('identitiesInfoConnectedGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -181,8 +180,7 @@ describe('identitiesInfoConnectedGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -264,8 +262,7 @@ describe('identitiesInfoConnectedGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -355,8 +352,7 @@ describe('identitiesInfoConnectedGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -447,8 +443,7 @@ describe('identitiesInfoConnectedGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -527,8 +522,7 @@ describe('identitiesInfoConnectedGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -614,8 +608,7 @@ describe('identitiesInfoConnectedGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -705,8 +698,7 @@ describe('identitiesInfoConnectedGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -778,8 +770,7 @@ describe('identitiesInfoConnectedGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -863,8 +854,7 @@ describe('identitiesInfoConnectedGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -955,8 +945,7 @@ describe('identitiesInfoConnectedGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -1034,8 +1023,7 @@ describe('identitiesInfoConnectedGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/identitiesInfoConnectedGet.test.ts
+++ b/tests/client/handlers/identitiesInfoConnectedGet.test.ts
@@ -111,7 +111,7 @@ describe('identitiesInfoConnectedGet', () => {
       manifest: {
         identitiesInfoConnectedGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -197,7 +197,7 @@ describe('identitiesInfoConnectedGet', () => {
       manifest: {
         identitiesInfoConnectedGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -280,7 +280,7 @@ describe('identitiesInfoConnectedGet', () => {
       manifest: {
         identitiesInfoConnectedGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -371,7 +371,7 @@ describe('identitiesInfoConnectedGet', () => {
       manifest: {
         identitiesInfoConnectedGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -463,7 +463,7 @@ describe('identitiesInfoConnectedGet', () => {
       manifest: {
         identitiesInfoConnectedGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -543,7 +543,7 @@ describe('identitiesInfoConnectedGet', () => {
       manifest: {
         identitiesInfoConnectedGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -630,7 +630,7 @@ describe('identitiesInfoConnectedGet', () => {
       manifest: {
         identitiesInfoConnectedGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -721,7 +721,7 @@ describe('identitiesInfoConnectedGet', () => {
       manifest: {
         identitiesInfoConnectedGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -794,7 +794,7 @@ describe('identitiesInfoConnectedGet', () => {
       manifest: {
         identitiesInfoConnectedGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -879,7 +879,7 @@ describe('identitiesInfoConnectedGet', () => {
       manifest: {
         identitiesInfoConnectedGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -971,7 +971,7 @@ describe('identitiesInfoConnectedGet', () => {
       manifest: {
         identitiesInfoConnectedGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -1050,7 +1050,7 @@ describe('identitiesInfoConnectedGet', () => {
       manifest: {
         identitiesInfoConnectedGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/identitiesInfoGet.test.ts
+++ b/tests/client/handlers/identitiesInfoGet.test.ts
@@ -108,7 +108,7 @@ describe('identitiesInfoConnectedGet', () => {
       manifest: {
         identitiesInfoGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -174,7 +174,7 @@ describe('identitiesInfoConnectedGet', () => {
       manifest: {
         identitiesInfoGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -262,7 +262,7 @@ describe('identitiesInfoConnectedGet', () => {
       manifest: {
         identitiesInfoGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -345,7 +345,7 @@ describe('identitiesInfoConnectedGet', () => {
       manifest: {
         identitiesInfoGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -414,7 +414,7 @@ describe('identitiesInfoConnectedGet', () => {
       manifest: {
         identitiesInfoGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -497,7 +497,7 @@ describe('identitiesInfoConnectedGet', () => {
       manifest: {
         identitiesInfoGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -587,7 +587,7 @@ describe('identitiesInfoConnectedGet', () => {
       manifest: {
         identitiesInfoGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/identitiesInfoGet.test.ts
+++ b/tests/client/handlers/identitiesInfoGet.test.ts
@@ -92,8 +92,7 @@ describe('identitiesInfoConnectedGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -158,8 +157,7 @@ describe('identitiesInfoConnectedGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -246,8 +244,7 @@ describe('identitiesInfoConnectedGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -329,8 +326,7 @@ describe('identitiesInfoConnectedGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -398,8 +394,7 @@ describe('identitiesInfoConnectedGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -481,8 +476,7 @@ describe('identitiesInfoConnectedGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -571,8 +565,7 @@ describe('identitiesInfoConnectedGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/identitiesInvite.test.ts
+++ b/tests/client/handlers/identitiesInvite.test.ts
@@ -150,8 +150,7 @@ describe('identitiesClaim', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/identitiesInvite.test.ts
+++ b/tests/client/handlers/identitiesInvite.test.ts
@@ -166,7 +166,7 @@ describe('identitiesClaim', () => {
       manifest: {
         identitiesInvite,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/identitiesProvidersList.test.ts
+++ b/tests/client/handlers/identitiesProvidersList.test.ts
@@ -94,8 +94,7 @@ describe('identitiesInfoConnectedGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/identitiesProvidersList.test.ts
+++ b/tests/client/handlers/identitiesProvidersList.test.ts
@@ -110,7 +110,7 @@ describe('identitiesInfoConnectedGet', () => {
       manifest: {
         identitiesProvidersList,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/identitiesTokenPutDeleteGet.test.ts
+++ b/tests/client/handlers/identitiesTokenPutDeleteGet.test.ts
@@ -124,7 +124,7 @@ describe('identitiesTokenPutDeleteGet', () => {
         identitiesTokenDelete,
         identitiesTokenGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/identitiesTokenPutDeleteGet.test.ts
+++ b/tests/client/handlers/identitiesTokenPutDeleteGet.test.ts
@@ -106,8 +106,7 @@ describe('identitiesTokenPutDeleteGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/keysCertsChainGet.test.ts
+++ b/tests/client/handlers/keysCertsChainGet.test.ts
@@ -105,8 +105,7 @@ describe('keysCertsChainGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/keysCertsChainGet.test.ts
+++ b/tests/client/handlers/keysCertsChainGet.test.ts
@@ -121,7 +121,7 @@ describe('keysCertsChainGet', () => {
       manifest: {
         keysCertsChainGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/keysCertsGet.test.ts
+++ b/tests/client/handlers/keysCertsGet.test.ts
@@ -104,8 +104,7 @@ describe('keysCertsGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/keysCertsGet.test.ts
+++ b/tests/client/handlers/keysCertsGet.test.ts
@@ -120,7 +120,7 @@ describe('keysCertsGet', () => {
       manifest: {
         keysCertsGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/keysEncryptDecrypt.test.ts
+++ b/tests/client/handlers/keysEncryptDecrypt.test.ts
@@ -103,7 +103,7 @@ describe('keysEncryptDecrypt', () => {
         keysEncrypt,
         keysDecrypt,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/keysEncryptDecrypt.test.ts
+++ b/tests/client/handlers/keysEncryptDecrypt.test.ts
@@ -86,8 +86,7 @@ describe('keysEncryptDecrypt', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/keysKeyPair.test.ts
+++ b/tests/client/handlers/keysKeyPair.test.ts
@@ -82,8 +82,7 @@ describe('keysKeyPair', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/keysKeyPair.test.ts
+++ b/tests/client/handlers/keysKeyPair.test.ts
@@ -98,7 +98,7 @@ describe('keysKeyPair', () => {
       manifest: {
         keysKeyPair,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/keysKeyPairRenew.test.ts
+++ b/tests/client/handlers/keysKeyPairRenew.test.ts
@@ -68,8 +68,7 @@ describe('keysKeyPairRenew', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/keysKeyPairRenew.test.ts
+++ b/tests/client/handlers/keysKeyPairRenew.test.ts
@@ -84,7 +84,7 @@ describe('keysKeyPairRenew', () => {
       manifest: {
         keysKeyPairRenew,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/keysKeyPairReset.test.ts
+++ b/tests/client/handlers/keysKeyPairReset.test.ts
@@ -68,8 +68,7 @@ describe('keysKeyPairReset', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/keysKeyPairReset.test.ts
+++ b/tests/client/handlers/keysKeyPairReset.test.ts
@@ -84,7 +84,7 @@ describe('keysKeyPairReset', () => {
       manifest: {
         keysKeyPairReset,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/keysPasswordChange.test.ts
+++ b/tests/client/handlers/keysPasswordChange.test.ts
@@ -98,7 +98,7 @@ describe('keysPasswordChange', () => {
       manifest: {
         keysPasswordChange,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/keysPasswordChange.test.ts
+++ b/tests/client/handlers/keysPasswordChange.test.ts
@@ -82,8 +82,7 @@ describe('keysPasswordChange', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/keysPublicKey.test.ts
+++ b/tests/client/handlers/keysPublicKey.test.ts
@@ -98,7 +98,7 @@ describe('keysPublicKey', () => {
       manifest: {
         keysPublicKey,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/keysPublicKey.test.ts
+++ b/tests/client/handlers/keysPublicKey.test.ts
@@ -82,8 +82,7 @@ describe('keysPublicKey', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/keysSignVerify.test.ts
+++ b/tests/client/handlers/keysSignVerify.test.ts
@@ -87,8 +87,7 @@ describe('keysSignVerify', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/keysSignVerify.test.ts
+++ b/tests/client/handlers/keysSignVerify.test.ts
@@ -104,7 +104,7 @@ describe('keysSignVerify', () => {
         keysSign,
         keysVerify,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/nodesAdd.test.ts
+++ b/tests/client/handlers/nodesAdd.test.ts
@@ -144,8 +144,7 @@ describe('nodesAdd', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -193,8 +192,7 @@ describe('nodesAdd', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/nodesAdd.test.ts
+++ b/tests/client/handlers/nodesAdd.test.ts
@@ -160,7 +160,7 @@ describe('nodesAdd', () => {
       manifest: {
         nodesAdd,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -209,7 +209,7 @@ describe('nodesAdd', () => {
       manifest: {
         nodesAdd,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/nodesClaim.test.ts
+++ b/tests/client/handlers/nodesClaim.test.ts
@@ -189,8 +189,7 @@ describe('nodesClaim', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -229,8 +228,7 @@ describe('nodesClaim', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/nodesClaim.test.ts
+++ b/tests/client/handlers/nodesClaim.test.ts
@@ -205,7 +205,7 @@ describe('nodesClaim', () => {
       manifest: {
         nodesClaim,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -245,7 +245,7 @@ describe('nodesClaim', () => {
       manifest: {
         nodesClaim,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/nodesFind.test.ts
+++ b/tests/client/handlers/nodesFind.test.ts
@@ -153,7 +153,7 @@ describe('nodesFind', () => {
       manifest: {
         nodesFind,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -192,7 +192,7 @@ describe('nodesFind', () => {
       manifest: {
         nodesFind,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/nodesFind.test.ts
+++ b/tests/client/handlers/nodesFind.test.ts
@@ -137,8 +137,7 @@ describe('nodesFind', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -176,8 +175,7 @@ describe('nodesFind', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/nodesPing.test.ts
+++ b/tests/client/handlers/nodesPing.test.ts
@@ -143,8 +143,7 @@ describe('nodesPing', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -182,8 +181,7 @@ describe('nodesPing', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -221,8 +219,7 @@ describe('nodesPing', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/nodesPing.test.ts
+++ b/tests/client/handlers/nodesPing.test.ts
@@ -159,7 +159,7 @@ describe('nodesPing', () => {
       manifest: {
         nodesPing,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -198,7 +198,7 @@ describe('nodesPing', () => {
       manifest: {
         nodesPing,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -237,7 +237,7 @@ describe('nodesPing', () => {
       manifest: {
         nodesPing,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/notificationsClear.test.ts
+++ b/tests/client/handlers/notificationsClear.test.ts
@@ -153,8 +153,7 @@ describe('notificationsClear', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/notificationsClear.test.ts
+++ b/tests/client/handlers/notificationsClear.test.ts
@@ -169,7 +169,7 @@ describe('notificationsClear', () => {
       manifest: {
         notificationsClear,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/notificationsRead.test.ts
+++ b/tests/client/handlers/notificationsRead.test.ts
@@ -173,8 +173,7 @@ describe('identitiesTokenPutDeleteGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -240,8 +239,7 @@ describe('identitiesTokenPutDeleteGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -324,8 +322,7 @@ describe('identitiesTokenPutDeleteGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -408,8 +405,7 @@ describe('identitiesTokenPutDeleteGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -472,8 +468,7 @@ describe('identitiesTokenPutDeleteGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -549,8 +544,7 @@ describe('identitiesTokenPutDeleteGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/notificationsRead.test.ts
+++ b/tests/client/handlers/notificationsRead.test.ts
@@ -189,7 +189,7 @@ describe('identitiesTokenPutDeleteGet', () => {
       manifest: {
         notificationsRead,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -256,7 +256,7 @@ describe('identitiesTokenPutDeleteGet', () => {
       manifest: {
         notificationsRead,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -340,7 +340,7 @@ describe('identitiesTokenPutDeleteGet', () => {
       manifest: {
         notificationsRead,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -424,7 +424,7 @@ describe('identitiesTokenPutDeleteGet', () => {
       manifest: {
         notificationsRead,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -488,7 +488,7 @@ describe('identitiesTokenPutDeleteGet', () => {
       manifest: {
         notificationsRead,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -565,7 +565,7 @@ describe('identitiesTokenPutDeleteGet', () => {
       manifest: {
         notificationsRead,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/notificationsSend.test.ts
+++ b/tests/client/handlers/notificationsSend.test.ts
@@ -190,7 +190,7 @@ describe('notificationsSend', () => {
       manifest: {
         notificationsSend,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/notificationsSend.test.ts
+++ b/tests/client/handlers/notificationsSend.test.ts
@@ -174,8 +174,7 @@ describe('notificationsSend', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/vaultsClone.test.ts
+++ b/tests/client/handlers/vaultsClone.test.ts
@@ -82,8 +82,8 @@ describe('notificationsSend', () => {
   //       logger,
   //     });
   //     webSocketServer = await WebSocketServer.createWebSocketServer({
-  //       connectionCallback: (streamPair, connectionInfo) =>
-  //         rpcServer.handleStream(streamPair, connectionInfo),
+  //       connectionCallback: (streamPair) =>
+  //         rpcServer.handleStream(streamPair),
   //       host,
   //       tlsConfig,
   //       logger: logger.getChild('server'),

--- a/tests/client/handlers/vaultsClone.test.ts
+++ b/tests/client/handlers/vaultsClone.test.ts
@@ -98,7 +98,7 @@ describe('notificationsSend', () => {
   //       manifest: {
   //         notificationsSend,
   //       },
-  //       streamFactory: async () => webSocketClient.startConnection(),
+  //       streamFactory: (ctx) => webSocketClient.startConnection(ctx),
   //       logger: logger.getChild('clientRPC'),
   //     });
   //

--- a/tests/client/handlers/vaultsCreateDeleteList.test.ts
+++ b/tests/client/handlers/vaultsCreateDeleteList.test.ts
@@ -104,8 +104,7 @@ describe('vaultsCreateDeleteList', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/vaultsCreateDeleteList.test.ts
+++ b/tests/client/handlers/vaultsCreateDeleteList.test.ts
@@ -122,7 +122,7 @@ describe('vaultsCreateDeleteList', () => {
         vaultsDelete,
         vaultsList,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/vaultsCreateDeleteList.test.ts
+++ b/tests/client/handlers/vaultsCreateDeleteList.test.ts
@@ -12,7 +12,7 @@ import { DB } from '@matrixai/db';
 import KeyRing from '@/keys/KeyRing';
 import * as keysUtils from '@/keys/utils';
 import RPCServer from '@/rpc/RPCServer';
-import { VaultsCreatehandler } from '@/client/handlers/vaultsCreate';
+import { VaultsCreateHandler } from '@/client/handlers/vaultsCreate';
 import { VaultsDeleteHandler } from '@/client/handlers/vaultsDelete';
 import { VaultsListHandler } from '@/client/handlers/vaultsList';
 import RPCClient from '@/rpc/RPCClient';
@@ -88,7 +88,7 @@ describe('vaultsCreateDeleteList', () => {
     // Setup
     const rpcServer = await RPCServer.createRPCServer({
       manifest: {
-        vaultsCreate: new VaultsCreatehandler({
+        vaultsCreate: new VaultsCreateHandler({
           vaultManager,
           db,
         }),

--- a/tests/client/handlers/vaultsLog.test.ts
+++ b/tests/client/handlers/vaultsLog.test.ts
@@ -114,8 +114,7 @@ describe('vaultsLog', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -159,8 +158,7 @@ describe('vaultsLog', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -204,8 +202,7 @@ describe('vaultsLog', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/vaultsLog.test.ts
+++ b/tests/client/handlers/vaultsLog.test.ts
@@ -130,7 +130,7 @@ describe('vaultsLog', () => {
       manifest: {
         vaultsLog,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -175,7 +175,7 @@ describe('vaultsLog', () => {
       manifest: {
         vaultsLog,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -220,7 +220,7 @@ describe('vaultsLog', () => {
       manifest: {
         vaultsLog,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/vaultsPermissionSetUnsetGet.test.ts
+++ b/tests/client/handlers/vaultsPermissionSetUnsetGet.test.ts
@@ -146,8 +146,7 @@ describe('vaultsPermissionSetUnsetGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/vaultsPermissionSetUnsetGet.test.ts
+++ b/tests/client/handlers/vaultsPermissionSetUnsetGet.test.ts
@@ -164,7 +164,7 @@ describe('vaultsPermissionSetUnsetGet', () => {
         vaultsPermissionGet,
         vaultsPermissionUnset,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/vaultsPull.test.ts
+++ b/tests/client/handlers/vaultsPull.test.ts
@@ -127,8 +127,8 @@ describe('vaultsPull', () => {
   //     logger,
   //   });
   //   webSocketServer = await WebSocketServer.createWebSocketServer({
-  //     connectionCallback: (streamPair, connectionInfo) =>
-  //       rpcServer.handleStream(streamPair, connectionInfo),
+  //     connectionCallback: (streamPair) =>
+  //       rpcServer.handleStream(streamPair),
   //     host,
   //     tlsConfig,
   //     logger: logger.getChild('server'),

--- a/tests/client/handlers/vaultsPull.test.ts
+++ b/tests/client/handlers/vaultsPull.test.ts
@@ -145,7 +145,7 @@ describe('vaultsPull', () => {
   //       vaultsPermissionGet,
   //       vaultsPermissionUnset,
   //     },
-  //     streamFactory: async () => webSocketClient.startConnection(),
+  //     streamFactory: (ctx) => webSocketClient.startConnection(ctx),
   //     logger: logger.getChild('clientRPC'),
   //   });
   //

--- a/tests/client/handlers/vaultsRename.test.ts
+++ b/tests/client/handlers/vaultsRename.test.ts
@@ -90,8 +90,7 @@ describe('vaultsRename', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/vaultsRename.test.ts
+++ b/tests/client/handlers/vaultsRename.test.ts
@@ -106,7 +106,7 @@ describe('vaultsRename', () => {
       manifest: {
         vaultsRename,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/vaultsScan.test.ts
+++ b/tests/client/handlers/vaultsScan.test.ts
@@ -83,8 +83,8 @@ describe('vaultsScan', () => {
   //     logger,
   //   });
   //   webSocketServer = await WebSocketServer.createWebSocketServer({
-  //     connectionCallback: (streamPair, connectionInfo) =>
-  //       rpcServer.handleStream(streamPair, connectionInfo),
+  //     connectionCallback: (streamPair) =>
+  //       rpcServer.handleStream(streamPair),
   //     host,
   //     tlsConfig,
   //     logger: logger.getChild('server'),

--- a/tests/client/handlers/vaultsScan.test.ts
+++ b/tests/client/handlers/vaultsScan.test.ts
@@ -99,7 +99,7 @@ describe('vaultsScan', () => {
   //     manifest: {
   //       vaultsRename,
   //     },
-  //     streamFactory: async () => webSocketClient.startConnection(),
+  //     streamFactory: (ctx) => webSocketClient.startConnection(ctx),
   //     logger: logger.getChild('clientRPC'),
   //   });
   //

--- a/tests/client/handlers/vaultsSecretsEdit.test.ts
+++ b/tests/client/handlers/vaultsSecretsEdit.test.ts
@@ -90,8 +90,7 @@ describe('vaultsSecretsEdit', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/vaultsSecretsEdit.test.ts
+++ b/tests/client/handlers/vaultsSecretsEdit.test.ts
@@ -106,7 +106,7 @@ describe('vaultsSecretsEdit', () => {
       manifest: {
         vaultsSecretsEdit,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/vaultsSecretsMkdir.test.ts
+++ b/tests/client/handlers/vaultsSecretsMkdir.test.ts
@@ -106,7 +106,7 @@ describe('vaultsSecretsMkdir', () => {
       manifest: {
         vaultsSecretsMkdir,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/vaultsSecretsMkdir.test.ts
+++ b/tests/client/handlers/vaultsSecretsMkdir.test.ts
@@ -90,8 +90,7 @@ describe('vaultsSecretsMkdir', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/vaultsSecretsNewDeleteGet.test.ts
+++ b/tests/client/handlers/vaultsSecretsNewDeleteGet.test.ts
@@ -29,6 +29,7 @@ import * as testUtils from '../../utils/index';
 import * as testsUtils from '../../utils';
 
 describe('vaultsSecretsNewDeleteGet', () => {
+  Error.stackTraceLimit = 100;
   const logger = new Logger('agentUnlock test', LogLevel.WARN, [
     new StreamHandler(
       formatting.format`${formatting.level}:${formatting.keys}:${formatting.msg}`,

--- a/tests/client/handlers/vaultsSecretsNewDeleteGet.test.ts
+++ b/tests/client/handlers/vaultsSecretsNewDeleteGet.test.ts
@@ -107,8 +107,7 @@ describe('vaultsSecretsNewDeleteGet', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/vaultsSecretsNewDeleteGet.test.ts
+++ b/tests/client/handlers/vaultsSecretsNewDeleteGet.test.ts
@@ -125,7 +125,7 @@ describe('vaultsSecretsNewDeleteGet', () => {
         vaultsSecretsDelete,
         vaultsSecretsGet,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/vaultsSecretsNewDirList.test.ts
+++ b/tests/client/handlers/vaultsSecretsNewDirList.test.ts
@@ -117,7 +117,7 @@ describe('vaultsSecretsNewDirList', () => {
         vaultsSecretsNewDir,
         vaultsSecretsList,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/vaultsSecretsNewDirList.test.ts
+++ b/tests/client/handlers/vaultsSecretsNewDirList.test.ts
@@ -100,8 +100,7 @@ describe('vaultsSecretsNewDirList', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/vaultsSecretsRename.test.ts
+++ b/tests/client/handlers/vaultsSecretsRename.test.ts
@@ -91,8 +91,7 @@ describe('vaultsSecretsRename', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/vaultsSecretsRename.test.ts
+++ b/tests/client/handlers/vaultsSecretsRename.test.ts
@@ -107,7 +107,7 @@ describe('vaultsSecretsRename', () => {
       manifest: {
         vaultsSecretsRename,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/vaultsSecretsStat.test.ts
+++ b/tests/client/handlers/vaultsSecretsStat.test.ts
@@ -91,8 +91,7 @@ describe('vaultsSecretsStat', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/handlers/vaultsSecretsStat.test.ts
+++ b/tests/client/handlers/vaultsSecretsStat.test.ts
@@ -107,7 +107,7 @@ describe('vaultsSecretsStat', () => {
       manifest: {
         vaultsSecretsStat,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/vaultsVersion.test.ts
+++ b/tests/client/handlers/vaultsVersion.test.ts
@@ -122,7 +122,7 @@ describe('vaultsVersion', () => {
       manifest: {
         vaultsVersion,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 
@@ -186,7 +186,7 @@ describe('vaultsVersion', () => {
       manifest: {
         vaultsVersion,
       },
-      streamFactory: async () => webSocketClient.startConnection(),
+      streamFactory: (ctx) => webSocketClient.startConnection(ctx),
       logger: logger.getChild('clientRPC'),
     });
 

--- a/tests/client/handlers/vaultsVersion.test.ts
+++ b/tests/client/handlers/vaultsVersion.test.ts
@@ -106,8 +106,7 @@ describe('vaultsVersion', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),
@@ -170,8 +169,7 @@ describe('vaultsVersion', () => {
       logger,
     });
     webSocketServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) =>
-        rpcServer.handleStream(streamPair, connectionInfo),
+      connectionCallback: (streamPair) => rpcServer.handleStream(streamPair),
       host,
       tlsConfig,
       logger: logger.getChild('server'),

--- a/tests/client/timeoutMiddleware.test.ts
+++ b/tests/client/timeoutMiddleware.test.ts
@@ -1,0 +1,204 @@
+import type {
+  ClientRPCRequestParams,
+  ClientRPCResponseResult,
+} from '@/client/types';
+import type { TLSConfig } from '../../src/network/types';
+import type { ContextTimed } from '@/contexts/types';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
+import { DB } from '@matrixai/db';
+import { Timer } from '@matrixai/timer';
+import KeyRing from '@/keys/KeyRing';
+import * as keysUtils from '@/keys/utils';
+import RPCServer from '@/rpc/RPCServer';
+import TaskManager from '@/tasks/TaskManager';
+import CertManager from '@/keys/CertManager';
+import RPCClient from '@/rpc/RPCClient';
+import * as timeoutMiddleware from '@/client/utils/timeoutMiddleware';
+import { UnaryCaller } from '@/rpc/callers';
+import { UnaryHandler } from '@/rpc/handlers';
+import * as middlewareUtils from '@/rpc/utils/middleware';
+import WebSocketServer from '@/websockets/WebSocketServer';
+import WebSocketClient from '@/websockets/WebSocketClient';
+import { promise } from '@/utils';
+import * as testsUtils from '../utils';
+
+describe('timeoutMiddleware', () => {
+  const logger = new Logger('agentUnlock test', LogLevel.WARN, [
+    new StreamHandler(),
+  ]);
+  const password = 'helloworld';
+  const host = '127.0.0.1';
+  let dataDir: string;
+  let db: DB;
+  let keyRing: KeyRing;
+  let taskManager: TaskManager;
+  let certManager: CertManager;
+  let clientServer: WebSocketServer;
+  let clientClient: WebSocketClient;
+  let tlsConfig: TLSConfig;
+
+  beforeEach(async () => {
+    dataDir = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'polykey-test-'),
+    );
+    const keysPath = path.join(dataDir, 'keys');
+    const dbPath = path.join(dataDir, 'db');
+    db = await DB.createDB({
+      dbPath,
+      logger,
+    });
+    keyRing = await KeyRing.createKeyRing({
+      password,
+      keysPath,
+      logger,
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
+    });
+    taskManager = await TaskManager.createTaskManager({ db, logger });
+    certManager = await CertManager.createCertManager({
+      db,
+      keyRing,
+      taskManager,
+      logger,
+    });
+    tlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);
+  });
+  afterEach(async () => {
+    await clientServer?.stop(true);
+    await clientClient?.destroy(true);
+    await certManager.stop();
+    await taskManager.stop();
+    await keyRing.stop();
+    await db.stop();
+    await fs.promises.rm(dataDir, {
+      force: true,
+      recursive: true,
+    });
+  });
+  test('Server side timeout updates', async () => {
+    // Setup
+    const ctxProm = promise<ContextTimed>();
+    class EchoHandler extends UnaryHandler<
+      { logger: Logger },
+      ClientRPCRequestParams,
+      ClientRPCResponseResult
+    > {
+      public async handle(
+        input: ClientRPCRequestParams,
+        _,
+        ctx,
+      ): Promise<ClientRPCResponseResult> {
+        ctxProm.resolveP(ctx);
+        return input;
+      }
+    }
+    const rpcServer = await RPCServer.createRPCServer({
+      manifest: {
+        testHandler: new EchoHandler({ logger }),
+      },
+      middlewareFactory: middlewareUtils.defaultServerMiddlewareWrapper(
+        timeoutMiddleware.timeoutMiddlewareServer,
+      ),
+      logger,
+    });
+    clientServer = await WebSocketServer.createWebSocketServer({
+      connectionCallback: (streamPair, connectionInfo) => {
+        rpcServer.handleStream(streamPair, connectionInfo);
+      },
+      host,
+      tlsConfig,
+      logger,
+    });
+    clientClient = await WebSocketClient.createWebSocketClient({
+      expectedNodeIds: [keyRing.getNodeId()],
+      host,
+      port: clientServer.getPort(),
+      logger,
+    });
+    const rpcClient = await RPCClient.createRPCClient({
+      manifest: {
+        testHandler: new UnaryCaller<
+          ClientRPCRequestParams,
+          ClientRPCResponseResult
+        >(),
+      },
+      streamFactory: async () => clientClient.startConnection(),
+      middlewareFactory: middlewareUtils.defaultClientMiddlewareWrapper(
+        timeoutMiddleware.timeoutMiddlewareClient,
+      ),
+      logger,
+    });
+
+    // Doing the test
+    const timer = new Timer({
+      delay: 100,
+    });
+    await rpcClient.methods.testHandler({}, { timer });
+
+    const ctx = await ctxProm.p;
+    expect(ctx.timer.delay).toBe(100);
+  });
+  test('client side timeout updates', async () => {
+    // Setup
+    class EchoHandler extends UnaryHandler<
+      { logger: Logger },
+      ClientRPCRequestParams,
+      ClientRPCResponseResult
+    > {
+      public async handle(
+        input: ClientRPCRequestParams,
+        _,
+      ): Promise<ClientRPCResponseResult> {
+        return input;
+      }
+    }
+    const rpcServer = await RPCServer.createRPCServer({
+      manifest: {
+        testHandler: new EchoHandler({ logger }),
+      },
+      middlewareFactory: middlewareUtils.defaultServerMiddlewareWrapper(
+        timeoutMiddleware.timeoutMiddlewareServer,
+      ),
+      defaultTimeout: 100,
+      logger,
+    });
+    clientServer = await WebSocketServer.createWebSocketServer({
+      connectionCallback: (streamPair, connectionInfo) => {
+        rpcServer.handleStream(streamPair, connectionInfo);
+      },
+      host,
+      tlsConfig,
+      logger,
+    });
+    clientClient = await WebSocketClient.createWebSocketClient({
+      expectedNodeIds: [keyRing.getNodeId()],
+      host,
+      port: clientServer.getPort(),
+      logger,
+    });
+    const rpcClient = await RPCClient.createRPCClient({
+      manifest: {
+        testHandler: new UnaryCaller<
+          ClientRPCRequestParams,
+          ClientRPCResponseResult
+        >(),
+      },
+      streamFactory: async () => clientClient.startConnection(),
+      middlewareFactory: middlewareUtils.defaultClientMiddlewareWrapper(
+        timeoutMiddleware.timeoutMiddlewareClient,
+      ),
+      logger,
+    });
+
+    // Doing the test
+    const timer = new Timer({
+      delay: 1000,
+    });
+    await rpcClient.methods.testHandler({}, { timer });
+    expect(timer.delay).toBe(100);
+  });
+});

--- a/tests/client/timeoutMiddleware.test.ts
+++ b/tests/client/timeoutMiddleware.test.ts
@@ -163,7 +163,7 @@ describe('timeoutMiddleware', () => {
       middlewareFactory: middlewareUtils.defaultServerMiddlewareWrapper(
         timeoutMiddleware.timeoutMiddlewareServer,
       ),
-      defaultTimeout: 100,
+      streamKeepAliveTimeoutTime: 100,
       logger,
     });
     clientServer = await WebSocketServer.createWebSocketServer({

--- a/tests/client/timeoutMiddleware.test.ts
+++ b/tests/client/timeoutMiddleware.test.ts
@@ -164,7 +164,7 @@ describe('timeoutMiddleware', () => {
       middlewareFactory: rpcUtilsMiddleware.defaultServerMiddlewareWrapper(
         timeoutMiddleware.timeoutMiddlewareServer,
       ),
-      streamKeepAliveTimeoutTime: 100,
+      handlerTimeoutTime: 100,
       logger,
     });
     clientServer = await WebSocketServer.createWebSocketServer({

--- a/tests/client/timeoutMiddleware.test.ts
+++ b/tests/client/timeoutMiddleware.test.ts
@@ -89,7 +89,8 @@ describe('timeoutMiddleware', () => {
     > {
       public async handle(
         input: ClientRPCRequestParams,
-        _,
+        _cancel,
+        _meta,
         ctx,
       ): Promise<ClientRPCResponseResult> {
         ctxProm.resolveP(ctx);
@@ -106,8 +107,8 @@ describe('timeoutMiddleware', () => {
       logger,
     });
     clientServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) => {
-        rpcServer.handleStream(streamPair, connectionInfo);
+      connectionCallback: (streamPair) => {
+        rpcServer.handleStream(streamPair);
       },
       host,
       tlsConfig,
@@ -167,8 +168,8 @@ describe('timeoutMiddleware', () => {
       logger,
     });
     clientServer = await WebSocketServer.createWebSocketServer({
-      connectionCallback: (streamPair, connectionInfo) => {
-        rpcServer.handleStream(streamPair, connectionInfo);
+      connectionCallback: (streamPair) => {
+        rpcServer.handleStream(streamPair);
       },
       host,
       tlsConfig,

--- a/tests/client/timeoutMiddleware.test.ts
+++ b/tests/client/timeoutMiddleware.test.ts
@@ -19,7 +19,7 @@ import RPCClient from '@/rpc/RPCClient';
 import * as timeoutMiddleware from '@/client/utils/timeoutMiddleware';
 import { UnaryCaller } from '@/rpc/callers';
 import { UnaryHandler } from '@/rpc/handlers';
-import * as middlewareUtils from '@/rpc/utils/middleware';
+import * as rpcUtilsMiddleware from '@/rpc/utils/middleware';
 import WebSocketServer from '@/websockets/WebSocketServer';
 import WebSocketClient from '@/websockets/WebSocketClient';
 import { promise } from '@/utils';
@@ -100,7 +100,7 @@ describe('timeoutMiddleware', () => {
       manifest: {
         testHandler: new EchoHandler({ logger }),
       },
-      middlewareFactory: middlewareUtils.defaultServerMiddlewareWrapper(
+      middlewareFactory: rpcUtilsMiddleware.defaultServerMiddlewareWrapper(
         timeoutMiddleware.timeoutMiddlewareServer,
       ),
       logger,
@@ -127,7 +127,7 @@ describe('timeoutMiddleware', () => {
         >(),
       },
       streamFactory: async () => clientClient.startConnection(),
-      middlewareFactory: middlewareUtils.defaultClientMiddlewareWrapper(
+      middlewareFactory: rpcUtilsMiddleware.defaultClientMiddlewareWrapper(
         timeoutMiddleware.timeoutMiddlewareClient,
       ),
       logger,
@@ -160,7 +160,7 @@ describe('timeoutMiddleware', () => {
       manifest: {
         testHandler: new EchoHandler({ logger }),
       },
-      middlewareFactory: middlewareUtils.defaultServerMiddlewareWrapper(
+      middlewareFactory: rpcUtilsMiddleware.defaultServerMiddlewareWrapper(
         timeoutMiddleware.timeoutMiddlewareServer,
       ),
       streamKeepAliveTimeoutTime: 100,
@@ -188,7 +188,7 @@ describe('timeoutMiddleware', () => {
         >(),
       },
       streamFactory: async () => clientClient.startConnection(),
-      middlewareFactory: middlewareUtils.defaultClientMiddlewareWrapper(
+      middlewareFactory: rpcUtilsMiddleware.defaultClientMiddlewareWrapper(
         timeoutMiddleware.timeoutMiddlewareClient,
       ),
       logger,

--- a/tests/client/timeoutMiddleware.test.ts
+++ b/tests/client/timeoutMiddleware.test.ts
@@ -79,7 +79,7 @@ describe('timeoutMiddleware', () => {
       recursive: true,
     });
   });
-  test('Server side timeout updates', async () => {
+  test('server side timeout updates', async () => {
     // Setup
     const ctxProm = promise<ContextTimed>();
     class EchoHandler extends UnaryHandler<

--- a/tests/rpc/RPC.test.ts
+++ b/tests/rpc/RPC.test.ts
@@ -23,7 +23,7 @@ import {
   UnaryCaller,
 } from '@/rpc/callers';
 import * as rpcErrors from '@/rpc/errors';
-import * as rpcMiddlewareUtils from '@/rpc/utils/middleware';
+import * as rpcUtilsMiddleware from '@/rpc/utils/middleware';
 import * as rpcTestUtils from './utils';
 
 describe('RPC', () => {
@@ -367,7 +367,7 @@ describe('RPC', () => {
         yield* input;
       }
     }
-    const middleware = rpcMiddlewareUtils.defaultServerMiddlewareWrapper(() => {
+    const middleware = rpcUtilsMiddleware.defaultServerMiddlewareWrapper(() => {
       return {
         forward: new TransformStream({
           start: (controller) => {

--- a/tests/rpc/RPC.test.ts
+++ b/tests/rpc/RPC.test.ts
@@ -1,5 +1,4 @@
 import type { ContainerType, JSONRPCRequest } from '@/rpc/types';
-import type { ConnectionInfo } from '@/network/types';
 import type { ReadableStream } from 'stream/web';
 import type { JSONValue } from '@/types';
 import { TransformStream } from 'stream/web';
@@ -56,13 +55,21 @@ describe('RPC', () => {
         },
         logger,
       });
-      rpcServer.handleStream(serverPair, {} as ConnectionInfo);
+      rpcServer.handleStream({
+        ...serverPair,
+        cancel: () => {},
+      });
 
       const rpcClient = await RPCClient.createRPCClient({
         manifest: {
           testMethod: new RawCaller(),
         },
-        streamFactory: async () => clientPair,
+        streamFactory: async () => {
+          return {
+            ...clientPair,
+            cancel: () => {},
+          };
+        },
         logger,
       });
 
@@ -109,13 +116,21 @@ describe('RPC', () => {
         },
         logger,
       });
-      rpcServer.handleStream(serverPair, {} as ConnectionInfo);
+      rpcServer.handleStream({
+        ...serverPair,
+        cancel: () => {},
+      });
 
       const rpcClient = await RPCClient.createRPCClient({
         manifest: {
           testMethod: new DuplexCaller(),
         },
-        streamFactory: async () => clientPair,
+        streamFactory: async () => {
+          return {
+            ...clientPair,
+            cancel: () => {},
+          };
+        },
         logger,
       });
 
@@ -157,13 +172,21 @@ describe('RPC', () => {
         },
         logger,
       });
-      rpcServer.handleStream(serverPair, {} as ConnectionInfo);
+      rpcServer.handleStream({
+        ...serverPair,
+        cancel: () => {},
+      });
 
       const rpcClient = await RPCClient.createRPCClient({
         manifest: {
           testMethod: new ServerCaller<number, number>(),
         },
-        streamFactory: async () => clientPair,
+        streamFactory: async () => {
+          return {
+            ...clientPair,
+            cancel: () => {},
+          };
+        },
         logger,
       });
 
@@ -202,13 +225,21 @@ describe('RPC', () => {
         },
         logger,
       });
-      rpcServer.handleStream(serverPair, {} as ConnectionInfo);
+      rpcServer.handleStream({
+        ...serverPair,
+        cancel: () => {},
+      });
 
       const rpcClient = await RPCClient.createRPCClient({
         manifest: {
           testMethod: new ClientCaller<number, number>(),
         },
-        streamFactory: async () => clientPair,
+        streamFactory: async () => {
+          return {
+            ...clientPair,
+            cancel: () => {},
+          };
+        },
         logger,
       });
 
@@ -244,13 +275,21 @@ describe('RPC', () => {
         },
         logger,
       });
-      rpcServer.handleStream(serverPair, {} as ConnectionInfo);
+      rpcServer.handleStream({
+        ...serverPair,
+        cancel: () => {},
+      });
 
       const rpcClient = await RPCClient.createRPCClient({
         manifest: {
           testMethod: new UnaryCaller(),
         },
-        streamFactory: async () => clientPair,
+        streamFactory: async () => {
+          return {
+            ...clientPair,
+            cancel: () => {},
+          };
+        },
         logger,
       });
 
@@ -283,13 +322,21 @@ describe('RPC', () => {
         },
         logger,
       });
-      rpcServer.handleStream(serverPair, {} as ConnectionInfo);
+      rpcServer.handleStream({
+        ...serverPair,
+        cancel: () => {},
+      });
 
       const rpcClient = await RPCClient.createRPCClient({
         manifest: {
           testMethod: new UnaryCaller(),
         },
-        streamFactory: async () => clientPair,
+        streamFactory: async () => {
+          return {
+            ...clientPair,
+            cancel: () => {},
+          };
+        },
         logger,
       });
 
@@ -331,13 +378,21 @@ describe('RPC', () => {
         sensitive: true,
         logger,
       });
-      rpcServer.handleStream(serverPair, {} as ConnectionInfo);
+      rpcServer.handleStream({
+        ...serverPair,
+        cancel: () => {},
+      });
 
       const rpcClient = await RPCClient.createRPCClient({
         manifest: {
           testMethod: new UnaryCaller(),
         },
-        streamFactory: async () => clientPair,
+        streamFactory: async () => {
+          return {
+            ...clientPair,
+            cancel: () => {},
+          };
+        },
         logger,
       });
 
@@ -389,13 +444,21 @@ describe('RPC', () => {
       middlewareFactory: middleware,
       logger,
     });
-    rpcServer.handleStream(serverPair, {} as ConnectionInfo);
+    rpcServer.handleStream({
+      ...serverPair,
+      cancel: () => {},
+    });
 
     const rpcClient = await RPCClient.createRPCClient({
       manifest: {
         testMethod: new DuplexCaller(),
       },
-      streamFactory: async () => clientPair,
+      streamFactory: async () => {
+        return {
+          ...clientPair,
+          cancel: () => {},
+        };
+      },
       logger,
     });
 

--- a/tests/rpc/RPC.test.ts
+++ b/tests/rpc/RPC.test.ts
@@ -355,7 +355,7 @@ describe('RPC', () => {
       await rpcClient.destroy();
     },
   );
-  test('Middleware can end stream early', async () => {
+  test('middleware can end stream early', async () => {
     const { clientPair, serverPair } = rpcTestUtils.createTapPairs<
       Uint8Array,
       Uint8Array

--- a/tests/rpc/RPCClient.test.ts
+++ b/tests/rpc/RPCClient.test.ts
@@ -785,42 +785,6 @@ describe(`${RPCClient.name}`, () => {
       expect(ctx?.signal.aborted).toBeTrue();
       expect(ctx?.signal.reason).toBe(rejectReason);
     });
-    test('raw caller uses default timeout awaiting stream', async () => {
-      const forwardPassThroughStream = new TransformStream<
-        Uint8Array,
-        Uint8Array
-      >();
-      const reversePassThroughStream = new TransformStream<
-        Uint8Array,
-        Uint8Array
-      >();
-      const streamPair: RPCStream<Uint8Array, Uint8Array> = {
-        cancel: () => {},
-        meta: undefined,
-        writable: forwardPassThroughStream.writable,
-        readable: reversePassThroughStream.readable,
-      };
-      let ctx: ContextTimed | undefined;
-      const rpcClient = await RPCClient.createRPCClient({
-        manifest: {},
-        streamFactory: async (ctx_) => {
-          ctx = ctx_;
-          return streamPair;
-        },
-        streamKeepAliveTimeoutTime: 200,
-        logger,
-      });
-
-      // Timing out on stream.
-      // Stream creation needs to read the header to complete.
-      await Promise.all([
-        rpcClient.rawStreamCaller('testMethod', {}),
-        forwardPassThroughStream.readable.getReader().read(),
-      ]);
-      await ctx?.timer;
-      expect(ctx?.signal.aborted).toBeTrue();
-      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRPCTimedOut);
-    });
     test('raw caller times out awaiting stream', async () => {
       const forwardPassThroughStream = new TransformStream<
         Uint8Array,

--- a/tests/rpc/RPCClient.test.ts
+++ b/tests/rpc/RPCClient.test.ts
@@ -5,9 +5,11 @@ import type {
   JSONRPCRequestMessage,
   JSONRPCResponse,
 } from '@/rpc/types';
+import type { ContextTimed } from '@/contexts/types';
 import { TransformStream, ReadableStream } from 'stream/web';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import { testProp, fc } from '@fast-check/jest';
+import { Timer } from '@matrixai/timer';
 import RPCClient from '@/rpc/RPCClient';
 import RPCServer from '@/rpc/RPCServer';
 import * as rpcErrors from '@/rpc/errors';
@@ -19,6 +21,7 @@ import {
   UnaryCaller,
 } from '@/rpc/callers';
 import * as middlewareUtils from '@/rpc/utils/middleware';
+import { promise, sleep } from '@/utils/index';
 import * as rpcTestUtils from './utils';
 
 describe(`${RPCClient.name}`, () => {
@@ -673,5 +676,468 @@ describe(`${RPCClient.name}`, () => {
     // @ts-ignore: ignoring type safety here
     expect(() => rpcClient.withMethods.someMethod()).toThrow();
     await rpcClient.destroy();
+  });
+  describe('raw caller', () => {
+    test('raw caller uses default timeout when creating stream', async () => {
+      const holdProm = promise();
+      let ctx: ContextTimed | undefined;
+      const rpcClient = await RPCClient.createRPCClient({
+        manifest: {},
+        streamFactory: async (ctx_) => {
+          ctx = ctx_;
+          await holdProm.p;
+          // Should never reach this when testing
+          return {} as ReadableWritablePair<Uint8Array, Uint8Array>;
+        },
+        defaultTimeout: 100,
+        logger,
+      });
+      // Timing out on stream creation
+      const callerInterfaceProm = rpcClient.rawStreamCaller('testMethod', {});
+      await expect(callerInterfaceProm).toReject();
+      await expect(callerInterfaceProm).rejects.toThrow(
+        rpcErrors.ErrorRpcTimedOut,
+      );
+      expect(ctx?.signal.aborted).toBeTrue();
+      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRpcTimedOut);
+    });
+    test('raw caller times out when creating stream', async () => {
+      const holdProm = promise();
+      let ctx: ContextTimed | undefined;
+      const rpcClient = await RPCClient.createRPCClient({
+        manifest: {},
+        streamFactory: async (ctx_) => {
+          ctx = ctx_;
+          await holdProm.p;
+          // Should never reach this when testing
+          return {} as ReadableWritablePair<Uint8Array, Uint8Array>;
+        },
+        logger,
+      });
+      // Timing out on stream creation
+      const callerInterfaceProm = rpcClient.rawStreamCaller(
+        'testMethod',
+        {},
+        { timer: new Timer({ delay: 100 }) },
+      );
+      await expect(callerInterfaceProm).toReject();
+      await expect(callerInterfaceProm).rejects.toThrow(
+        rpcErrors.ErrorRpcTimedOut,
+      );
+      expect(ctx?.signal.aborted).toBeTrue();
+      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRpcTimedOut);
+    });
+    test('raw caller handles abort when creating stream', async () => {
+      const holdProm = promise();
+      let ctx: ContextTimed | undefined;
+      const rpcClient = await RPCClient.createRPCClient({
+        manifest: {},
+        streamFactory: async (ctx_) => {
+          ctx = ctx_;
+          await holdProm.p;
+          // Should never reach this when testing
+          return {} as ReadableWritablePair<Uint8Array, Uint8Array>;
+        },
+        logger,
+      });
+      const abortController = new AbortController();
+      const rejectReason = Symbol('rejectReason');
+      abortController.abort(rejectReason);
+
+      // Timing out on stream creation
+      const callerInterfaceProm = rpcClient.rawStreamCaller(
+        'testMethod',
+        {},
+        { signal: abortController.signal },
+      );
+      await expect(callerInterfaceProm).toReject();
+      await expect(callerInterfaceProm).rejects.toBe(rejectReason);
+      expect(ctx?.signal.aborted).toBeTrue();
+      expect(ctx?.signal.reason).toBe(rejectReason);
+    });
+    test('raw caller uses default timeout awaiting stream', async () => {
+      const forwardPassThroughStream = new TransformStream<
+        Uint8Array,
+        Uint8Array
+      >();
+      const reversePassThroughStream = new TransformStream<
+        Uint8Array,
+        Uint8Array
+      >();
+      const streamPair: ReadableWritablePair<Uint8Array, Uint8Array> = {
+        writable: forwardPassThroughStream.writable,
+        readable: reversePassThroughStream.readable,
+      };
+      let ctx: ContextTimed | undefined;
+      const rpcClient = await RPCClient.createRPCClient({
+        manifest: {},
+        streamFactory: async (ctx_) => {
+          ctx = ctx_;
+          return streamPair;
+        },
+        defaultTimeout: 200,
+        logger,
+      });
+
+      // Timing out on stream.
+      // Stream creation needs to read the header to complete.
+      await Promise.all([
+        rpcClient.rawStreamCaller('testMethod', {}),
+        forwardPassThroughStream.readable.getReader().read(),
+      ]);
+      await ctx?.timer;
+      expect(ctx?.signal.aborted).toBeTrue();
+      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRpcTimedOut);
+    });
+    test('raw caller times out awaiting stream', async () => {
+      const forwardPassThroughStream = new TransformStream<
+        Uint8Array,
+        Uint8Array
+      >();
+      const reversePassThroughStream = new TransformStream<
+        Uint8Array,
+        Uint8Array
+      >();
+      const streamPair: ReadableWritablePair<Uint8Array, Uint8Array> = {
+        writable: forwardPassThroughStream.writable,
+        readable: reversePassThroughStream.readable,
+      };
+      let ctx: ContextTimed | undefined;
+      const rpcClient = await RPCClient.createRPCClient({
+        manifest: {},
+        streamFactory: async (ctx_) => {
+          ctx = ctx_;
+          return streamPair;
+        },
+        logger,
+      });
+      // Timing out on stream
+      await Promise.all([
+        rpcClient.rawStreamCaller(
+          'testMethod',
+          {},
+          { timer: new Timer({ delay: 100 }) },
+        ),
+        forwardPassThroughStream.readable.getReader().read(),
+      ]);
+      await ctx?.timer;
+      expect(ctx?.signal.aborted).toBeTrue();
+      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRpcTimedOut);
+    });
+    test('raw caller handles abort awaiting stream', async () => {
+      const forwardPassThroughStream = new TransformStream<
+        Uint8Array,
+        Uint8Array
+      >();
+      const reversePassThroughStream = new TransformStream<
+        Uint8Array,
+        Uint8Array
+      >();
+      const streamPair: ReadableWritablePair<Uint8Array, Uint8Array> = {
+        writable: forwardPassThroughStream.writable,
+        readable: reversePassThroughStream.readable,
+      };
+      const ctxProm = promise<ContextTimed>();
+      const rpcClient = await RPCClient.createRPCClient({
+        manifest: {},
+        streamFactory: async (ctx) => {
+          ctxProm.resolveP(ctx);
+          return streamPair;
+        },
+        logger,
+      });
+      const abortController = new AbortController();
+      const rejectReason = Symbol('rejectReason');
+      // Timing out on stream
+      const reader = forwardPassThroughStream.readable.getReader();
+      await Promise.all([
+        rpcClient.rawStreamCaller(
+          'testMethod',
+          {},
+          { signal: abortController.signal },
+        ),
+        reader.read(),
+      ]);
+      const ctx = await ctxProm.p;
+      const abortProm = promise<void>();
+      if (ctx.signal.aborted) abortProm.resolveP();
+      ctx.signal.addEventListener('abort', () => {
+        abortProm.resolveP();
+      });
+      abortController.abort(rejectReason);
+      await abortProm.p;
+      expect(ctx?.signal.aborted).toBeTrue();
+      expect(ctx?.signal.reason).toBe(rejectReason);
+    });
+  });
+  describe('duplex caller', () => {
+    test('duplex caller uses default timeout when creating stream', async () => {
+      const holdProm = promise();
+      let ctx: ContextTimed | undefined;
+      const rpcClient = await RPCClient.createRPCClient({
+        manifest: {},
+        streamFactory: async (ctx_) => {
+          ctx = ctx_;
+          await holdProm.p;
+          // Should never reach this when testing
+          return {} as ReadableWritablePair<Uint8Array, Uint8Array>;
+        },
+        defaultTimeout: 100,
+        logger,
+      });
+      // Timing out on stream creation
+      const callerInterfaceProm = rpcClient.duplexStreamCaller('testMethod');
+      await expect(callerInterfaceProm).toReject();
+      await expect(callerInterfaceProm).rejects.toThrow(
+        rpcErrors.ErrorRpcTimedOut,
+      );
+      expect(ctx?.signal.aborted).toBeTrue();
+      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRpcTimedOut);
+    });
+    test('duplex caller times out when creating stream', async () => {
+      const holdProm = promise();
+      let ctx: ContextTimed | undefined;
+      const rpcClient = await RPCClient.createRPCClient({
+        manifest: {},
+        streamFactory: async (ctx_) => {
+          ctx = ctx_;
+          await holdProm.p;
+          // Should never reach this when testing
+          return {} as ReadableWritablePair<Uint8Array, Uint8Array>;
+        },
+        logger,
+      });
+      // Timing out on stream creation
+      const callerInterfaceProm = rpcClient.duplexStreamCaller('testMethod', {
+        timer: new Timer({ delay: 100 }),
+      });
+      await expect(callerInterfaceProm).toReject();
+      await expect(callerInterfaceProm).rejects.toThrow(
+        rpcErrors.ErrorRpcTimedOut,
+      );
+      expect(ctx?.signal.aborted).toBeTrue();
+      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRpcTimedOut);
+    });
+    test('duplex caller handles abort when creating stream', async () => {
+      const holdProm = promise();
+      let ctx: ContextTimed | undefined;
+      const rpcClient = await RPCClient.createRPCClient({
+        manifest: {},
+        streamFactory: async (ctx_) => {
+          ctx = ctx_;
+          await holdProm.p;
+          // Should never reach this when testing
+          return {} as ReadableWritablePair<Uint8Array, Uint8Array>;
+        },
+        logger,
+      });
+      const abortController = new AbortController();
+      const rejectReason = Symbol('rejectReason');
+      abortController.abort(rejectReason);
+
+      // Timing out on stream creation
+      const callerInterfaceProm = rpcClient.duplexStreamCaller('testMethod', {
+        signal: abortController.signal,
+      });
+      await expect(callerInterfaceProm).toReject();
+      await expect(callerInterfaceProm).rejects.toBe(rejectReason);
+      expect(ctx?.signal.aborted).toBeTrue();
+      expect(ctx?.signal.reason).toBe(rejectReason);
+    });
+    test('duplex caller uses default timeout awaiting stream', async () => {
+      const forwardPassThroughStream = new TransformStream<
+        Uint8Array,
+        Uint8Array
+      >();
+      const reversePassThroughStream = new TransformStream<
+        Uint8Array,
+        Uint8Array
+      >();
+      const streamPair: ReadableWritablePair<Uint8Array, Uint8Array> = {
+        writable: forwardPassThroughStream.writable,
+        readable: reversePassThroughStream.readable,
+      };
+      let ctx: ContextTimed | undefined;
+      const rpcClient = await RPCClient.createRPCClient({
+        manifest: {},
+        streamFactory: async (ctx_) => {
+          ctx = ctx_;
+          return streamPair;
+        },
+        defaultTimeout: 100,
+        logger,
+      });
+
+      // Timing out on stream
+      await rpcClient.duplexStreamCaller('testMethod');
+      await ctx?.timer;
+      expect(ctx?.signal.aborted).toBeTrue();
+      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRpcTimedOut);
+    });
+    test('duplex caller times out awaiting stream', async () => {
+      const forwardPassThroughStream = new TransformStream<
+        Uint8Array,
+        Uint8Array
+      >();
+      const reversePassThroughStream = new TransformStream<
+        Uint8Array,
+        Uint8Array
+      >();
+      const streamPair: ReadableWritablePair<Uint8Array, Uint8Array> = {
+        writable: forwardPassThroughStream.writable,
+        readable: reversePassThroughStream.readable,
+      };
+      let ctx: ContextTimed | undefined;
+      const rpcClient = await RPCClient.createRPCClient({
+        manifest: {},
+        streamFactory: async (ctx_) => {
+          ctx = ctx_;
+          return streamPair;
+        },
+        logger,
+      });
+
+      // Timing out on stream
+      await rpcClient.duplexStreamCaller('testMethod', {
+        timer: new Timer({ delay: 100 }),
+      });
+      await ctx?.timer;
+      expect(ctx?.signal.aborted).toBeTrue();
+      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRpcTimedOut);
+    });
+    test('duplex caller handles abort awaiting stream', async () => {
+      const forwardPassThroughStream = new TransformStream<
+        Uint8Array,
+        Uint8Array
+      >();
+      const reversePassThroughStream = new TransformStream<
+        Uint8Array,
+        Uint8Array
+      >();
+      const streamPair: ReadableWritablePair<Uint8Array, Uint8Array> = {
+        writable: forwardPassThroughStream.writable,
+        readable: reversePassThroughStream.readable,
+      };
+      const ctxProm = promise<ContextTimed>();
+      const rpcClient = await RPCClient.createRPCClient({
+        manifest: {},
+        streamFactory: async (ctx) => {
+          ctxProm.resolveP(ctx);
+          return streamPair;
+        },
+        logger,
+      });
+      const abortController = new AbortController();
+      const rejectReason = Symbol('rejectReason');
+      abortController.abort(rejectReason);
+      // Timing out on stream
+      await rpcClient.duplexStreamCaller('testMethod', {
+        signal: abortController.signal,
+      });
+      const ctx = await ctxProm.p;
+      const abortProm = promise<void>();
+      if (ctx.signal.aborted) abortProm.resolveP();
+      ctx.signal.addEventListener('abort', () => {
+        abortProm.resolveP();
+      });
+      expect(ctx?.signal.aborted).toBeTrue();
+      expect(ctx?.signal.reason).toBe(rejectReason);
+    });
+    testProp(
+      'duplex caller timeout is refreshed when sending message',
+      [specificMessageArb],
+      async (messages) => {
+        const inputStream = rpcTestUtils.messagesToReadableStream(messages);
+        const [outputResult, outputStream] =
+          rpcTestUtils.streamToArray<Uint8Array>();
+        const streamPair: ReadableWritablePair = {
+          readable: inputStream,
+          writable: outputStream,
+        };
+        const ctxProm = promise<ContextTimed>();
+        const rpcClient = await RPCClient.createRPCClient({
+          manifest: {},
+          streamFactory: async (ctx) => {
+            ctxProm.resolveP(ctx);
+            return streamPair;
+          },
+          logger,
+        });
+        const callerInterface = await rpcClient.duplexStreamCaller<
+          JSONValue,
+          JSONValue
+        >(methodName);
+
+        const ctx = await ctxProm.p;
+        // Reading refreshes timer
+        const reader = callerInterface.readable.getReader();
+        await sleep(50);
+        let timeLeft = ctx.timer.getTimeout();
+        const message = await reader.read();
+        expect(ctx.timer.getTimeout()).toBeGreaterThan(timeLeft);
+        reader.releaseLock();
+        for await (const _ of callerInterface.readable) {
+          // Do nothing
+        }
+
+        // Writing should refresh timer
+        const writer = callerInterface.writable.getWriter();
+        await sleep(50);
+        timeLeft = ctx.timer.getTimeout();
+        await writer.write(message.value);
+        expect(ctx.timer.getTimeout()).toBeGreaterThan(timeLeft);
+        await writer.close();
+
+        await outputResult;
+        await rpcClient.destroy();
+      },
+      { numRuns: 5 },
+    );
+    testProp(
+      'Check that ctx is provided to the middleWare and that the middleware can reset the timer',
+      [specificMessageArb],
+      async (messages) => {
+        const inputStream = rpcTestUtils.messagesToReadableStream(messages);
+        const [outputResult, outputStream] =
+          rpcTestUtils.streamToArray<Uint8Array>();
+        const streamPair: ReadableWritablePair = {
+          readable: inputStream,
+          writable: outputStream,
+        };
+        const ctxProm = promise<ContextTimed>();
+        const rpcClient = await RPCClient.createRPCClient({
+          manifest: {},
+          streamFactory: async (ctx) => {
+            ctxProm.resolveP(ctx);
+            return streamPair;
+          },
+          middlewareFactory: middlewareUtils.defaultClientMiddlewareWrapper(
+            (ctx) => {
+              ctx.timer.reset(1000);
+              return {
+                forward: new TransformStream(),
+                reverse: new TransformStream(),
+              };
+            },
+          ),
+          logger,
+        });
+        const callerInterface = await rpcClient.duplexStreamCaller<
+          JSONValue,
+          JSONValue
+        >(methodName);
+
+        const ctx = await ctxProm.p;
+        // Writing should refresh timer engage the middleware
+        const writer = callerInterface.writable.getWriter();
+        await writer.write({});
+        expect(ctx.timer.delay).toBe(1000);
+        await writer.close();
+
+        await outputResult;
+        await rpcClient.destroy();
+      },
+      { numRuns: 1 },
+    );
   });
 });

--- a/tests/rpc/RPCClient.test.ts
+++ b/tests/rpc/RPCClient.test.ts
@@ -696,10 +696,10 @@ describe(`${RPCClient.name}`, () => {
       const callerInterfaceProm = rpcClient.rawStreamCaller('testMethod', {});
       await expect(callerInterfaceProm).toReject();
       await expect(callerInterfaceProm).rejects.toThrow(
-        rpcErrors.ErrorRpcTimedOut,
+        rpcErrors.ErrorRPCTimedOut,
       );
       expect(ctx?.signal.aborted).toBeTrue();
-      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRpcTimedOut);
+      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRPCTimedOut);
     });
     test('raw caller times out when creating stream', async () => {
       const holdProm = promise();
@@ -722,10 +722,10 @@ describe(`${RPCClient.name}`, () => {
       );
       await expect(callerInterfaceProm).toReject();
       await expect(callerInterfaceProm).rejects.toThrow(
-        rpcErrors.ErrorRpcTimedOut,
+        rpcErrors.ErrorRPCTimedOut,
       );
       expect(ctx?.signal.aborted).toBeTrue();
-      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRpcTimedOut);
+      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRPCTimedOut);
     });
     test('raw caller handles abort when creating stream', async () => {
       const holdProm = promise();
@@ -787,7 +787,7 @@ describe(`${RPCClient.name}`, () => {
       ]);
       await ctx?.timer;
       expect(ctx?.signal.aborted).toBeTrue();
-      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRpcTimedOut);
+      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRPCTimedOut);
     });
     test('raw caller times out awaiting stream', async () => {
       const forwardPassThroughStream = new TransformStream<
@@ -822,7 +822,7 @@ describe(`${RPCClient.name}`, () => {
       ]);
       await ctx?.timer;
       expect(ctx?.signal.aborted).toBeTrue();
-      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRpcTimedOut);
+      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRPCTimedOut);
     });
     test('raw caller handles abort awaiting stream', async () => {
       const forwardPassThroughStream = new TransformStream<
@@ -889,10 +889,10 @@ describe(`${RPCClient.name}`, () => {
       const callerInterfaceProm = rpcClient.duplexStreamCaller('testMethod');
       await expect(callerInterfaceProm).toReject();
       await expect(callerInterfaceProm).rejects.toThrow(
-        rpcErrors.ErrorRpcTimedOut,
+        rpcErrors.ErrorRPCTimedOut,
       );
       expect(ctx?.signal.aborted).toBeTrue();
-      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRpcTimedOut);
+      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRPCTimedOut);
     });
     test('duplex caller times out when creating stream', async () => {
       const holdProm = promise();
@@ -913,10 +913,10 @@ describe(`${RPCClient.name}`, () => {
       });
       await expect(callerInterfaceProm).toReject();
       await expect(callerInterfaceProm).rejects.toThrow(
-        rpcErrors.ErrorRpcTimedOut,
+        rpcErrors.ErrorRPCTimedOut,
       );
       expect(ctx?.signal.aborted).toBeTrue();
-      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRpcTimedOut);
+      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRPCTimedOut);
     });
     test('duplex caller handles abort when creating stream', async () => {
       const holdProm = promise();
@@ -972,7 +972,7 @@ describe(`${RPCClient.name}`, () => {
       await rpcClient.duplexStreamCaller('testMethod');
       await ctx?.timer;
       expect(ctx?.signal.aborted).toBeTrue();
-      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRpcTimedOut);
+      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRPCTimedOut);
     });
     test('duplex caller times out awaiting stream', async () => {
       const forwardPassThroughStream = new TransformStream<
@@ -1003,7 +1003,7 @@ describe(`${RPCClient.name}`, () => {
       });
       await ctx?.timer;
       expect(ctx?.signal.aborted).toBeTrue();
-      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRpcTimedOut);
+      expect(ctx?.signal.reason).toBeInstanceOf(rpcErrors.ErrorRPCTimedOut);
     });
     test('duplex caller handles abort awaiting stream', async () => {
       const forwardPassThroughStream = new TransformStream<

--- a/tests/rpc/RPCClient.test.ts
+++ b/tests/rpc/RPCClient.test.ts
@@ -20,7 +20,7 @@ import {
   ServerCaller,
   UnaryCaller,
 } from '@/rpc/callers';
-import * as middlewareUtils from '@/rpc/utils/middleware';
+import * as rpcUtilsMiddleware from '@/rpc/utils/middleware';
 import { promise, sleep } from '@/utils/index';
 import * as rpcTestUtils from './utils';
 
@@ -364,7 +364,7 @@ describe(`${RPCClient.name}`, () => {
       const rpcClient = await RPCClient.createRPCClient({
         manifest: {},
         streamFactory: async () => streamPair,
-        middlewareFactory: middlewareUtils.defaultClientMiddlewareWrapper(
+        middlewareFactory: rpcUtilsMiddleware.defaultClientMiddlewareWrapper(
           () => {
             return {
               forward: new TransformStream<JSONRPCRequest, JSONRPCRequest>({
@@ -430,7 +430,7 @@ describe(`${RPCClient.name}`, () => {
       const rpcClient = await RPCClient.createRPCClient({
         manifest: {},
         streamFactory: async () => streamPair,
-        middlewareFactory: middlewareUtils.defaultClientMiddlewareWrapper(
+        middlewareFactory: rpcUtilsMiddleware.defaultClientMiddlewareWrapper(
           () => {
             return {
               forward: new TransformStream(),
@@ -1111,7 +1111,7 @@ describe(`${RPCClient.name}`, () => {
             ctxProm.resolveP(ctx);
             return streamPair;
           },
-          middlewareFactory: middlewareUtils.defaultClientMiddlewareWrapper(
+          middlewareFactory: rpcUtilsMiddleware.defaultClientMiddlewareWrapper(
             (ctx) => {
               ctx.timer.reset(1000);
               return {

--- a/tests/rpc/RPCClient.test.ts
+++ b/tests/rpc/RPCClient.test.ts
@@ -689,7 +689,7 @@ describe(`${RPCClient.name}`, () => {
           // Should never reach this when testing
           return {} as ReadableWritablePair<Uint8Array, Uint8Array>;
         },
-        defaultTimeout: 100,
+        streamKeepAliveTimeoutTime: 100,
         logger,
       });
       // Timing out on stream creation
@@ -775,7 +775,7 @@ describe(`${RPCClient.name}`, () => {
           ctx = ctx_;
           return streamPair;
         },
-        defaultTimeout: 200,
+        streamKeepAliveTimeoutTime: 200,
         logger,
       });
 
@@ -882,7 +882,7 @@ describe(`${RPCClient.name}`, () => {
           // Should never reach this when testing
           return {} as ReadableWritablePair<Uint8Array, Uint8Array>;
         },
-        defaultTimeout: 100,
+        streamKeepAliveTimeoutTime: 100,
         logger,
       });
       // Timing out on stream creation
@@ -964,7 +964,7 @@ describe(`${RPCClient.name}`, () => {
           ctx = ctx_;
           return streamPair;
         },
-        defaultTimeout: 100,
+        streamKeepAliveTimeoutTime: 100,
         logger,
       });
 

--- a/tests/rpc/RPCClient.test.ts
+++ b/tests/rpc/RPCClient.test.ts
@@ -1,9 +1,9 @@
-import type { ReadableWritablePair } from 'stream/web';
 import type { JSONValue } from '@/types';
 import type {
   JSONRPCRequest,
   JSONRPCRequestMessage,
   JSONRPCResponse,
+  RPCStream,
 } from '@/rpc/types';
 import type { ContextTimed } from '@/contexts/types';
 import { TransformStream, ReadableStream } from 'stream/web';
@@ -48,7 +48,9 @@ describe(`${RPCClient.name}`, () => {
         rpcTestUtils.streamToArray<Uint8Array>();
       const [outputResult, outputWritableStream] =
         rpcTestUtils.streamToArray<Uint8Array>();
-      const streamPair: ReadableWritablePair<Uint8Array, Uint8Array> = {
+      const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+        cancel: () => {},
+        meta: undefined,
         readable: new ReadableStream<Uint8Array>({
           start: (controller) => {
             for (const datum of outputData) {
@@ -92,7 +94,9 @@ describe(`${RPCClient.name}`, () => {
     const inputStream = rpcTestUtils.messagesToReadableStream(messages);
     const [outputResult, outputStream] =
       rpcTestUtils.streamToArray<Uint8Array>();
-    const streamPair: ReadableWritablePair = {
+    const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+      cancel: () => {},
+      meta: undefined,
       readable: inputStream,
       writable: outputStream,
     };
@@ -132,7 +136,9 @@ describe(`${RPCClient.name}`, () => {
     async (messages, params) => {
       const inputStream = rpcTestUtils.messagesToReadableStream(messages);
       const [outputResult, outputStream] = rpcTestUtils.streamToArray();
-      const streamPair: ReadableWritablePair = {
+      const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+        cancel: () => {},
+        meta: undefined,
         readable: inputStream,
         writable: outputStream,
       };
@@ -172,7 +178,9 @@ describe(`${RPCClient.name}`, () => {
       const inputStream = rpcTestUtils.messagesToReadableStream([message]);
       const [outputResult, outputStream] =
         rpcTestUtils.streamToArray<Uint8Array>();
-      const streamPair: ReadableWritablePair = {
+      const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+        cancel: () => {},
+        meta: undefined,
         readable: inputStream,
         writable: outputStream,
       };
@@ -211,7 +219,9 @@ describe(`${RPCClient.name}`, () => {
     async (message, params) => {
       const inputStream = rpcTestUtils.messagesToReadableStream([message]);
       const [outputResult, outputStream] = rpcTestUtils.streamToArray();
-      const streamPair: ReadableWritablePair = {
+      const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+        cancel: () => {},
+        meta: undefined,
         readable: inputStream,
         writable: outputStream,
       };
@@ -249,7 +259,8 @@ describe(`${RPCClient.name}`, () => {
       ]);
       const [outputResult, outputStream] =
         rpcTestUtils.streamToArray<Uint8Array>();
-      const streamPair: ReadableWritablePair = {
+      const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+        cancel: () => {},
         readable: inputStream,
         writable: outputStream,
       };
@@ -286,7 +297,9 @@ describe(`${RPCClient.name}`, () => {
       ]);
       const [outputResult, outputStream] =
         rpcTestUtils.streamToArray<Uint8Array>();
-      const streamPair: ReadableWritablePair = {
+      const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+        cancel: () => {},
+        meta: undefined,
         readable: inputStream,
         writable: outputStream,
       };
@@ -326,7 +339,9 @@ describe(`${RPCClient.name}`, () => {
       ]);
       const [outputResult, outputStream] =
         rpcTestUtils.streamToArray<Uint8Array>();
-      const streamPair: ReadableWritablePair = {
+      const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+        cancel: () => {},
+        meta: undefined,
         readable: inputStream,
         writable: outputStream,
       };
@@ -357,7 +372,9 @@ describe(`${RPCClient.name}`, () => {
       const inputStream = rpcTestUtils.messagesToReadableStream(messages);
       const [outputResult, outputStream] =
         rpcTestUtils.streamToArray<Uint8Array>();
-      const streamPair: ReadableWritablePair = {
+      const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+        cancel: () => {},
+        meta: undefined,
         readable: inputStream,
         writable: outputStream,
       };
@@ -423,7 +440,9 @@ describe(`${RPCClient.name}`, () => {
       const inputStream = rpcTestUtils.messagesToReadableStream(messages);
       const [outputResult, outputStream] =
         rpcTestUtils.streamToArray<Uint8Array>();
-      const streamPair: ReadableWritablePair = {
+      const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+        cancel: () => {},
+        meta: undefined,
         readable: inputStream,
         writable: outputStream,
       };
@@ -473,8 +492,11 @@ describe(`${RPCClient.name}`, () => {
     [specificMessageArb, fc.string()],
     async (messages, params) => {
       const inputStream = rpcTestUtils.messagesToReadableStream(messages);
-      const [outputResult, outputStream] = rpcTestUtils.streamToArray<string>();
-      const streamPair: ReadableWritablePair = {
+      const [outputResult, outputStream] =
+        rpcTestUtils.streamToArray<Uint8Array>();
+      const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+        cancel: () => {},
+        meta: undefined,
         readable: inputStream,
         writable: outputStream,
       };
@@ -513,7 +535,9 @@ describe(`${RPCClient.name}`, () => {
       const inputStream = rpcTestUtils.messagesToReadableStream([message]);
       const [outputResult, outputStream] =
         rpcTestUtils.streamToArray<Uint8Array>();
-      const streamPair: ReadableWritablePair = {
+      const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+        cancel: () => {},
+        meta: undefined,
         readable: inputStream,
         writable: outputStream,
       };
@@ -551,7 +575,9 @@ describe(`${RPCClient.name}`, () => {
     async (message, params) => {
       const inputStream = rpcTestUtils.messagesToReadableStream([message]);
       const [outputResult, outputStream] = rpcTestUtils.streamToArray();
-      const streamPair: ReadableWritablePair = {
+      const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+        cancel: () => {},
+        meta: undefined,
         readable: inputStream,
         writable: outputStream,
       };
@@ -587,7 +613,9 @@ describe(`${RPCClient.name}`, () => {
         rpcTestUtils.streamToArray<Uint8Array>();
       const [outputResult, outputWritableStream] =
         rpcTestUtils.streamToArray<Uint8Array>();
-      const streamPair: ReadableWritablePair<Uint8Array, Uint8Array> = {
+      const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+        cancel: () => {},
+        meta: undefined,
         readable: new ReadableStream<Uint8Array>({
           start: (controller) => {
             for (const datum of outputData) {
@@ -637,7 +665,9 @@ describe(`${RPCClient.name}`, () => {
       const inputStream = rpcTestUtils.messagesToReadableStream(messages);
       const [outputResult, outputStream] =
         rpcTestUtils.streamToArray<Uint8Array>();
-      const streamPair: ReadableWritablePair = {
+      const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+        cancel: () => {},
+        meta: undefined,
         readable: inputStream,
         writable: outputStream,
       };
@@ -667,7 +697,7 @@ describe(`${RPCClient.name}`, () => {
     const rpcClient = await RPCClient.createRPCClient({
       manifest: {},
       streamFactory: async () => {
-        return {} as ReadableWritablePair;
+        return {} as RPCStream<Uint8Array, Uint8Array>;
       },
       logger,
     });
@@ -687,7 +717,7 @@ describe(`${RPCClient.name}`, () => {
           ctx = ctx_;
           await holdProm.p;
           // Should never reach this when testing
-          return {} as ReadableWritablePair<Uint8Array, Uint8Array>;
+          return {} as RPCStream<Uint8Array, Uint8Array>;
         },
         streamKeepAliveTimeoutTime: 100,
         logger,
@@ -710,7 +740,7 @@ describe(`${RPCClient.name}`, () => {
           ctx = ctx_;
           await holdProm.p;
           // Should never reach this when testing
-          return {} as ReadableWritablePair<Uint8Array, Uint8Array>;
+          return {} as RPCStream<Uint8Array, Uint8Array>;
         },
         logger,
       });
@@ -736,7 +766,7 @@ describe(`${RPCClient.name}`, () => {
           ctx = ctx_;
           await holdProm.p;
           // Should never reach this when testing
-          return {} as ReadableWritablePair<Uint8Array, Uint8Array>;
+          return {} as RPCStream<Uint8Array, Uint8Array>;
         },
         logger,
       });
@@ -764,7 +794,9 @@ describe(`${RPCClient.name}`, () => {
         Uint8Array,
         Uint8Array
       >();
-      const streamPair: ReadableWritablePair<Uint8Array, Uint8Array> = {
+      const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+        cancel: () => {},
+        meta: undefined,
         writable: forwardPassThroughStream.writable,
         readable: reversePassThroughStream.readable,
       };
@@ -798,7 +830,9 @@ describe(`${RPCClient.name}`, () => {
         Uint8Array,
         Uint8Array
       >();
-      const streamPair: ReadableWritablePair<Uint8Array, Uint8Array> = {
+      const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+        cancel: () => {},
+        meta: undefined,
         writable: forwardPassThroughStream.writable,
         readable: reversePassThroughStream.readable,
       };
@@ -833,7 +867,9 @@ describe(`${RPCClient.name}`, () => {
         Uint8Array,
         Uint8Array
       >();
-      const streamPair: ReadableWritablePair<Uint8Array, Uint8Array> = {
+      const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+        cancel: () => {},
+        meta: undefined,
         writable: forwardPassThroughStream.writable,
         readable: reversePassThroughStream.readable,
       };
@@ -880,7 +916,7 @@ describe(`${RPCClient.name}`, () => {
           ctx = ctx_;
           await holdProm.p;
           // Should never reach this when testing
-          return {} as ReadableWritablePair<Uint8Array, Uint8Array>;
+          return {} as RPCStream<Uint8Array, Uint8Array>;
         },
         streamKeepAliveTimeoutTime: 100,
         logger,
@@ -903,7 +939,7 @@ describe(`${RPCClient.name}`, () => {
           ctx = ctx_;
           await holdProm.p;
           // Should never reach this when testing
-          return {} as ReadableWritablePair<Uint8Array, Uint8Array>;
+          return {} as RPCStream<Uint8Array, Uint8Array>;
         },
         logger,
       });
@@ -927,7 +963,7 @@ describe(`${RPCClient.name}`, () => {
           ctx = ctx_;
           await holdProm.p;
           // Should never reach this when testing
-          return {} as ReadableWritablePair<Uint8Array, Uint8Array>;
+          return {} as RPCStream<Uint8Array, Uint8Array>;
         },
         logger,
       });
@@ -953,7 +989,9 @@ describe(`${RPCClient.name}`, () => {
         Uint8Array,
         Uint8Array
       >();
-      const streamPair: ReadableWritablePair<Uint8Array, Uint8Array> = {
+      const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+        cancel: () => {},
+        meta: undefined,
         writable: forwardPassThroughStream.writable,
         readable: reversePassThroughStream.readable,
       };
@@ -983,7 +1021,9 @@ describe(`${RPCClient.name}`, () => {
         Uint8Array,
         Uint8Array
       >();
-      const streamPair: ReadableWritablePair<Uint8Array, Uint8Array> = {
+      const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+        cancel: () => {},
+        meta: undefined,
         writable: forwardPassThroughStream.writable,
         readable: reversePassThroughStream.readable,
       };
@@ -1014,7 +1054,9 @@ describe(`${RPCClient.name}`, () => {
         Uint8Array,
         Uint8Array
       >();
-      const streamPair: ReadableWritablePair<Uint8Array, Uint8Array> = {
+      const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+        cancel: () => {},
+        meta: undefined,
         writable: forwardPassThroughStream.writable,
         readable: reversePassThroughStream.readable,
       };
@@ -1050,7 +1092,9 @@ describe(`${RPCClient.name}`, () => {
         const inputStream = rpcTestUtils.messagesToReadableStream(messages);
         const [outputResult, outputStream] =
           rpcTestUtils.streamToArray<Uint8Array>();
-        const streamPair: ReadableWritablePair = {
+        const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+          cancel: () => {},
+          meta: undefined,
           readable: inputStream,
           writable: outputStream,
         };
@@ -1100,7 +1144,9 @@ describe(`${RPCClient.name}`, () => {
         const inputStream = rpcTestUtils.messagesToReadableStream(messages);
         const [outputResult, outputStream] =
           rpcTestUtils.streamToArray<Uint8Array>();
-        const streamPair: ReadableWritablePair = {
+        const streamPair: RPCStream<Uint8Array, Uint8Array> = {
+          cancel: () => {},
+          meta: undefined,
           readable: inputStream,
           writable: outputStream,
         };

--- a/tests/rpc/RPCServer.test.ts
+++ b/tests/rpc/RPCServer.test.ts
@@ -270,9 +270,9 @@ describe(`${RPCServer.name}`, () => {
       class TestMethod extends DuplexHandler {
         public async *handle(
           input: AsyncIterable<JSONValue>,
-          connectionInfo_: ConnectionInfo,
+          connectionInfo: ConnectionInfo,
         ): AsyncIterable<JSONValue> {
-          handledConnectionInfo = connectionInfo_;
+          handledConnectionInfo = connectionInfo;
           for await (const val of input) {
             yield val;
           }
@@ -300,7 +300,7 @@ describe(`${RPCServer.name}`, () => {
     class TestMethod extends DuplexHandler {
       public async *handle(
         input: AsyncIterable<JSONValue>,
-        connectionInfo_: ConnectionInfo,
+        _connectionInfo: ConnectionInfo,
         ctx: ContextTimed,
       ): AsyncIterable<JSONValue> {
         for await (const val of input) {
@@ -390,9 +390,9 @@ describe(`${RPCServer.name}`, () => {
         logger,
       });
       let resolve, reject;
-      const errorProm = new Promise((_resolve, _reject) => {
-        resolve = _resolve;
-        reject = _reject;
+      const errorProm = new Promise((resolve_, reject_) => {
+        resolve = resolve_;
+        reject = reject_;
       });
       rpcServer.addEventListener('error', (thing: RPCErrorEvent) => {
         resolve(thing);
@@ -431,9 +431,9 @@ describe(`${RPCServer.name}`, () => {
         logger,
       });
       let resolve, reject;
-      const errorProm = new Promise((_resolve, _reject) => {
-        resolve = _resolve;
-        reject = _reject;
+      const errorProm = new Promise((resolve_, reject_) => {
+        resolve = resolve_;
+        reject = reject_;
       });
       rpcServer.addEventListener('error', (thing: RPCErrorEvent) => {
         resolve(thing);
@@ -513,8 +513,8 @@ describe(`${RPCServer.name}`, () => {
       const handlerEndedProm = promise();
       let ctx: ContextTimed | undefined;
       class TestMethod extends DuplexHandler {
-        public async *handle(input, _, _ctx): AsyncIterable<JSONValue> {
-          ctx = _ctx;
+        public async *handle(input, _, ctx_): AsyncIterable<JSONValue> {
+          ctx = ctx_;
           // Echo input
           try {
             yield* input;
@@ -530,8 +530,8 @@ describe(`${RPCServer.name}`, () => {
         logger,
       });
       let resolve;
-      const errorProm = new Promise<RPCErrorEvent>((_resolve) => {
-        resolve = _resolve;
+      const errorProm = new Promise<RPCErrorEvent>((resolve_) => {
+        resolve = resolve_;
       });
       rpcServer.addEventListener('error', (thing: RPCErrorEvent) => {
         resolve(thing);
@@ -744,16 +744,16 @@ describe(`${RPCServer.name}`, () => {
   test('default timeout', async () => {
     const ctxProm = promise<ContextTimed>();
     class TestHandler extends RawHandler {
-      public handle(_input, _connectionInfo, _ctx): ReadableStream<Uint8Array> {
-        ctxProm.resolveP(_ctx);
+      public handle(_input, _connectionInfo, ctx_): ReadableStream<Uint8Array> {
+        ctxProm.resolveP(ctx_);
         // Do nothing, expecting timeout
         let controller: ReadableStreamController<Uint8Array>;
         const stream = new ReadableStream<Uint8Array>({
-          start: (_controller) => {
-            controller = _controller;
+          start: (controller_) => {
+            controller = controller_;
           },
         });
-        _ctx.signal.addEventListener('abort', () => {
+        ctx_.signal.addEventListener('abort', () => {
           controller!.error(Error('ending'));
         });
         return stream;
@@ -822,8 +822,8 @@ describe(`${RPCServer.name}`, () => {
       const ctxShortProm = promise<ContextTimed>();
       class TestMethodShortTimeout extends UnaryHandler {
         timeout = 25;
-        public async handle(input: JSONValue, _, _ctx): Promise<JSONValue> {
-          ctxShortProm.resolveP(_ctx);
+        public async handle(input: JSONValue, _, ctx_): Promise<JSONValue> {
+          ctxShortProm.resolveP(ctx_);
           await waitProm.p;
           return input;
         }
@@ -831,8 +831,8 @@ describe(`${RPCServer.name}`, () => {
       const ctxLongProm = promise<ContextTimed>();
       class TestMethodLongTimeout extends UnaryHandler {
         timeout = 100;
-        public async handle(input: JSONValue, _, _ctx): Promise<JSONValue> {
-          ctxLongProm.resolveP(_ctx);
+        public async handle(input: JSONValue, _, ctx_): Promise<JSONValue> {
+          ctxLongProm.resolveP(ctx_);
           await waitProm.p;
           return input;
         }
@@ -946,8 +946,8 @@ describe(`${RPCServer.name}`, () => {
   test('stream ending cleans up timer and abortSignal', async () => {
     const ctxProm = promise<ContextTimed>();
     class TestHandler extends RawHandler {
-      public handle(input, _connectionInfo, _ctx): ReadableStream<Uint8Array> {
-        ctxProm.resolveP(_ctx);
+      public handle(input, _connectionInfo, ctx_): ReadableStream<Uint8Array> {
+        ctxProm.resolveP(ctx_);
         // Do nothing, expecting timeout
         void (async () => {
           for await (const _ of input[1]) {
@@ -992,8 +992,8 @@ describe(`${RPCServer.name}`, () => {
   test('Timeout has a grace period before forcing the streams closed', async () => {
     const ctxProm = promise<ContextTimed>();
     class TestHandler extends RawHandler {
-      public handle(_input, _connectionInfo, _ctx): ReadableStream<Uint8Array> {
-        ctxProm.resolveP(_ctx);
+      public handle(_input, _connectionInfo, ctx_): ReadableStream<Uint8Array> {
+        ctxProm.resolveP(ctx_);
         // Do nothing, expecting timeout
         return new ReadableStream<Uint8Array>();
       }

--- a/tests/rpc/RPCServer.test.ts
+++ b/tests/rpc/RPCServer.test.ts
@@ -787,7 +787,7 @@ describe(`${RPCServer.name}`, () => {
     const ctx = await ctxProm.p;
     expect(ctx.timer.delay).toEqual(100);
     await ctx.timer;
-    expect(ctx.signal.reason).toBeInstanceOf(rpcErrors.ErrorRpcTimedOut);
+    expect(ctx.signal.reason).toBeInstanceOf(rpcErrors.ErrorRPCTimedOut);
     await expect(outputResult).toReject();
     await rpcServer.destroy();
   });
@@ -984,7 +984,7 @@ describe(`${RPCServer.name}`, () => {
     await outputResult;
     await rpcServer.destroy(false);
     expect(ctx.signal.aborted).toBeTrue();
-    expect(ctx.signal.reason).toBeInstanceOf(rpcErrors.ErrorRpcStreamEnded);
+    expect(ctx.signal.reason).toBeInstanceOf(rpcErrors.ErrorRPCStreamEnded);
     // If the timer has already resolved then it was cancelled
     await expect(ctx.timer).toReject();
     await rpcServer.destroy();
@@ -1027,7 +1027,7 @@ describe(`${RPCServer.name}`, () => {
     const ctx = await ctxProm.p;
     await ctx.timer;
     const then = Date.now();
-    expect(ctx.signal.reason).toBeInstanceOf(rpcErrors.ErrorRpcTimedOut);
+    expect(ctx.signal.reason).toBeInstanceOf(rpcErrors.ErrorRPCTimedOut);
     // Should end after grace period
     await expect(outputResult).rejects.toThrow();
     expect(Date.now() - then).toBeGreaterThanOrEqual(100);

--- a/tests/rpc/RPCServer.test.ts
+++ b/tests/rpc/RPCServer.test.ts
@@ -763,7 +763,7 @@ describe(`${RPCServer.name}`, () => {
       manifest: {
         testMethod: new TestHandler({}),
       },
-      defaultTimeout: 100,
+      streamKeepAliveTimeoutTime: 100,
       logger,
     });
     const [outputResult, outputStream] = rpcTestUtils.streamToArray();
@@ -794,7 +794,7 @@ describe(`${RPCServer.name}`, () => {
   test('default timeout before handler selected', async () => {
     const rpcServer = await RPCServer.createRPCServer({
       manifest: {},
-      defaultTimeout: 100,
+      streamKeepAliveTimeoutTime: 100,
       logger,
     });
     const readWriteStream: ReadableWritablePair = {
@@ -842,7 +842,7 @@ describe(`${RPCServer.name}`, () => {
           testShort: new TestMethodShortTimeout({}),
           testLong: new TestMethodLongTimeout({}),
         },
-        defaultTimeout: 50,
+        streamKeepAliveTimeoutTime: 50,
         logger,
       });
       const streamShort = rpcTestUtils.messagesToReadableStream([
@@ -1002,8 +1002,8 @@ describe(`${RPCServer.name}`, () => {
       manifest: {
         testMethod: new TestHandler({}),
       },
-      defaultTimeout: 50,
-      forceEndDelay: 100,
+      streamKeepAliveTimeoutTime: 50,
+      timeoutForceCloseTime: 100,
       logger,
     });
     const [outputResult, outputStream] = rpcTestUtils.streamToArray();

--- a/tests/rpc/RPCServer.test.ts
+++ b/tests/rpc/RPCServer.test.ts
@@ -789,7 +789,7 @@ describe(`${RPCServer.name}`, () => {
       manifest: {
         testMethod: new TestHandler({}),
       },
-      streamKeepAliveTimeoutTime: 100,
+      handlerTimeoutTime: 100,
       logger,
     });
     const [outputResult, outputStream] = rpcTestUtils.streamToArray();
@@ -821,7 +821,7 @@ describe(`${RPCServer.name}`, () => {
   test('timeout with default time before handler selected', async () => {
     const rpcServer = await RPCServer.createRPCServer({
       manifest: {},
-      streamKeepAliveTimeoutTime: 100,
+      handlerTimeoutTime: 100,
       logger,
     });
     const readWriteStream: RPCStream<Uint8Array, Uint8Array> = {
@@ -880,7 +880,7 @@ describe(`${RPCServer.name}`, () => {
           testShort: new TestMethodShortTimeout({}),
           testLong: new TestMethodLongTimeout({}),
         },
-        streamKeepAliveTimeoutTime: 50,
+        handlerTimeoutTime: 50,
         logger,
       });
       const streamShort = rpcTestUtils.messagesToReadableStream([
@@ -1045,8 +1045,8 @@ describe(`${RPCServer.name}`, () => {
       manifest: {
         testMethod: new TestHandler({}),
       },
-      streamKeepAliveTimeoutTime: 50,
-      timeoutForceCloseTime: 100,
+      handlerTimeoutTime: 50,
+      handlerTimeoutGraceTime: 100,
       logger,
     });
     const [, outputStream] = rpcTestUtils.streamToArray();
@@ -1136,7 +1136,7 @@ describe(`${RPCServer.name}`, () => {
       manifest: {
         testMethod: new TestHandler({}),
       },
-      timeoutForceCloseTime: 0,
+      handlerTimeoutGraceTime: 0,
       logger,
     });
     const [, outputStream] = rpcTestUtils.streamToArray();

--- a/tests/rpc/RPCServer.test.ts
+++ b/tests/rpc/RPCServer.test.ts
@@ -217,7 +217,7 @@ describe(`${RPCServer.name}`, () => {
     },
   );
   testProp(
-    'Handler is provided with container',
+    'handler is provided with container',
     [specificMessageArb],
     async (messages) => {
       const stream = rpcTestUtils.messagesToReadableStream(messages);
@@ -254,7 +254,7 @@ describe(`${RPCServer.name}`, () => {
     },
   );
   testProp(
-    'Handler is provided with connectionInfo',
+    'handler is provided with connectionInfo',
     [specificMessageArb],
     async (messages) => {
       const stream = rpcTestUtils.messagesToReadableStream(messages);
@@ -295,7 +295,7 @@ describe(`${RPCServer.name}`, () => {
       expect(handledConnectionInfo).toBe(connectionInfo);
     },
   );
-  testProp('Handler can be aborted', [specificMessageArb], async (messages) => {
+  testProp('handler can be aborted', [specificMessageArb], async (messages) => {
     const stream = rpcTestUtils.messagesToReadableStream(messages);
     class TestMethod extends DuplexHandler {
       public async *handle(
@@ -346,7 +346,7 @@ describe(`${RPCServer.name}`, () => {
     ).not.toThrow();
     await rpcServer.destroy();
   });
-  testProp('Handler yields nothing', [specificMessageArb], async (messages) => {
+  testProp('handler yields nothing', [specificMessageArb], async (messages) => {
     const stream = rpcTestUtils.messagesToReadableStream(messages);
     class TestMethod extends DuplexHandler {
       public async *handle(
@@ -743,7 +743,7 @@ describe(`${RPCServer.name}`, () => {
       await rpcServer.destroy();
     },
   );
-  test('default timeout', async () => {
+  test('timeout with default time after handler selected', async () => {
     const ctxProm = promise<ContextTimed>();
     class TestHandler extends RawHandler {
       public handle(_input, _connectionInfo, ctx_): ReadableStream<Uint8Array> {
@@ -793,7 +793,7 @@ describe(`${RPCServer.name}`, () => {
     await expect(outputResult).toReject();
     await rpcServer.destroy();
   });
-  test('default timeout before handler selected', async () => {
+  test('timeout with default time before handler selected', async () => {
     const rpcServer = await RPCServer.createRPCServer({
       manifest: {},
       streamKeepAliveTimeoutTime: 100,
@@ -1037,7 +1037,7 @@ describe(`${RPCServer.name}`, () => {
     await rpcServer.destroy();
   });
   testProp(
-    'Middleware can update timeout timer',
+    'middleware can update timeout timer',
     [specificMessageArb],
     async (messages) => {
       const stream = rpcTestUtils.messagesToReadableStream(messages);

--- a/tests/rpc/utils/middleware.test.ts
+++ b/tests/rpc/utils/middleware.test.ts
@@ -3,7 +3,7 @@ import { AsyncIterableX as AsyncIterable } from 'ix/asynciterable';
 import * as rpcUtils from '@/rpc/utils';
 import 'ix/add/asynciterable-operators/toarray';
 import * as rpcErrors from '@/rpc/errors';
-import * as middleware from '@/rpc/utils/middleware';
+import * as rpcUtilsMiddleware from '@/rpc/utils/middleware';
 import * as rpcTestUtils from '../utils';
 
 describe('Middleware tests', () => {
@@ -21,7 +21,9 @@ describe('Middleware tests', () => {
       const parsedStream = rpcTestUtils
         .messagesToReadableStream(messages)
         .pipeThrough(
-          middleware.binaryToJsonMessageStream(rpcUtils.parseJSONRPCMessage),
+          rpcUtilsMiddleware.binaryToJsonMessageStream(
+            rpcUtils.parseJSONRPCMessage,
+          ),
         ); // Converting back.
 
       const asd = await AsyncIterable.as(parsedStream).toArray();
@@ -44,7 +46,7 @@ describe('Middleware tests', () => {
         .messagesToReadableStream(messages)
         .pipeThrough(rpcTestUtils.binaryStreamToSnippedStream([10]))
         .pipeThrough(
-          middleware.binaryToJsonMessageStream(
+          rpcUtilsMiddleware.binaryToJsonMessageStream(
             rpcUtils.parseJSONRPCMessage,
             50,
           ),
@@ -67,7 +69,9 @@ describe('Middleware tests', () => {
         .messagesToReadableStream(messages)
         .pipeThrough(rpcTestUtils.binaryStreamToSnippedStream(snippattern)) // Imaginary internet here
         .pipeThrough(
-          middleware.binaryToJsonMessageStream(rpcUtils.parseJSONRPCMessage),
+          rpcUtilsMiddleware.binaryToJsonMessageStream(
+            rpcUtils.parseJSONRPCMessage,
+          ),
         ); // Converting back.
 
       const asd = await AsyncIterable.as(parsedStream).toArray();
@@ -84,7 +88,9 @@ describe('Middleware tests', () => {
         .pipeThrough(rpcTestUtils.binaryStreamToSnippedStream(snippattern)) // Imaginary internet here
         .pipeThrough(rpcTestUtils.binaryStreamToNoisyStream(noise)) // Adding bad data to the stream
         .pipeThrough(
-          middleware.binaryToJsonMessageStream(rpcUtils.parseJSONRPCMessage),
+          rpcUtilsMiddleware.binaryToJsonMessageStream(
+            rpcUtils.parseJSONRPCMessage,
+          ),
         ); // Converting back.
 
       await expect(AsyncIterable.as(parsedStream).toArray()).rejects.toThrow(

--- a/tests/rpc/utils/utils.test.ts
+++ b/tests/rpc/utils/utils.test.ts
@@ -1,4 +1,4 @@
-import { testProp } from '@fast-check/jest';
+import { testProp, fc } from '@fast-check/jest';
 import * as rpcUtils from '@/rpc/utils';
 import 'ix/add/asynciterable-operators/toarray';
 import * as rpcTestUtils from '../utils';
@@ -12,6 +12,14 @@ describe('utils tests', () => {
     },
     { numRuns: 1000 },
   );
-  // TODO:
-  //  - Test for badly structured data
+  testProp(
+    'malformed data cases parsing errors',
+    [fc.json()],
+    async (message) => {
+      expect(() =>
+        rpcUtils.parseJSONRPCMessage(Buffer.from(JSON.stringify(message))),
+      ).toThrow();
+    },
+    { numRuns: 1000 },
+  );
 });

--- a/tests/rpc/utils/utils.test.ts
+++ b/tests/rpc/utils/utils.test.ts
@@ -1,8 +1,6 @@
 import { testProp } from '@fast-check/jest';
-import { AsyncIterableX as AsyncIterable } from 'ix/asynciterable';
 import * as rpcUtils from '@/rpc/utils';
 import 'ix/add/asynciterable-operators/toarray';
-import * as middleware from '@/rpc/utils/middleware';
 import * as rpcTestUtils from '../utils';
 
 describe('utils tests', () => {
@@ -14,29 +12,6 @@ describe('utils tests', () => {
     },
     { numRuns: 1000 },
   );
-
-  testProp(
-    'can get the head message',
-    [rpcTestUtils.jsonMessagesArb],
-    async (messages) => {
-      const { firstMessageProm, headTransformStream } =
-        rpcUtils.extractFirstMessageTransform(rpcUtils.parseJSONRPCRequest);
-      const parsedStream = rpcTestUtils
-        .messagesToReadableStream(messages)
-        .pipeThrough(rpcTestUtils.binaryStreamToSnippedStream([7]))
-        .pipeThrough(headTransformStream)
-        .pipeThrough(
-          middleware.binaryToJsonMessageStream(rpcUtils.parseJSONRPCMessage),
-        ); // Converting back.
-
-      expect(await firstMessageProm).toStrictEqual(messages[0]);
-      expect(await AsyncIterable.as(parsedStream).toArray()).toStrictEqual(
-        messages.slice(1),
-      );
-    },
-    { numRuns: 1000 },
-  );
-
   // TODO:
   //  - Test for badly structured data
 });

--- a/tests/websockets/WebSocket.test.ts
+++ b/tests/websockets/WebSocket.test.ts
@@ -150,7 +150,7 @@ describe('WebSocket', () => {
     expect((await reader.read()).done).toBeTrue();
     logger.info('ending');
   });
-  test('Handles a connection and closes before message', async () => {
+  test('handles a connection and closes before message', async () => {
     webSocketServer = await WebSocketServer.createWebSocketServer({
       connectionCallback: (streamPair) => {
         logger.info('inside callback');
@@ -178,7 +178,7 @@ describe('WebSocket', () => {
     logger.info('ending');
   });
   testProp(
-    'Handles multiple connections',
+    'handles multiple connections',
     [streamsArb],
     async (streamsData) => {
       try {
@@ -297,7 +297,7 @@ describe('WebSocket', () => {
   });
   // Readable backpressure is not actually supported. We're dealing with it by
   //  using a buffer with a provided limit that can be very large.
-  test('Exceeding readable buffer limit causes error', async () => {
+  test('exceeding readable buffer limit causes error', async () => {
     const startReading = promise<void>();
     const handlingProm = promise<void>();
     webSocketServer = await WebSocketServer.createWebSocketServer({
@@ -409,7 +409,7 @@ describe('WebSocket', () => {
     await expect(serverWritable.write(Buffer.from('test'))).rejects.toThrow();
     logger.info('ending');
   });
-  test('Server ends connection abruptly', async () => {
+  test('server ends connection abruptly', async () => {
     const testProcess = await testsUtils.spawn(
       'ts-node',
       [
@@ -578,7 +578,7 @@ describe('WebSocket', () => {
         }
       },
     );
-    test('Destroying ClientServer stops all connections', async () => {
+    test('destroying ClientServer stops all connections', async () => {
       const streamPairProm =
         promise<ReadableWritablePair<Uint8Array, Uint8Array>>();
       webSocketServer = await WebSocketServer.createWebSocketServer({
@@ -618,7 +618,7 @@ describe('WebSocket', () => {
       await expect(serverWritable.write(Buffer.from('test'))).rejects.toThrow();
       logger.info('ending');
     });
-    test('Server rejects normal HTTPS requests', async () => {
+    test('server rejects normal HTTPS requests', async () => {
       webSocketServer = await WebSocketServer.createWebSocketServer({
         connectionCallback: (streamPair) => {
           logger.info('inside callback');
@@ -676,7 +676,7 @@ describe('WebSocket', () => {
     });
   });
   describe('WebSocketClient', () => {
-    test('Destroying ClientClient stops all connections', async () => {
+    test('destroying ClientClient stops all connections', async () => {
       const streamPairProm =
         promise<ReadableWritablePair<Uint8Array, Uint8Array>>();
       webSocketServer = await WebSocketServer.createWebSocketServer({
@@ -718,7 +718,7 @@ describe('WebSocket', () => {
       await webSocketServer.stop();
       logger.info('ending');
     });
-    test('Authentication rejects bad server certificate', async () => {
+    test('authentication rejects bad server certificate', async () => {
       const invalidNodeId = testNodeUtils.generateRandomNodeId();
       webSocketServer = await WebSocketServer.createWebSocketServer({
         connectionCallback: (streamPair) => {
@@ -749,7 +749,7 @@ describe('WebSocket', () => {
       await webSocketServer.stop();
       logger.info('ending');
     });
-    test('Authenticates with multiple certs in chain', async () => {
+    test('authenticates with multiple certs in chain', async () => {
       const keyPairs: Array<KeyPair> = [
         keyRing.keyPair,
         keysUtils.generateKeyPair(),
@@ -787,7 +787,7 @@ describe('WebSocket', () => {
       expect(activeConnections.size).toBe(1);
       logger.info('ending');
     });
-    test('Authenticates with multiple expected nodes', async () => {
+    test('authenticates with multiple expected nodes', async () => {
       const alternativeNodeId = testNodeUtils.generateRandomNodeId();
       webSocketServer = await WebSocketServer.createWebSocketServer({
         connectionCallback: (streamPair) => {
@@ -815,7 +815,7 @@ describe('WebSocket', () => {
       expect(activeConnections.size).toBe(1);
       logger.info('ending');
     });
-    test('Connection times out', async () => {
+    test('connection times out', async () => {
       webSocketClient = await WebSocketClient.createWebSocketClient({
         host,
         port: 12345,
@@ -854,7 +854,7 @@ describe('WebSocket', () => {
       await webSocketClient.destroy();
       logger.info('ending');
     });
-    test('Stream is aborted', async () => {
+    test('stream is aborted', async () => {
       webSocketServer = await WebSocketServer.createWebSocketServer({
         connectionCallback: (streamPair) => {
           logger.info('inside callback');

--- a/tests/websockets/WebSocket.test.ts
+++ b/tests/websockets/WebSocket.test.ts
@@ -323,7 +323,7 @@ describe('WebSocket', () => {
       tlsConfig,
       host,
       // Setting a really low buffer limit
-      maxReadBufferBytes: 1500,
+      maxReadableStreamBytes: 1500,
       logger: logger.getChild('server'),
     });
     logger.info(`Server started on port ${webSocketServer.getPort()}`);
@@ -660,7 +660,7 @@ describe('WebSocket', () => {
         basePath: dataDir,
         tlsConfig,
         host,
-        pingTimeout: 100,
+        pingTimeoutTime: 100,
         logger: logger.getChild('server'),
       });
       logger.info(`Server started on port ${webSocketServer.getPort()}`);
@@ -820,7 +820,7 @@ describe('WebSocket', () => {
         host,
         port: 12345,
         expectedNodeIds: [keyRing.getNodeId()],
-        connectionTimeout: 0,
+        connectionTimeoutTime: 0,
         logger: logger.getChild('clientClient'),
       });
       await expect(webSocketClient.startConnection({})).rejects.toThrow();
@@ -847,7 +847,7 @@ describe('WebSocket', () => {
         host,
         port: webSocketServer.getPort(),
         expectedNodeIds: [keyRing.getNodeId()],
-        pingTimeout: 100,
+        pingTimeoutTime: 100,
         logger: logger.getChild('clientClient'),
       });
       await webSocketClient.startConnection();


### PR DESCRIPTION
### Description

This PR handles adding the timeout features to the agnostic RPC system

### Issues Fixed

* Fixes #510 
* Fixes #516 

### Tasks

- [x] 1. Update `RPCServer` to support timeouts.
- [x] 2. Update `RPCClient` to support timeouts.
- [x] 3. Update client handlers to make use of the new cancellation/timeout `ctx`.
- ~5. Update agentHandlers to make use of the new cancellation/timeout `ctx`.~ This is blocked by #512 
- [x] 6. Support communicating timeouts between `RPCClient` and `RPCServer`. support updating the timeouts based on these communicated values.
- [x] 7. Update `WebSocketClient` to take a `ctx: ContextTime` and allow it to abort the current connection.

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
