### PR TITLE
Encapsulate WebSocketClient in PolykeyClient

### DIFF
--- a/src/PolykeyClient.ts
+++ b/src/PolykeyClient.ts
@@ -1,24 +1,39 @@
-import type { FileSystem } from './types';
-import type { StreamFactory } from '@matrixai/rpc';
+import type { PromiseCancellable } from '@matrixai/async-cancellable';
+import type { ContextTimed, ContextTimedInput } from '@matrixai/contexts';
+import type { DeepPartial, FileSystem } from './types';
+import type { NodeId } from './ids/types';
 import path from 'path';
 import Logger from '@matrixai/logger';
-import { CreateDestroyStartStop } from '@matrixai/async-init/dist/CreateDestroyStartStop';
-import { RPCClient } from '@matrixai/rpc';
-import { middleware as rpcMiddleware } from '@matrixai/rpc';
-import * as clientMiddleware from './client/middleware';
+import {
+  CreateDestroyStartStop,
+  ready,
+} from '@matrixai/async-init/dist/CreateDestroyStartStop';
+import { timedCancellable, context } from '@matrixai/contexts/dist/decorators';
+import { WebSocketClient } from '@matrixai/ws';
+import { RPCClient, middleware as rpcMiddleware } from '@matrixai/rpc';
 import { Session } from './sessions';
+import * as ids from './ids';
 import * as utils from './utils';
 import * as errors from './errors';
 import * as events from './events';
-import config from './config';
 import * as networkUtils from './network/utils';
+import * as validationErrors from './validation/errors';
+import * as clientUtils from './client/utils';
+import * as clientMiddleware from './client/middleware';
 import clientClientManifest from './client/callers';
+import config from './config';
 
 /**
- * This PolykeyClient would create a new PolykeyClient object that constructs
- * a new RPCClient which attempts to connect to an existing PolykeyAgent's
- * RPC server.
+ * Optional configuration for`PolykeyClient`.
  */
