### PR TITLE
Improve search iteration for Github identity search

### DIFF
--- a/src/identities/providers/github/GitHubProvider.ts
+++ b/src/identities/providers/github/GitHubProvider.ts
@@ -315,6 +315,15 @@ class GitHubProvider extends Provider {
             { cause: e },
           );
         }
+        const error = data?.errors?.at?.(0);
+        if (error != null) {
+          throw new identitiesErrors.ErrorProviderCall(
+            `Provider response body contains an error: ${error.message}`,
+            {
+              data: error
+            }
+          );
+        }
         const foundIdentityData: any[] = data?.data?.user?.[identityGroup]?.nodes ?? [];
         for (const identityData of foundIdentityData) {
           identityData.providerId = this.id;

--- a/src/identities/providers/github/GitHubProvider.ts
+++ b/src/identities/providers/github/GitHubProvider.ts
@@ -282,16 +282,14 @@ class GitHubProvider extends Provider {
     providerToken = await this.checkToken(providerToken, authIdentityId);
 
     const foundIdentityIds: Set<IdentityId> = new Set();
-    for (const identityGroup of ['followers', 'following'] as const) {
+    for (const identityGroup of ['following', 'followers'] as const) {
       let cursor: string | undefined;
       while (true) {
         const request = this.createRequest(
           `${this.apiUrl}/graphql`,
           {
             method: 'POST',
-            body: JSON.stringify({
-              query: this.getConnectedIdentityDatasRequestBody(authIdentityId, identityGroup, cursor)
-            })
+            body: this.getConnectedIdentityDatasRequestBody(authIdentityId, identityGroup, cursor)
           },
           providerToken,
         );
@@ -365,7 +363,7 @@ class GitHubProvider extends Provider {
         }
       }
     }`;
-    return query;
+    return JSON.stringify({ query });
   }
 
   /**


### PR DESCRIPTION

### Description

PR aims to improve github identity search since it was very slow iterating over every user followed / following. Now it does a rate search and Promise.all if current rate limit allows it.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #578

### Tasks

- [x] 1. Introduce rate limit
- [x] 2. Introduce Promise.all for followers/following.
- [x] 3. Default back to old search if exceeds rate limit.

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