+type PolykeyClientOptions = {
+  nodePath: string;
+  keepAliveTimeoutTime: number;
+  keepAliveIntervalTime: number;
+  rpcCallTimeoutTime: number;
+  rpcParserBufferSize: number;
+};
+
 interface PolykeyClient extends CreateDestroyStartStop {}
 @CreateDestroyStartStop(
   new errors.ErrorPolykeyClientRunning(),
@@ -33,48 +48,127 @@ interface PolykeyClient extends CreateDestroyStartStop {}
   },
 )
 class PolykeyClient {
-  static async createPolykeyClient({
-    nodePath = config.defaultsUser.nodePath,
-    streamFactory,
-    streamKeepAliveTimeoutTime,
-    parserBufferByteLimit,
-    fs = require('fs'),
-    logger = new Logger(this.name),
-    fresh = false,
-  }: {
-    nodePath?: string;
-    streamFactory: StreamFactory;
-    streamKeepAliveTimeoutTime?: number;
-    parserBufferByteLimit?: number;
-    fs?: FileSystem;
-    logger?: Logger;
-    fresh?: boolean;
-  }): Promise<PolykeyClient> {
+  /**
+   * Creates a Polykey Client.
+   *
+   * @param opts
+   * @param opts.nodeId
+   * @param opts.host
+   * @param opts.port
+   * @param ctx
+   */
+  public static createPolykeyClient(
+    opts: {
+      nodeId: string | NodeId;
+      port: number;
+      host: string;
+      options?: DeepPartial<PolykeyClientOptions>;
+      fresh?: boolean;
+      fs?: FileSystem;
+      logger?: Logger;
+    },
+    ctx?: Partial<ContextTimedInput>,
+  ): PromiseCancellable<PolykeyClient>;
+  @timedCancellable(
+    true,
+    config.defaultsSystem.clientConnectTimeoutTime,
+    errors.ErrorPolykeyClientCreateTimeout,
+  )
+  public static async createPolykeyClient(
+    {
+      // Required parameters
+      nodeId,
+      host,
+      port,
+      // Options
+      options = {},
+      fresh = false,
+      // Optional dependencies
+      fs = require('fs'),
+      logger = new Logger(this.name),
+    }: {
+      nodeId: string | NodeId;
+      host: string;
+      port: number;
+      options?: DeepPartial<PolykeyClientOptions>;
+      fresh?: boolean;
+      fs?: FileSystem;
+      logger?: Logger;
+    },
+    @context ctx: ContextTimed,
+  ): Promise<PolykeyClient> {
     logger.info(`Creating ${this.name}`);
-    if (nodePath == null) {
+    let nodeId_: NodeId;
+    if (typeof nodeId === 'string') {
+      try {
+        nodeId_ = ids.parseNodeId(nodeId);
+      } catch (e) {
+        if (e instanceof validationErrors.ErrorParse) {
+          throw new errors.ErrorPolykeyClientNodeIdInvalid(
+            'Encoded node ID must be a multibase base32hex encoded public-key',
+            {
+              cause: e,
+              data: { nodeId },
+            },
+          );
+        }
+        throw e;
+      }
+    } else {
+      nodeId_ = nodeId;
+    }
+    const optionsDefaulted = utils.mergeObjects(options, {
+      nodePath: config.defaultsUser.nodePath,
+      connectTimeoutTime: config.defaultsSystem.clientConnectTimeoutTime,
+      keepAliveTimeoutTime: config.defaultsSystem.clientKeepAliveTimeoutTime,
+      keepAliveIntervalTime: config.defaultsSystem.clientKeepAliveIntervalTime,
+      callTimeoutTime: config.defaultsSystem.rpcCallTimeoutTime,
+      parserBufferSize: config.defaultsSystem.rpcParserBufferSize,
+    }) as PolykeyClientOptions;
+    if (optionsDefaulted.nodePath == null) {
       throw new errors.ErrorUtilsNodePath();
     }
-    await utils.mkdirExists(fs, nodePath);
-    const sessionTokenPath = path.join(nodePath, config.paths.tokenBase);
+    await utils.mkdirExists(fs, optionsDefaulted.nodePath);
+    const sessionTokenPath = path.join(
+      optionsDefaulted.nodePath,
+      config.paths.tokenBase,
+    );
     const session = await Session.createSession({
       sessionTokenPath,
       logger: logger.getChild(Session.name),
       fresh,
     });
-    const rpcClientClient = new RPCClient({
+    const webSocketClient = await WebSocketClient.createWebSocketClient(
+      {
+        host,
+        port,
+        config: {
+          verifyPeer: true,
+          verifyCallback: async (certs) => {
+            await clientUtils.verifyServerCertificateChain([nodeId_], certs);
+          },
+          keepAliveTimeoutTime: optionsDefaulted.keepAliveTimeoutTime,
+          keepAliveIntervalTime: optionsDefaulted.keepAliveIntervalTime,
+        },
+        logger: logger.getChild(WebSocketClient.name),
+      },
+      ctx,
+    );
+    const rpcClient = new RPCClient({
       manifest: clientClientManifest,
-      streamFactory,
+      streamFactory: () => webSocketClient.connection.newStream(),
       middlewareFactory: rpcMiddleware.defaultClientMiddlewareWrapper(
         clientMiddleware.middlewareClient(session),
-        parserBufferByteLimit,
+        optionsDefaulted.rpcParserBufferSize,
       ),
       toError: networkUtils.toError,
-      streamKeepAliveTimeoutTime,
+      streamKeepAliveTimeoutTime: optionsDefaulted.rpcCallTimeoutTime,
       logger: logger.getChild(RPCClient.name),
     });
     const pkClient = new this({
-      nodePath,
-      rpcClientClient: rpcClientClient,
+      nodePath: optionsDefaulted.nodePath,
+      webSocketClient,
+      rpcClient,
       session,
       fs,
       logger,
@@ -86,29 +180,53 @@ class PolykeyClient {
 
   public readonly nodePath: string;
   public readonly session: Session;
-  public readonly rpcClientClient: RPCClient<typeof clientClientManifest>;
+  public readonly webSocketClient: WebSocketClient;
+  public readonly rpcClient: RPCClient<typeof clientClientManifest>;
 
   protected fs: FileSystem;
   protected logger: Logger;
 
   constructor({
     nodePath,
-    rpcClientClient,
+    webSocketClient,
+    rpcClient,
     session,
     fs,
     logger,
   }: {
     nodePath: string;
-    rpcClientClient: RPCClient<typeof clientClientManifest>;
+    webSocketClient: WebSocketClient;
+    rpcClient: RPCClient<typeof clientClientManifest>;
     session: Session;
     fs: FileSystem;
     logger: Logger;
   }) {
     this.logger = logger;
     this.nodePath = nodePath;
+    this.webSocketClient = webSocketClient;
+    this.rpcClient = rpcClient;
     this.session = session;
-    this.rpcClientClient = rpcClientClient;
     this.fs = fs;
+  }
+
+  @ready(new errors.ErrorPolykeyClientNotRunning())
+  public get host() {
+    return this.webSocketClient.connection.remoteHost;
+  }
+
+  @ready(new errors.ErrorPolykeyClientNotRunning())
+  public get port() {
+    return this.webSocketClient.connection.remotePort;
+  }
+
+  @ready(new errors.ErrorPolykeyClientNotRunning())
+  public get localHost() {
+    return this.webSocketClient.connection.localHost;
+  }
+
+  @ready(new errors.ErrorPolykeyClientNotRunning())
+  public get localPort() {
+    return this.webSocketClient.connection.localPort;
   }
 
   public async start(): Promise<void> {
@@ -122,11 +240,14 @@ class PolykeyClient {
     this.logger.info(`Stopped ${this.constructor.name}`);
   }
 
-  public async destroy() {
+  public async destroy({ force = false }: { force?: boolean }) {
     this.logger.info(`Destroying ${this.constructor.name}`);
+    await this.webSocketClient.destroy({ force });
     await this.session.destroy();
     this.logger.info(`Destroyed ${this.constructor.name}`);
   }
 }
 
 export default PolykeyClient;
+
+export type { PolykeyClientOptions };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
-import type { Host, Port } from './network/types';
+import type { PasswordMemLimit, PasswordOpsLimit } from './keys/types';
 import type { NodeAddress } from './nodes/types';
+import type { Host, Port } from './network/types';
 import { getDefaultNodePath } from './utils';
 // @ts-ignore package.json is outside rootDir
 import { version } from '../package.json';
@@ -253,6 +254,33 @@ const config = {
    */
   defaultsUser: {
     nodePath: getDefaultNodePath(),
+    /**
+     * Ops limit for password hashing.
+     *
+     * This is the moderate choice: 0.7 seconds on 2.8 Ghz Intel Core i7.
+     * This can only be set when a new password is set.
+     * If this changes, the password hash for the same password will change.
+     */
+    passwordOpsLimit: 3 as PasswordOpsLimit,
+    /**
+     * Memory limit for password hashing.
+     *
+     * This is the moderate choice: requiring at least 512 MiB of memory.
+     * This can only be set when a new password is set.
+     * If this changes, the password hash for the same password will change.
+     */
+    passwordMemLimit: 268435456 as PasswordMemLimit,
+    /**
+     * Locking sensitive memory from being swapped to disk.
+     *
+     * Locks the memory used for keys and password hashes to prevent swapping.
+     * On some systems, this can also prevent the memory being included during
+     * core dumps.
+     *
+     * This should be disabled during testing, as only a limited amount of
+     * memory is allowed to be locked.
+     */
+    strictMemoryLock: true,
     certDuration: 31536000,
     certRenewLeadTime: 86400,
     /**

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -41,6 +41,16 @@ class ErrorPolykeyClientDestroyed<T> extends ErrorPolykey<T> {
   exitCode = sysexits.USAGE;
 }
 
+class ErrorPolykeyClientCreateTimeout<T> extends ErrorPolykey<T> {
+  static description = 'PolykeyClient create timeout';
+  exitCode = sysexits.UNAVAILABLE;
+}
+
+class ErrorPolykeyClientNodeIdInvalid<T> extends ErrorPolykey<T> {
+  static description = 'PolykeyClient failed parsing encoded node ID';
+  exitCode = sysexits.USAGE;
+}
+
 export {
   sysexits,
   ErrorPolykey,
@@ -52,6 +62,8 @@ export {
   ErrorPolykeyClientRunning,
   ErrorPolykeyClientNotRunning,
   ErrorPolykeyClientDestroyed,
+  ErrorPolykeyClientCreateTimeout,
+  ErrorPolykeyClientNodeIdInvalid,
 };
 
 /**

--- a/src/ids/index.ts
+++ b/src/ids/index.ts
@@ -43,14 +43,37 @@ function createNodeIdGenerator(): () => NodeId {
   };
 }
 
-function parseNodeId(data: any): NodeId {
-  data = decodeNodeId(data);
-  if (data == null) {
+function isNodeId(nodeId: any): nodeId is NodeId {
+  if (!(nodeId instanceof IdInternal)) {
+    return false;
+  }
+  if (nodeId.length !== 32) {
+    return false;
+  }
+  return true;
+}
+
+function assertNodeId(nodeId: unknown): asserts nodeId is NodeId {
+  if (!(nodeId instanceof IdInternal)) {
+    throw new validationErrors.ErrorParse('must be instance of Id');
+  }
+  if (nodeId.length !== 32) {
+    throw new validationErrors.ErrorParse('must be 32 bytes long');
+  }
+}
+
+function generateNodeId(nodeId: NodeId): NodeIdEncoded {
+  return encodeNodeId(nodeId);
+}
+
+function parseNodeId(nodeIdEncoded: unknown): NodeId {
+  const nodeId = decodeNodeId(nodeIdEncoded);
+  if (nodeId == null) {
     throw new validationErrors.ErrorParse(
       'Node ID must be multibase base32hex encoded public-keys',
     );
   }
-  return data;
+  return nodeId;
 }
 
 /**
@@ -426,6 +449,9 @@ function decodeNotificationId(
 export {
   createPermIdGenerator,
   createNodeIdGenerator,
+  isNodeId,
+  assertNodeId,
+  generateNodeId,
   parseNodeId,
   encodeNodeId,
   decodeNodeId,

--- a/src/keys/CertManager.ts
+++ b/src/keys/CertManager.ts
@@ -8,7 +8,6 @@ import type {
   KeyPair,
   RecoveryCode,
   CertificatePEMChain,
-  CertManagerOptions,
 } from './types';
 import type KeyRing from './KeyRing';
 import type TaskManager from '../tasks/TaskManager';
@@ -26,7 +25,6 @@ import * as keysUtils from './utils';
 import * as keysErrors from './errors';
 import * as keysEvents from './events';
 import * as ids from '../ids';
-import * as utils from '../utils/utils';
 import config from '../config';
 
 /**
@@ -68,7 +66,8 @@ class CertManager {
     db,
     keyRing,
     taskManager,
-    options = {},
+    certDuration = config.defaultsUser.certDuration,
+    certRenewLeadTime = config.defaultsUser.certRenewLeadTime,
     workerManager,
     logger = new Logger(this.name),
     subjectAttrsExtra,
@@ -79,7 +78,8 @@ class CertManager {
     db: DB;
     keyRing: KeyRing;
     taskManager: TaskManager;
-    options?: Partial<CertManagerOptions>;
+    certDuration?: number;
+    certRenewLeadTime?: number;
     workerManager?: PolykeyWorkerManagerInterface;
     logger?: Logger;
     subjectAttrsExtra?: Array<{ [key: string]: Array<string> }>;
@@ -89,15 +89,12 @@ class CertManager {
     fresh?: boolean;
   }): Promise<CertManager> {
     logger.info(`Creating ${this.name}`);
-    const optionsDefaulted = utils.mergeObjects(options, {
-      certDuration: config.defaultsUser.certDuration,
-      certRenewLeadTime: config.defaultsUser.certRenewLeadTime,
-    }) as CertManagerOptions;
     const certManager = new this({
       db,
       keyRing,
       taskManager,
-      options: optionsDefaulted,
+      certDuration,
+      certRenewLeadTime,
       workerManager,
       logger,
     });
@@ -153,14 +150,16 @@ class CertManager {
     db,
     keyRing,
     taskManager,
-    options,
+    certDuration,
+    certRenewLeadTime,
     workerManager,
     logger,
   }: {
     db: DB;
     keyRing: KeyRing;
     taskManager: TaskManager;
-    options: CertManagerOptions;
+    certDuration: number;
+    certRenewLeadTime: number;
     workerManager?: PolykeyWorkerManagerInterface;
     logger: Logger;
   }) {
@@ -168,8 +167,8 @@ class CertManager {
     this.db = db;
     this.keyRing = keyRing;
     this.taskManager = taskManager;
-    this.certDuration = options.certDuration;
-    this.certRenewLeadTime = options.certRenewLeadTime;
+    this.certDuration = certDuration;
+    this.certRenewLeadTime = certRenewLeadTime;
     this.workerManager = workerManager;
   }
 

--- a/src/keys/types.ts
+++ b/src/keys/types.ts
@@ -1,6 +1,6 @@
 import type { X509Certificate } from '@peculiar/x509';
 import type { NodeId } from '../ids/types';
-import type { Opaque, InverseRecord, ObjectEmpty } from '../types';
+import type { Opaque, InverseRecord } from '../types';
 
 /**
  * Locked buffer wrapper type for sensitive in-memory data.
@@ -213,7 +213,21 @@ type PasswordHash = Opaque<'PasswordHash', Buffer>;
 
 type PasswordSalt = Opaque<'PasswordSalt', Buffer>;
 
+type PasswordOpsLimitChoice =
+  | 'min'
+  | 'max'
+  | 'interactive'
+  | 'moderate'
+  | 'sensitive';
+
 type PasswordOpsLimit = Opaque<'PasswordOpsLimit', number>;
+
+type PasswordMemLimitChoice =
+  | 'min'
+  | 'max'
+  | 'interactive'
+  | 'moderate'
+  | 'sensitive';
 
 type PasswordMemLimit = Opaque<'PasswordMemLimit', number>;
 
@@ -262,39 +276,6 @@ type CertManagerChangeData = {
   recoveryCode?: RecoveryCode;
 };
 
-/**
- * Used by the PolykeyAgent for it's top level options
- */
-type KeysOptions = KeyRingOptions & CertManagerOptions;
-
-/**
- * Options for the KeyRing
- */
-type KeyRingOptions = {
-  passwordOpsLimit?: PasswordOpsLimit;
-  passwordMemLimit?: PasswordMemLimit;
-  strictMemoryLock: boolean;
-} & (
-  | ObjectEmpty
-  | {
-      recoveryCode: RecoveryCode;
-    }
-  | {
-      privateKey: PrivateKey;
-    }
-  | {
-      privateKeyPath: string;
-    }
-);
-
-/**
- * Options for the CertManager
- */
-type CertManagerOptions = {
-  certDuration: number;
-  certRenewLeadTime: number;
-};
-
 export type {
   BufferLocked,
   Key,
@@ -322,7 +303,9 @@ export type {
   MAC,
   PasswordHash,
   PasswordSalt,
+  PasswordOpsLimitChoice,
   PasswordOpsLimit,
+  PasswordMemLimitChoice,
   PasswordMemLimit,
   RecoveryCode,
   RecoveryCodeLocked,
@@ -331,9 +314,6 @@ export type {
   CertificatePEM,
   CertificatePEMChain,
   CertManagerChangeData,
-  KeysOptions,
-  KeyRingOptions,
-  CertManagerOptions,
 };
 
 export type { CertId, CertIdString, CertIdEncoded } from '../ids/types';

--- a/src/keys/utils/password.ts
+++ b/src/keys/utils/password.ts
@@ -1,7 +1,9 @@
 import type {
   PasswordHash,
   PasswordSalt,
+  PasswordOpsLimitChoice,
   PasswordOpsLimit,
+  PasswordMemLimitChoice,
   PasswordMemLimit,
 } from '../types';
 import sodium from 'sodium-native';
@@ -11,13 +13,7 @@ import * as keysErrors from '../errors';
 /**
  * Use the `min` limit during testing to improve performance.
  */
-const passwordOpsLimits: {
-  min: PasswordOpsLimit;
-  max: PasswordOpsLimit;
-  interactive: PasswordOpsLimit;
-  moderate: PasswordOpsLimit;
-  sensitive: PasswordOpsLimit;
-} = {
+const passwordOpsLimits: Record<PasswordOpsLimitChoice, PasswordOpsLimit> = {
   min: sodium.crypto_pwhash_OPSLIMIT_MIN,
   max: sodium.crypto_pwhash_OPSLIMIT_MAX,
   interactive: sodium.crypto_pwhash_OPSLIMIT_INTERACTIVE,
@@ -28,13 +24,7 @@ const passwordOpsLimits: {
 /**
  * Use the `min` limit during testing to improve performance.
  */
-const passwordMemLimits: {
-  min: PasswordMemLimit;
-  max: PasswordMemLimit;
-  interactive: PasswordMemLimit;
-  moderate: PasswordMemLimit;
-  sensitive: PasswordMemLimit;
-} = {
+const passwordMemLimits: Record<PasswordMemLimitChoice, PasswordMemLimit> = {
   min: sodium.crypto_pwhash_MEMLIMIT_MIN,
   max: sodium.crypto_pwhash_MEMLIMIT_MAX,
   interactive: sodium.crypto_pwhash_MEMLIMIT_INTERACTIVE,

--- a/src/nodes/types.ts
+++ b/src/nodes/types.ts
@@ -26,17 +26,6 @@ type NodeData = {
 
 type SeedNodes = Record<NodeIdEncoded, NodeAddress>;
 
-type NodesOptions = {
-  connectionIdleTimeoutTime: number;
-  connectionFindConcurrencyLimit: number;
-  connectionConnectTimeoutTime: number;
-  connectionKeepAliveTimeoutTime: number;
-  connectionKeepAliveIntervalTime: number;
-  connectionHolePunchIntervalTime: number;
-  rpcParserBufferSize: number;
-  rpcCallTimeoutTime: number;
-};
-
 export type {
   NodeId,
   NodeIdString,
@@ -48,5 +37,4 @@ export type {
   NodeBucket,
   NodeData,
   NodeGraphSpace,
-  NodesOptions,
 };

--- a/tests/PolykeyClient.test.ts
+++ b/tests/PolykeyClient.test.ts
@@ -2,114 +2,182 @@ import type { SessionToken } from '@/sessions/types';
 import os from 'os';
 import path from 'path';
 import fs from 'fs';
+import net from 'net';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
-import { WebSocketClient } from '@matrixai/ws';
-import { PolykeyClient, PolykeyAgent } from '@';
-import { Session } from '@/sessions';
+import {
+  utils as webSocketUtils,
+  errors as webSocketErrors,
+} from '@matrixai/ws';
+import PolykeyAgent from '@/PolykeyAgent';
+import PolykeyClient from '@/PolykeyClient';
+import Session from '@/sessions/Session';
 import config from '@/config';
+import * as ids from '@/ids';
 import * as clientUtils from '@/client/utils';
 import * as keysUtils from '@/keys/utils';
 import * as errors from '@/errors';
 import * as testUtils from './utils';
 
-describe('PolykeyClient', () => {
-  const password = 'password';
-  const localhost = '127.0.0.1';
-  const logger = new Logger('PolykeyClient Test', LogLevel.WARN, [
+describe(PolykeyClient.name, () => {
+  const logger = new Logger(`${PolykeyClient.name} Test`, LogLevel.WARN, [
     new StreamHandler(),
   ]);
+  const password = 'password';
+  const localHost = '127.0.0.1';
+  const nodeIdGenerator = ids.createNodeIdGenerator();
   let dataDir: string;
   let nodePath: string;
-  let pkAgent: PolykeyAgent;
   beforeEach(async () => {
     dataDir = await fs.promises.mkdtemp(
       path.join(os.tmpdir(), 'polykey-test-'),
     );
     nodePath = path.join(dataDir, 'polykey');
-    pkAgent = await PolykeyAgent.createPolykeyAgent({
-      password,
-      options: {
-        nodePath,
-        agentServiceHost: localhost,
-        clientServiceHost: localhost,
-        keys: {
-          passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-          passwordMemLimit: keysUtils.passwordMemLimits.min,
-          strictMemoryLock: false,
-        },
-      },
-      logger,
-    });
   });
   afterEach(async () => {
-    await pkAgent.stop();
     await fs.promises.rm(dataDir, {
       force: true,
       recursive: true,
     });
   });
-  test('preserving and destroying session state', async () => {
-    const session = await Session.createSession({
-      sessionTokenPath: path.join(nodePath, config.paths.tokenBase),
-      fs,
-      logger,
-    });
-    await session.writeToken('dummy' as SessionToken);
-    // Using fresh: true means that any token would be destroyed
-    const webSocketClient = await WebSocketClient.createWebSocketClient({
-      config: {
-        verifyPeer: false,
-      },
-      host: pkAgent.clientServiceHost,
-      port: pkAgent.clientServicePort,
-      logger,
-    });
-    const pkClient = await PolykeyClient.createPolykeyClient({
-      streamFactory: () => webSocketClient.connection.newStream(),
-      nodePath,
-      fs,
-      logger,
-      fresh: true,
-    });
-    expect(await session.readToken()).toBeUndefined();
-    await session.writeToken('abc' as SessionToken);
-    await pkClient.stop();
-    expect(await session.readToken()).toBeDefined();
-    await pkClient.destroy();
-    expect(await session.readToken()).toBeUndefined();
-    await webSocketClient.destroy({ force: true });
-  });
-  test('end to end with authentication logic', async () => {
-    const webSocketClient = await WebSocketClient.createWebSocketClient({
-      config: {
-        verifyPeer: true,
-        verifyCallback: async (certs) => {
-          await clientUtils.verifyServerCertificateChain(
-            [pkAgent.keyRing.getNodeId()],
-            certs,
-          );
+  test('connect to the nothing', async () => {
+    await expect(
+      PolykeyClient.createPolykeyClient({
+        nodeId: nodeIdGenerator(),
+        host: '127.0.0.1',
+        port: 1,
+        options: {
+          nodePath: nodePath,
         },
-      },
-      host: pkAgent.clientServiceHost,
-      port: pkAgent.clientServicePort,
-      logger: logger.getChild(WebSocketClient.name),
+        fs,
+        logger: logger.getChild(PolykeyClient.name),
+        fresh: true,
+      }),
+    ).rejects.toThrow(webSocketErrors.ErrorWebSocketConnectionLocal);
+  });
+  test('connect timeout', async () => {
+    const sockets: Array<net.Socket> = [];
+    const server = net.createServer((socket) => {
+      sockets.push(socket);
     });
-    const pkClient = await PolykeyClient.createPolykeyClient({
-      streamFactory: () => webSocketClient.connection.newStream(),
-      nodePath,
-      fs,
-      logger: logger.getChild(PolykeyClient.name),
-      fresh: true,
+    await new Promise<void>((resolve) => {
+      server.listen(0, () => {
+        resolve();
+      });
     });
-
-    const callP = pkClient.rpcClientClient.methods.agentStatus({});
-    await expect(callP).rejects.toThrow(errors.ErrorPolykeyRemote);
-    await testUtils.expectRemoteError(callP, errors.ErrorClientAuthMissing);
-    // Correct auth runs without error
-    await pkClient.rpcClientClient.methods.agentStatus({
-      metadata: {
-        authorization: clientUtils.encodeAuthFromPassword(password),
-      },
+    const serverPort = (server.address() as net.AddressInfo).port;
+    await expect(
+      PolykeyClient.createPolykeyClient(
+        {
+          nodeId: nodeIdGenerator(),
+          host: '127.0.0.1',
+          port: serverPort,
+          options: {
+            nodePath: nodePath,
+          },
+          fs,
+          logger: logger.getChild(PolykeyClient.name),
+          fresh: true,
+        },
+        { timer: 1000 },
+      ),
+    ).rejects.toThrow(errors.ErrorPolykeyClientCreateTimeout);
+    server.close();
+    for (const socket of sockets) {
+      socket.destroy();
+    }
+  });
+  describe('with polykey agent', () => {
+    let pkAgent: PolykeyAgent;
+    beforeEach(async () => {
+      pkAgent = await PolykeyAgent.createPolykeyAgent({
+        password,
+        options: {
+          nodePath,
+          agentServiceHost: localHost,
+          clientServiceHost: localHost,
+          keys: {
+            passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+            passwordMemLimit: keysUtils.passwordMemLimits.min,
+            strictMemoryLock: false,
+          },
+        },
+        logger: logger.getChild(PolykeyAgent.name),
+      });
+    });
+    afterEach(async () => {
+      await pkAgent.stop();
+    });
+    test('preserving and destroying session state', async () => {
+      const session = await Session.createSession({
+        sessionTokenPath: path.join(nodePath, config.paths.tokenBase),
+        fs,
+        logger,
+      });
+      await session.writeToken('dummy' as SessionToken);
+      const pkClient = await PolykeyClient.createPolykeyClient({
+        nodeId: pkAgent.keyRing.getNodeId(),
+        host: pkAgent.clientServiceHost,
+        port: pkAgent.clientServicePort,
+        options: {
+          nodePath,
+        },
+        fs,
+        logger: logger.getChild(PolykeyClient.name),
+        // Using fresh: true means that any token would be destroyed
+        fresh: true,
+      });
+      expect(await session.readToken()).toBeUndefined();
+      await session.writeToken('abc' as SessionToken);
+      await pkClient.stop();
+      expect(await session.readToken()).toBeDefined();
+      await pkClient.destroy({ force: true });
+      expect(await session.readToken()).toBeUndefined();
+    });
+    test('connect to agent client service', async () => {
+      const pkClient = await PolykeyClient.createPolykeyClient({
+        nodeId: pkAgent.keyRing.getNodeId(),
+        port: pkAgent.clientServicePort,
+        host: pkAgent.clientServiceHost,
+        options: {
+          nodePath: nodePath,
+        },
+        fs,
+        logger: logger.getChild(PolykeyClient.name),
+        fresh: true,
+      });
+      expect(pkClient.host).toBe(pkAgent.clientServiceHost);
+      expect(pkClient.port).toBe(pkAgent.clientServicePort);
+      const connectionMeta = pkClient.webSocketClient.connection.meta();
+      expect(connectionMeta.remoteCertsChain).toHaveLength(1);
+      const remoteCert = connectionMeta.remoteCertsChain[0];
+      const remoteCertPem = webSocketUtils.derToPEM(remoteCert);
+      const agentCertPem = await pkAgent.certManager.getCurrentCertPEM();
+      expect(remoteCertPem).toEqual(agentCertPem);
+      await pkClient.stop();
+    });
+    test('authenticated RPC request to agent client service', async () => {
+      const pkClient = await PolykeyClient.createPolykeyClient({
+        nodeId: pkAgent.keyRing.getNodeId(),
+        port: pkAgent.clientServicePort,
+        host: pkAgent.clientServiceHost,
+        options: {
+          nodePath: nodePath,
+        },
+        fs,
+        logger: logger.getChild(PolykeyClient.name),
+        fresh: true,
+      });
+      const callP = pkClient.rpcClient.methods.agentStatus({});
+      // Authentication error
+      await expect(callP).rejects.toThrow(errors.ErrorPolykeyRemote);
+      await testUtils.expectRemoteError(callP, errors.ErrorClientAuthMissing);
+      // Correct auth runs without error
+      await pkClient.rpcClient.methods.agentStatus({
+        metadata: {
+          authorization: clientUtils.encodeAuthFromPassword(password),
+        },
+      });
+      await pkClient.stop();
     });
   });
 });

--- a/tests/bootstrap/utils.test.ts
+++ b/tests/bootstrap/utils.test.ts
@@ -28,9 +28,7 @@ describe('bootstrap/utils', () => {
     const password = 'password';
     const recoveryCode = await bootstrapUtils.bootstrapState({
       password,
-      options: {
-        nodePath,
-      },
+      nodePath,
       fs,
       logger,
     });
@@ -56,9 +54,7 @@ describe('bootstrap/utils', () => {
     const password = 'password';
     const recoveryCode = await bootstrapUtils.bootstrapState({
       password,
-      options: {
-        nodePath,
-      },
+      nodePath,
       fs,
       logger,
     });
@@ -91,9 +87,7 @@ describe('bootstrap/utils', () => {
     await expect(
       bootstrapUtils.bootstrapState({
         password,
-        options: {
-          nodePath: nodePath1,
-        },
+        nodePath: nodePath1,
         fs,
         logger,
       }),
@@ -109,9 +103,7 @@ describe('bootstrap/utils', () => {
     await expect(
       bootstrapUtils.bootstrapState({
         password,
-        options: {
-          nodePath: nodePath2,
-        },
+        nodePath: nodePath2,
         fs,
         logger,
       }),
@@ -123,9 +115,7 @@ describe('bootstrap/utils', () => {
     await expect(
       bootstrapUtils.bootstrapState({
         password,
-        options: {
-          nodePath: nodePath3,
-        },
+        nodePath: nodePath3,
         fs,
         logger,
       }),
@@ -137,17 +127,13 @@ describe('bootstrap/utils', () => {
     const [result1, result2] = await Promise.allSettled([
       bootstrapUtils.bootstrapState({
         password,
-        options: {
-          nodePath,
-        },
+        nodePath,
         fs,
         logger,
       }),
       bootstrapUtils.bootstrapState({
         password,
-        options: {
-          nodePath,
-        },
+        nodePath,
         fs,
         logger,
       }),

--- a/tests/client/authenticationMiddleware.test.ts
+++ b/tests/client/authenticationMiddleware.test.ts
@@ -57,11 +57,9 @@ describe('authenticationMiddleware', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     taskManager = await TaskManager.createTaskManager({ db, logger });

--- a/tests/client/handlers/agent.test.ts
+++ b/tests/client/handlers/agent.test.ts
@@ -68,11 +68,9 @@ describe('agentLockAll', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     taskManager = await TaskManager.createTaskManager({ db, logger });
@@ -248,11 +246,9 @@ describe('agentStop', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     taskManager = await TaskManager.createTaskManager({ db, logger });
@@ -361,11 +357,9 @@ describe('agentUnlock', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     taskManager = await TaskManager.createTaskManager({ db, logger });

--- a/tests/client/handlers/gestalts.test.ts
+++ b/tests/client/handlers/gestalts.test.ts
@@ -108,11 +108,9 @@ describe('gestaltsActionsByIdentity', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     taskManager = await TaskManager.createTaskManager({ db, logger });
@@ -269,11 +267,9 @@ describe('gestaltsActionsByNode', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     taskManager = await TaskManager.createTaskManager({ db, logger });
@@ -407,11 +403,9 @@ describe('gestaltsDiscoveryByIdentity', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     taskManager = await TaskManager.createTaskManager({
@@ -586,11 +580,9 @@ describe('gestaltsDiscoveryByNode', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     taskManager = await TaskManager.createTaskManager({
@@ -757,11 +749,9 @@ describe('gestaltsGestaltGetByIdentity', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     taskManager = await TaskManager.createTaskManager({ db, logger });
@@ -906,11 +896,9 @@ describe('gestaltsGestaltGetByNode', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     taskManager = await TaskManager.createTaskManager({ db, logger });
@@ -1053,11 +1041,9 @@ describe('gestaltsGestaltList', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     taskManager = await TaskManager.createTaskManager({ db, logger });
@@ -1206,11 +1192,9 @@ describe('gestaltsGestaltTrustByIdentity', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     taskManager = await TaskManager.createTaskManager({
@@ -1579,11 +1563,9 @@ describe('gestaltsGestaltTrustByNode', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     taskManager = await TaskManager.createTaskManager({

--- a/tests/client/handlers/identities.test.ts
+++ b/tests/client/handlers/identities.test.ts
@@ -96,11 +96,9 @@ describe('identitiesAuthenticate', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     identitiesManager = await IdentitiesManager.createIdentitiesManager({
@@ -234,11 +232,9 @@ describe('identitiesAuthenticatedGet', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     identitiesManager = await IdentitiesManager.createIdentitiesManager({
@@ -496,11 +492,9 @@ describe('identitiesClaim', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     sigchain = await Sigchain.createSigchain({
@@ -641,11 +635,9 @@ describe('identitiesInfoConnectedGet', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     identitiesManager = await IdentitiesManager.createIdentitiesManager({
@@ -1327,11 +1319,9 @@ describe('identitiesInfoGet', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     identitiesManager = await IdentitiesManager.createIdentitiesManager({
@@ -1776,11 +1766,9 @@ describe('identitiesInvite', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     sigchain = await Sigchain.createSigchain({
@@ -1902,11 +1890,9 @@ describe('identitiesProvidersList', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     identitiesManager = await IdentitiesManager.createIdentitiesManager({
@@ -2005,11 +1991,9 @@ describe('identitiesTokenPutDeleteGet', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     identitiesManager = await IdentitiesManager.createIdentitiesManager({

--- a/tests/client/handlers/keys.test.ts
+++ b/tests/client/handlers/keys.test.ts
@@ -86,11 +86,9 @@ describe('keysCertsChainGet', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     identitiesManager = await IdentitiesManager.createIdentitiesManager({
@@ -200,11 +198,9 @@ describe('keysCertsGet', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     identitiesManager = await IdentitiesManager.createIdentitiesManager({
@@ -305,11 +301,9 @@ describe('keysEncrypt and keysDecrypt', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     identitiesManager = await IdentitiesManager.createIdentitiesManager({
@@ -406,11 +400,9 @@ describe('keysKeyPair', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     identitiesManager = await IdentitiesManager.createIdentitiesManager({
@@ -768,11 +760,9 @@ describe('keysPasswordChange', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     identitiesManager = await IdentitiesManager.createIdentitiesManager({
@@ -864,11 +854,9 @@ describe('keysPublicKey', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     identitiesManager = await IdentitiesManager.createIdentitiesManager({
@@ -963,11 +951,9 @@ describe('keysSign and keysVerify', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     identitiesManager = await IdentitiesManager.createIdentitiesManager({

--- a/tests/client/handlers/nodes.test.ts
+++ b/tests/client/handlers/nodes.test.ts
@@ -61,11 +61,9 @@ describe('nodesAdd', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     tlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);
@@ -89,10 +87,8 @@ describe('nodesAdd', () => {
       nodeGraph,
       // TLS not needed for this test
       tlsConfig: {} as TLSConfig,
-      options: {
-        connectionConnectTimeoutTime: 2000,
-        connectionIdleTimeoutTime: 2000,
-      },
+      connectionConnectTimeoutTime: 2000,
+      connectionIdleTimeoutTime: 2000,
       logger: logger.getChild('NodeConnectionManager'),
     });
     nodeManager = new NodeManager({
@@ -270,11 +266,9 @@ describe('nodesClaim', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     tlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);
@@ -303,10 +297,8 @@ describe('nodesClaim', () => {
       nodeGraph,
       // TLS not needed for this test
       tlsConfig: {} as TLSConfig,
-      options: {
-        connectionConnectTimeoutTime: 2000,
-        connectionIdleTimeoutTime: 2000,
-      },
+      connectionConnectTimeoutTime: 2000,
+      connectionIdleTimeoutTime: 2000,
       logger: logger.getChild('NodeConnectionManager'),
     });
     nodeManager = new NodeManager({
@@ -441,11 +433,9 @@ describe('nodesFind', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     tlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);
@@ -469,10 +459,8 @@ describe('nodesFind', () => {
       nodeGraph,
       // TLS not needed for this test
       tlsConfig: {} as TLSConfig,
-      options: {
-        connectionConnectTimeoutTime: 2000,
-        connectionIdleTimeoutTime: 2000,
-      },
+      connectionConnectTimeoutTime: 2000,
+      connectionIdleTimeoutTime: 2000,
       logger: logger.getChild('NodeConnectionManager'),
     });
     await nodeConnectionManager.start({ host: localhost as Host });
@@ -572,11 +560,9 @@ describe('nodesPing', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     tlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);
@@ -605,10 +591,8 @@ describe('nodesPing', () => {
       nodeGraph,
       // TLS not needed for this test
       tlsConfig: {} as TLSConfig,
-      options: {
-        connectionConnectTimeoutTime: 2000,
-        connectionIdleTimeoutTime: 2000,
-      },
+      connectionConnectTimeoutTime: 2000,
+      connectionIdleTimeoutTime: 2000,
       logger: logger.getChild('NodeConnectionManager'),
     });
     nodeManager = new NodeManager({

--- a/tests/client/handlers/notifications.test.ts
+++ b/tests/client/handlers/notifications.test.ts
@@ -71,11 +71,9 @@ describe('notificationsClear', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     tlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);
@@ -108,10 +106,8 @@ describe('notificationsClear', () => {
       nodeGraph,
       // TLS not needed for this test
       tlsConfig: {} as TLSConfig,
-      options: {
-        connectionConnectTimeoutTime: 2000,
-        connectionIdleTimeoutTime: 2000,
-      },
+      connectionConnectTimeoutTime: 2000,
+      connectionIdleTimeoutTime: 2000,
       logger: logger.getChild('NodeConnectionManager'),
     });
     nodeManager = new NodeManager({
@@ -230,11 +226,9 @@ describe('notificationsRead', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     tlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);
@@ -267,10 +261,8 @@ describe('notificationsRead', () => {
       nodeGraph,
       // TLS not needed for this test
       tlsConfig: {} as TLSConfig,
-      options: {
-        connectionConnectTimeoutTime: 2000,
-        connectionIdleTimeoutTime: 2000,
-      },
+      connectionConnectTimeoutTime: 2000,
+      connectionIdleTimeoutTime: 2000,
       logger: logger.getChild('NodeConnectionManager'),
     });
     nodeManager = new NodeManager({
@@ -616,11 +608,9 @@ describe('notificationsSend', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     tlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);
@@ -652,10 +642,8 @@ describe('notificationsSend', () => {
       keyRing,
       nodeGraph,
       tlsConfig: {} as TLSConfig,
-      options: {
-        connectionConnectTimeoutTime: 2000,
-        connectionIdleTimeoutTime: 2000,
-      },
+      connectionConnectTimeoutTime: 2000,
+      connectionIdleTimeoutTime: 2000,
       logger: logger.getChild('NodeConnectionManager'),
     });
     nodeManager = new NodeManager({

--- a/tests/client/handlers/vaults.test.ts
+++ b/tests/client/handlers/vaults.test.ts
@@ -89,11 +89,9 @@ describe('vaultsClone', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     // TlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);
@@ -155,11 +153,9 @@ describe('vaultsCreate and vaultsDelete and vaultsList', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     tlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);
@@ -292,11 +288,9 @@ describe('vaultsLog', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     tlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);
@@ -447,11 +441,9 @@ describe('vaultsPermissionSet and vaultsPermissionUnset and vaultsPermissionGet'
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     tlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);
@@ -624,11 +616,9 @@ describe('vaultsPull', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     const dbPath = path.join(dataDir, 'db');
@@ -711,11 +701,9 @@ describe('vaultsRename', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     tlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);
@@ -809,11 +797,9 @@ describe('vaultsScan', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     const dbPath = path.join(dataDir, 'db');
@@ -872,11 +858,9 @@ describe('vaultsSecretsEdit', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     tlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);
@@ -987,11 +971,9 @@ describe('vaultsSecretsMkdir', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     tlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);
@@ -1097,11 +1079,9 @@ describe('vaultsSecretsNew and vaultsSecretsDelete, vaultsSecretsGet', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     tlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);
@@ -1234,11 +1214,9 @@ describe('vaultsSecretsNewDir and vaultsSecretsList', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     tlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);
@@ -1364,11 +1342,9 @@ describe('vaultsSecretsRename', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     tlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);
@@ -1480,11 +1456,9 @@ describe('vaultsSecretsStat', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     tlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);
@@ -1601,11 +1575,9 @@ describe('vaultsVersion', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     tlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);

--- a/tests/client/timeoutMiddleware.test.ts
+++ b/tests/client/timeoutMiddleware.test.ts
@@ -56,18 +56,15 @@ describe('timeoutMiddleware', () => {
       password,
       keysPath,
       logger,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
     });
     taskManager = await TaskManager.createTaskManager({ db, logger });
     certManager = await CertManager.createCertManager({
       db,
       keyRing,
       taskManager,
-      options: {},
       logger,
     });
     tlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);

--- a/tests/discovery/Discovery.test.ts
+++ b/tests/discovery/Discovery.test.ts
@@ -85,11 +85,9 @@ describe('Discovery', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger: logger.getChild('KeyRing'),
     });
     const dbPath = path.join(dataDir, 'db');
@@ -158,10 +156,8 @@ describe('Discovery', () => {
       keyRing,
       nodeGraph,
       tlsConfig,
-      options: {
-        connectionConnectTimeoutTime: 2000,
-        connectionIdleTimeoutTime: 2000,
-      },
+      connectionConnectTimeoutTime: 2000,
+      connectionIdleTimeoutTime: 2000,
       logger: logger.getChild('NodeConnectionManager'),
     });
     nodeManager = new NodeManager({

--- a/tests/identities/IdentitiesManager.test.ts
+++ b/tests/identities/IdentitiesManager.test.ts
@@ -329,11 +329,9 @@ describe('IdentitiesManager', () => {
       const keyRing = await KeyRing.createKeyRing({
         password: 'password',
         keysPath: path.join(dataDir, 'keys'),
-        options: {
-          strictMemoryLock: false,
-          passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-          passwordMemLimit: keysUtils.passwordMemLimits.min,
-        },
+        strictMemoryLock: false,
+        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+        passwordMemLimit: keysUtils.passwordMemLimits.min,
         logger,
         fresh: true,
       });

--- a/tests/keys/CertManager.test.ts
+++ b/tests/keys/CertManager.test.ts
@@ -39,12 +39,10 @@ describe(CertManager.name, () => {
     keyRing = await KeyRing.createKeyRing({
       keysPath,
       password,
-      options: {
-        privateKey,
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      privateKey,
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     dbPath = `${dataDir}/db`;

--- a/tests/keys/KeyRing.test.ts
+++ b/tests/keys/KeyRing.test.ts
@@ -30,10 +30,8 @@ describe(KeyRing.name, () => {
     const keyRing = await KeyRing.createKeyRing({
       keysPath,
       password,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
       logger,
     });
     await expect(async () => {
@@ -58,10 +56,8 @@ describe(KeyRing.name, () => {
     const keyRing = await KeyRing.createKeyRing({
       keysPath,
       password,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
       logger,
     });
     const keysPathContents = await fs.promises.readdir(keysPath);
@@ -81,10 +77,8 @@ describe(KeyRing.name, () => {
     const keyRing = await KeyRing.createKeyRing({
       keysPath,
       password,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
       logger,
     });
     const nodeId = keyRing.getNodeId();
@@ -110,10 +104,8 @@ describe(KeyRing.name, () => {
     const keyRing = await KeyRing.createKeyRing({
       keysPath,
       password,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
       logger,
     });
     const keysPathContents1 = await fs.promises.readdir(keysPath);
@@ -132,10 +124,8 @@ describe(KeyRing.name, () => {
       const keyRing = await KeyRing.createKeyRing({
         keysPath,
         password,
-        options: {
-          passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-          passwordMemLimit: keysUtils.passwordMemLimits.min,
-        },
+        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+        passwordMemLimit: keysUtils.passwordMemLimits.min,
         logger,
       });
       expect(await keyRing.checkPassword(password)).toBe(true);
@@ -149,10 +139,8 @@ describe(KeyRing.name, () => {
         keysPath,
         password: 'first password',
         logger,
-        options: {
-          passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-          passwordMemLimit: keysUtils.passwordMemLimits.min,
-        },
+        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+        passwordMemLimit: keysUtils.passwordMemLimits.min,
       });
       await keyRing.changePassword('second password');
       await keyRing.stop();
@@ -165,10 +153,8 @@ describe(KeyRing.name, () => {
         await KeyRing.createKeyRing({
           password: 'wrong password',
           keysPath,
-          options: {
-            passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-            passwordMemLimit: keysUtils.passwordMemLimits.min,
-          },
+          passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+          passwordMemLimit: keysUtils.passwordMemLimits.min,
           logger,
         });
       }).rejects.toThrow(keysErrors.ErrorKeyPairParse);
@@ -180,10 +166,8 @@ describe(KeyRing.name, () => {
       const keyRing = await KeyRing.createKeyRing({
         keysPath,
         password,
-        options: {
-          passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-          passwordMemLimit: keysUtils.passwordMemLimits.min,
-        },
+        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+        passwordMemLimit: keysUtils.passwordMemLimits.min,
         logger,
       });
       const nodeId = keyRing.getNodeId();
@@ -222,11 +206,9 @@ describe(KeyRing.name, () => {
       const keyRing1 = await KeyRing.createKeyRing({
         password,
         keysPath: keysPath1,
-        options: {
-          recoveryCode,
-          passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-          passwordMemLimit: keysUtils.passwordMemLimits.min,
-        },
+        recoveryCode,
+        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+        passwordMemLimit: keysUtils.passwordMemLimits.min,
         logger,
       });
       expect(keyRing1.recoveryCode).toBe(recoveryCode);
@@ -236,11 +218,9 @@ describe(KeyRing.name, () => {
       const keyRing2 = await KeyRing.createKeyRing({
         password,
         keysPath: keysPath2,
-        options: {
-          recoveryCode,
-          passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-          passwordMemLimit: keysUtils.passwordMemLimits.min,
-        },
+        recoveryCode,
+        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+        passwordMemLimit: keysUtils.passwordMemLimits.min,
         logger,
       });
       expect(keyRing2.recoveryCode).toBe(recoveryCode);
@@ -255,10 +235,8 @@ describe(KeyRing.name, () => {
       const keyRing = await KeyRing.createKeyRing({
         keysPath,
         password,
-        options: {
-          passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-          passwordMemLimit: keysUtils.passwordMemLimits.min,
-        },
+        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+        passwordMemLimit: keysUtils.passwordMemLimits.min,
         logger,
       });
       const keyPair = {
@@ -283,11 +261,9 @@ describe(KeyRing.name, () => {
       const keyRing = await KeyRing.createKeyRing({
         keysPath,
         password,
-        options: {
-          privateKey: keyPair.privateKey,
-          passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-          passwordMemLimit: keysUtils.passwordMemLimits.min,
-        },
+        privateKey: keyPair.privateKey,
+        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+        passwordMemLimit: keysUtils.passwordMemLimits.min,
         logger,
       });
       expect(keyRing.keyPair).toStrictEqual(keyPair);
@@ -313,11 +289,9 @@ describe(KeyRing.name, () => {
       const keyRing = await KeyRing.createKeyRing({
         keysPath,
         password: 'newpassword',
-        options: {
-          privateKeyPath: `${dataDir}/private-key.jwe`,
-          passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-          passwordMemLimit: keysUtils.passwordMemLimits.min,
-        },
+        privateKeyPath: `${dataDir}/private-key.jwe`,
+        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+        passwordMemLimit: keysUtils.passwordMemLimits.min,
         logger,
       });
       expect(keyRing.keyPair).toStrictEqual(keyPair);
@@ -339,11 +313,9 @@ describe(KeyRing.name, () => {
       const keyRing = await KeyRing.createKeyRing({
         keysPath,
         password: 'newpassword',
-        options: {
-          privateKeyPath: `${dataDir}/private-key.jwk`,
-          passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-          passwordMemLimit: keysUtils.passwordMemLimits.min,
-        },
+        privateKeyPath: `${dataDir}/private-key.jwk`,
+        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+        passwordMemLimit: keysUtils.passwordMemLimits.min,
         logger,
       });
       expect(keyRing.keyPair).toStrictEqual(keyPair);
@@ -364,10 +336,8 @@ describe(KeyRing.name, () => {
       keyRing = await KeyRing.createKeyRing({
         password,
         keysPath,
-        options: {
-          passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-          passwordMemLimit: keysUtils.passwordMemLimits.min,
-        },
+        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+        passwordMemLimit: keysUtils.passwordMemLimits.min,
         logger,
       });
     });
@@ -406,10 +376,8 @@ describe(KeyRing.name, () => {
       const keyRing = await KeyRing.createKeyRing({
         password,
         keysPath,
-        options: {
-          passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-          passwordMemLimit: keysUtils.passwordMemLimits.min,
-        },
+        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+        passwordMemLimit: keysUtils.passwordMemLimits.min,
         logger,
       });
       // Make a copy of the existing DB key

--- a/tests/keys/utils/password.test.ts
+++ b/tests/keys/utils/password.test.ts
@@ -1,0 +1,24 @@
+import * as password from '@/keys/utils/password';
+
+describe('keys/utils/password', () => {
+  test('password hashing ops limits raw numbers', () => {
+    expect(password.passwordOpsLimits['min']).toBe(1);
+    expect(password.passwordOpsLimits['interactive']).toBe(2);
+    expect(password.passwordOpsLimits['moderate']).toBe(3);
+    expect(password.passwordOpsLimits['sensitive']).toBe(4);
+    expect(password.passwordOpsLimits['max']).toBe(4294967295);
+    expect(password.passwordOpsLimitDefault).toBe(
+      password.passwordOpsLimits['moderate'],
+    );
+  });
+  test('password hashing mem limits raw numbers', () => {
+    expect(password.passwordMemLimits['min']).toBe(8192);
+    expect(password.passwordMemLimits['interactive']).toBe(67108864);
+    expect(password.passwordMemLimits['moderate']).toBe(268435456);
+    expect(password.passwordMemLimits['sensitive']).toBe(1073741824);
+    expect(password.passwordMemLimits['max']).toBe(4294966272);
+    expect(password.passwordMemLimitDefault).toBe(
+      password.passwordMemLimits['moderate'],
+    );
+  });
+});

--- a/tests/nodes/NodeConnectionManager.general.test.ts
+++ b/tests/nodes/NodeConnectionManager.general.test.ts
@@ -121,11 +121,9 @@ describe(`${NodeConnectionManager.name} general test`, () => {
       password,
       keysPath,
       logger,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
     });
     tlsConfig = await tlsTestUtils.createTLSConfig(keyRing.keyPair);
     const dbPath = path.join(dataDir, 'db');
@@ -228,10 +226,8 @@ describe(`${NodeConnectionManager.name} general test`, () => {
       keyRing,
       logger: logger.getChild(NodeConnectionManager.name),
       nodeGraph,
-      options: {
-        connectionKeepAliveTimeoutTime: 10000,
-        connectionKeepAliveIntervalTime: 1000,
-      },
+      connectionKeepAliveTimeoutTime: 10000,
+      connectionKeepAliveIntervalTime: 1000,
       tlsConfig,
       seedNodes: undefined,
     });
@@ -281,10 +277,8 @@ describe(`${NodeConnectionManager.name} general test`, () => {
       keyRing,
       logger: logger.getChild(NodeConnectionManager.name),
       nodeGraph,
-      options: {
-        connectionKeepAliveTimeoutTime: 10000,
-        connectionKeepAliveIntervalTime: 1000,
-      },
+      connectionKeepAliveTimeoutTime: 10000,
+      connectionKeepAliveIntervalTime: 1000,
       tlsConfig,
       seedNodes: undefined,
     });
@@ -327,10 +321,8 @@ describe(`${NodeConnectionManager.name} general test`, () => {
       keyRing,
       logger: logger.getChild(NodeConnectionManager.name),
       nodeGraph,
-      options: {
-        connectionKeepAliveTimeoutTime: 10000,
-        connectionKeepAliveIntervalTime: 1000,
-      },
+      connectionKeepAliveTimeoutTime: 10000,
+      connectionKeepAliveIntervalTime: 1000,
       tlsConfig,
       seedNodes: undefined,
     });
@@ -408,10 +400,8 @@ describe(`${NodeConnectionManager.name} general test`, () => {
       keyRing,
       logger: logger.getChild(NodeConnectionManager.name),
       nodeGraph,
-      options: {
-        connectionKeepAliveTimeoutTime: 10000,
-        connectionKeepAliveIntervalTime: 1000,
-      },
+      connectionKeepAliveTimeoutTime: 10000,
+      connectionKeepAliveIntervalTime: 1000,
       tlsConfig,
       seedNodes: undefined,
     });
@@ -489,10 +479,8 @@ describe(`${NodeConnectionManager.name} general test`, () => {
       keyRing,
       logger: logger.getChild(NodeConnectionManager.name),
       nodeGraph,
-      options: {
-        connectionKeepAliveTimeoutTime: 10000,
-        connectionKeepAliveIntervalTime: 1000,
-      },
+      connectionKeepAliveTimeoutTime: 10000,
+      connectionKeepAliveIntervalTime: 1000,
       tlsConfig,
       seedNodes: undefined,
     });

--- a/tests/nodes/NodeConnectionManager.lifecycle.test.ts
+++ b/tests/nodes/NodeConnectionManager.lifecycle.test.ts
@@ -65,12 +65,10 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     keyRingPeer = await KeyRing.createKeyRing({
       password,
       keysPath: keysPathPeer,
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
     });
     nodeConnectionManagerPeer1 = new NodeConnectionManager({
       keyRing: keyRingPeer,
@@ -98,12 +96,10 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
     });
     const dbPath = path.join(dataDir, 'db');
     db = await DB.createDB({
@@ -173,9 +169,7 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     nodeConnectionManager = new NodeConnectionManager({
       keyRing,
       nodeGraph,
-      options: {
-        connectionConnectTimeoutTime: 1000,
-      },
+      connectionConnectTimeoutTime: 1000,
       logger: logger.getChild(`${NodeConnectionManager.name}Local`),
       tlsConfig: clientTlsConfig,
       seedNodes: undefined,

--- a/tests/nodes/NodeConnectionManager.seednodes.test.ts
+++ b/tests/nodes/NodeConnectionManager.seednodes.test.ts
@@ -115,12 +115,10 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
     });
     const dbPath = path.join(dataDir, 'db');
     db = await DB.createDB({
@@ -186,9 +184,7 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
       keyRing,
       logger: logger.getChild(NodeConnectionManager.name),
       nodeGraph,
-      options: {
-        connectionConnectTimeoutTime: 1000,
-      },
+      connectionConnectTimeoutTime: 1000,
       tlsConfig,
       seedNodes,
     });
@@ -245,9 +241,7 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
       keyRing,
       logger: logger.getChild(NodeConnectionManager.name),
       nodeGraph,
-      options: {
-        connectionConnectTimeoutTime: 1000,
-      },
+      connectionConnectTimeoutTime: 1000,
       tlsConfig,
       seedNodes,
     });
@@ -300,9 +294,7 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
       keyRing,
       logger: logger.getChild(NodeConnectionManager.name),
       nodeGraph,
-      options: {
-        connectionConnectTimeoutTime: 1000,
-      },
+      connectionConnectTimeoutTime: 1000,
       tlsConfig,
       seedNodes,
     });
@@ -357,9 +349,7 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
       keyRing,
       logger: logger.getChild(NodeConnectionManager.name),
       nodeGraph,
-      options: {
-        connectionConnectTimeoutTime: 1000,
-      },
+      connectionConnectTimeoutTime: 1000,
       tlsConfig,
       seedNodes,
     });
@@ -419,9 +409,7 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
       keyRing,
       logger: logger.getChild(NodeConnectionManager.name),
       nodeGraph,
-      options: {
-        connectionConnectTimeoutTime: 1000,
-      },
+      connectionConnectTimeoutTime: 1000,
       tlsConfig,
       seedNodes,
     });
@@ -478,9 +466,7 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
       keyRing,
       logger: logger.getChild(NodeConnectionManager.name),
       nodeGraph,
-      options: {
-        connectionConnectTimeoutTime: 1000,
-      },
+      connectionConnectTimeoutTime: 1000,
       tlsConfig,
       seedNodes,
     });
@@ -538,9 +524,7 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
       keyRing,
       logger: logger.getChild(NodeConnectionManager.name),
       nodeGraph,
-      options: {
-        connectionConnectTimeoutTime: 1000,
-      },
+      connectionConnectTimeoutTime: 1000,
       tlsConfig,
       seedNodes,
     });

--- a/tests/nodes/NodeConnectionManager.timeout.test.ts
+++ b/tests/nodes/NodeConnectionManager.timeout.test.ts
@@ -75,11 +75,9 @@ describe(`${NodeConnectionManager.name} timeout test`, () => {
       password,
       keysPath,
       logger,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
     });
     const dbPath = path.join(dataDir, 'db');
     db = await DB.createDB({
@@ -113,10 +111,8 @@ describe(`${NodeConnectionManager.name} timeout test`, () => {
       nodeGraph,
       tlsConfig,
       seedNodes: undefined,
-      options: {
-        connectionConnectTimeoutTime: 1000,
-        connectionIdleTimeoutTime: 100,
-      },
+      connectionConnectTimeoutTime: 1000,
+      connectionIdleTimeoutTime: 100,
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
@@ -155,9 +151,7 @@ describe(`${NodeConnectionManager.name} timeout test`, () => {
       nodeGraph,
       tlsConfig,
       seedNodes: undefined,
-      options: {
-        connectionIdleTimeoutTime: 1000,
-      },
+      connectionIdleTimeoutTime: 1000,
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
@@ -212,9 +206,7 @@ describe(`${NodeConnectionManager.name} timeout test`, () => {
       nodeGraph,
       tlsConfig,
       seedNodes: undefined,
-      options: {
-        connectionIdleTimeoutTime: 1000,
-      },
+      connectionIdleTimeoutTime: 1000,
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
@@ -253,10 +245,8 @@ describe(`${NodeConnectionManager.name} timeout test`, () => {
       nodeGraph,
       tlsConfig,
       seedNodes: undefined,
-      options: {
-        connectionIdleTimeoutTime: 5000,
-        connectionConnectTimeoutTime: 200,
-      },
+      connectionIdleTimeoutTime: 5000,
+      connectionConnectTimeoutTime: 200,
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
@@ -280,10 +270,8 @@ describe(`${NodeConnectionManager.name} timeout test`, () => {
       nodeGraph,
       tlsConfig,
       seedNodes: undefined,
-      options: {
-        connectionIdleTimeoutTime: 5000,
-        connectionConnectTimeoutTime: 200,
-      },
+      connectionIdleTimeoutTime: 5000,
+      connectionConnectTimeoutTime: 200,
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
@@ -313,10 +301,8 @@ describe(`${NodeConnectionManager.name} timeout test`, () => {
       nodeGraph,
       tlsConfig,
       seedNodes: undefined,
-      options: {
-        connectionIdleTimeoutTime: 5000,
-        connectionConnectTimeoutTime: 200,
-      },
+      connectionIdleTimeoutTime: 5000,
+      connectionConnectTimeoutTime: 200,
     });
     await nodeConnectionManager.start({
       host: localHost as Host,

--- a/tests/nodes/NodeGraph.test.ts
+++ b/tests/nodes/NodeGraph.test.ts
@@ -40,11 +40,9 @@ describe(`${NodeGraph.name} test`, () => {
       password,
       keysPath,
       logger,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
     });
     dbKey = keysUtils.generateKey();
     dbPath = `${dataDir}/db`;

--- a/tests/nodes/NodeManager.test.ts
+++ b/tests/nodes/NodeManager.test.ts
@@ -64,11 +64,9 @@ describe(`${NodeManager.name} test`, () => {
       password,
       keysPath,
       logger,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
     });
     const dbPath = path.join(dataDir, 'db');
     db = await DB.createDB({

--- a/tests/nodes/agent/handlers/nodesClaimsGet.test.ts
+++ b/tests/nodes/agent/handlers/nodesClaimsGet.test.ts
@@ -51,11 +51,9 @@ describe('nodesClaimsGet', () => {
     keyRing = await KeyRing.createKeyRing({
       keysPath,
       password,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     const dbPath = path.join(dataDir, 'db');

--- a/tests/nodes/agent/handlers/nodesClosestLocalNode.test.ts
+++ b/tests/nodes/agent/handlers/nodesClosestLocalNode.test.ts
@@ -50,11 +50,9 @@ describe('nodesClosestLocalNode', () => {
     keyRing = await KeyRing.createKeyRing({
       keysPath,
       password,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     const dbPath = path.join(dataDir, 'db');

--- a/tests/nodes/agent/handlers/nodesCrossSignClaim.test.ts
+++ b/tests/nodes/agent/handlers/nodesCrossSignClaim.test.ts
@@ -66,11 +66,9 @@ describe('nodesCrossSignClaim', () => {
     keyRing = await KeyRing.createKeyRing({
       keysPath,
       password,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     remoteNodeId = keyRing.getNodeId();

--- a/tests/nodes/agent/handlers/nodesHolePunchMessage.test.ts
+++ b/tests/nodes/agent/handlers/nodesHolePunchMessage.test.ts
@@ -65,11 +65,9 @@ describe('nodesHolePunchMessage', () => {
     keyRing = await KeyRing.createKeyRing({
       keysPath,
       password,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     const dbPath = path.join(dataDir, 'db');
@@ -114,10 +112,8 @@ describe('nodesHolePunchMessage', () => {
       tlsConfig: tlsConfigClient,
       keyRing,
       nodeGraph,
-      options: {
-        connectionConnectTimeoutTime: 2000,
-        connectionIdleTimeoutTime: 2000,
-      },
+      connectionConnectTimeoutTime: 2000,
+      connectionIdleTimeoutTime: 2000,
       logger: logger.getChild('NodeConnectionManager'),
     });
     nodeManager = new NodeManager({

--- a/tests/nodes/agent/handlers/notificationsSend.test.ts
+++ b/tests/nodes/agent/handlers/notificationsSend.test.ts
@@ -70,11 +70,9 @@ describe('notificationsSend', () => {
     senderKeyRing = await KeyRing.createKeyRing({
       keysPath: senderKeysPath,
       password,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     senderNodeId = senderKeyRing.getNodeId();
@@ -84,11 +82,9 @@ describe('notificationsSend', () => {
     keyRing = await KeyRing.createKeyRing({
       keysPath,
       password,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     const dbPath = path.join(dataDir, 'db');
@@ -127,10 +123,8 @@ describe('notificationsSend', () => {
       tlsConfig: tlsConfigClient,
       keyRing,
       nodeGraph,
-      options: {
-        connectionConnectTimeoutTime: 2000,
-        connectionIdleTimeoutTime: 2000,
-      },
+      connectionConnectTimeoutTime: 2000,
+      connectionIdleTimeoutTime: 2000,
       logger: logger.getChild('NodeConnectionManager'),
     });
     nodeManager = new NodeManager({

--- a/tests/notifications/NotificationsManager.test.ts
+++ b/tests/notifications/NotificationsManager.test.ts
@@ -64,11 +64,9 @@ describe('NotificationsManager', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     const dbPath = path.join(dataDir, 'db');

--- a/tests/scratch.test.ts
+++ b/tests/scratch.test.ts
@@ -1,13 +1,6 @@
-import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
-
-// This is a 'scratch paper' test file for quickly running tests in the CI
+/**
+ * This is a 'scratch paper' test file for quickly running tests in the CI
+ */
 describe('scratch', () => {
-  const _logger = new Logger(`scratch test`, LogLevel.WARN, [
-    new StreamHandler(),
-  ]);
-
-  // We can't have empty test files so here is a sanity test
-  test('Should avoid empty test suite', async () => {
-    expect(1 + 1).toBe(2);
-  });
+  test('', async () => {});
 });

--- a/tests/sessions/SessionManager.test.ts
+++ b/tests/sessions/SessionManager.test.ts
@@ -30,11 +30,9 @@ describe('SessionManager', () => {
     keyRing = await KeyRing.createKeyRing({
       password,
       keysPath,
-      options: {
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     const dbPath = path.join(dataDir, 'db');

--- a/tests/sigchain/Sigchain.test.ts
+++ b/tests/sigchain/Sigchain.test.ts
@@ -35,12 +35,10 @@ describe(Sigchain.name, () => {
     keyRing = await KeyRing.createKeyRing({
       keysPath,
       password,
-      options: {
-        privateKey,
-        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-        passwordMemLimit: keysUtils.passwordMemLimits.min,
-        strictMemoryLock: false,
-      },
+      privateKey,
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
       logger,
     });
     dbPath = `${dataDir}/db`;

--- a/tests/vaults/VaultManager.test.ts
+++ b/tests/vaults/VaultManager.test.ts
@@ -555,11 +555,9 @@ describe('VaultManager', () => {
       keyRing = await KeyRing.createKeyRing({
         keysPath: path.join(allDataDir, 'allKeyRing'),
         password: 'password',
-        options: {
-          passwordOpsLimit: keysUtils.passwordOpsLimits.min,
-          passwordMemLimit: keysUtils.passwordMemLimits.min,
-          strictMemoryLock: false,
-        },
+        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+        passwordMemLimit: keysUtils.passwordMemLimits.min,
+        strictMemoryLock: false,
         logger,
       });
       localNodeId = keyRing.getNodeId();


### PR DESCRIPTION
### Description

This PR aims to encapsulate WebSocketClient in PolykeyClient.

At the same time `Options` usage has to be limited to only `PolykeyAgent` and `PolykeyClient`.

Because:

1. Subdomains aren't really meant to have "options". They are just groups of classes closely related, that may or may not be factored out in a separate package one day.
2. Classes themselves have options - more correctly as parameters. As parameters, they should be top level, not nested within a `options`. Why? Because you can just do `X.createX({ param1, param2 });`, no need to do `X.createX({ options: { param1, param2 });` as the `options` is superfluous.
3. But why does `PolykeyAgent` and `PolykeyClient` have `options`? The reason is simply because there is so many parameters, that it is useful to have a separate type to keep track of them all. But this is exceptional to `PolykeyAgent` and `PolykeyClient`, it should not be considered the default way of creating classes in our codebase. And this type `PolykeyAgentOptions` and `PolykeyClientOptions` will be used in various places, in particular tests that need to run many different variants of the Polykey program.
4. There should necessarily be an exact relationship between the parameters in each domain class, and the options of `PolykeyAgent` and `PolykeyClient`. We want to retain some flexibility here.

Thus we will design which will be put into `src/types.ts`:

```
type PolykeyAgentOptions
type PolykeyClientOptions
```

But all other domains will not do such a thing.

### Tasks

- [x] 1. Align `PolykeyClientOptions` with `PolykeyAgentOptions`
- [x] 2. Ensure that subdomains are just flattened parameters, not `options` which is unique only to `PolykeyClient` and `PolykeyAgent`.
- [x] 3. Encapsulate `WebSocketClient` into `PolykeyClient` and brought back `nodeId` as a necessary parameter, verification of the client service certificate is now done within `PolykeyClient`.
- [x] 4. Made `PolykeyClient` a `@timedCancellable` operation with the timeout defaulted to `config.defaultsSystem.clientConnectTimeoutTime`. This propagates down to the `await WebSocketClient.createWebSocketClient`.
- [x] 5. Created password ops limits and mem limits defaults in the config using the raw value and added tests to ensure that the raw values is maintained. It is now configured at the top level.
- [x] 6. Update all tests using `PolykeyAgent` and `PolykeyClient` and subdomains which was relying upon `options`, these call signatures are all changed.
- [x] 7. Test that the timed cancellable works for `PolykeyClient`.

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
