### PR TITLE
Local Polykey Node Discovery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@matrixai/events": "^3.2.3",
         "@matrixai/id": "^3.3.6",
         "@matrixai/logger": "^3.1.0",
+        "@matrixai/mdns": "^1.2.0",
         "@matrixai/quic": "^1.0.0",
         "@matrixai/resources": "^1.1.5",
         "@matrixai/rpc": "^0.2.4",
@@ -1517,6 +1518,48 @@
       "resolved": "https://registry.npmjs.org/@matrixai/logger/-/logger-3.1.0.tgz",
       "integrity": "sha512-C4JWpgbNik3V99bfGfDell5cH3JULD67eEq9CeXl4rYgsvanF8hhuY84ZYvndPhimt9qjA9/Z8uExKGoiv1zVw=="
     },
+    "node_modules/@matrixai/mdns": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/mdns/-/mdns-1.2.0.tgz",
+      "integrity": "sha512-0w9zjRFLG6iBpHmDsWrjEoWc1XhHwzfTGf5/Fp20th/EQyeFlrXW5GOoIEftTl9rNzvoSSH8UuWHdS1FqlGR1A==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@matrixai/async-cancellable": "^1.1.1",
+        "@matrixai/async-init": "^1.10.0",
+        "@matrixai/contexts": "^1.1.0",
+        "@matrixai/errors": "^1.1.7",
+        "@matrixai/events": "^3.2.0",
+        "@matrixai/logger": "^3.1.0",
+        "@matrixai/table": "^1.2.0",
+        "@matrixai/timer": "^1.1.1",
+        "canonicalize": "^2.0.0",
+        "ip-num": "^1.5.1"
+      },
+      "engines": {
+        "msvs": "2019",
+        "node": ">=19.0.0"
+      },
+      "optionalDependencies": {
+        "@matrixai/mdns-linux-x64": "1.2.0"
+      }
+    },
+    "node_modules/@matrixai/mdns-linux-x64": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/mdns-linux-x64/-/mdns-linux-x64-1.2.0.tgz",
+      "integrity": "sha512-ssxBGA8was5XNw3ZL+S/89bzIpfiKyeLD8ofbSVqL/CoKZmsTRuDtm4bJBtERvD99jlCW1Yodu+HyzgTnJqYVA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@matrixai/mdns/node_modules/canonicalize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.0.0.tgz",
+      "integrity": "sha512-ulDEYPv7asdKvqahuAY35c1selLdzDwHqugK92hfkzvlDCwXRRelDkR+Er33md/PtnpqHemgkuDPanZ4fiYZ8w=="
+    },
     "node_modules/@matrixai/quic": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@matrixai/quic/-/quic-1.0.0.tgz",
@@ -1605,6 +1648,14 @@
         "@matrixai/logger": "^3.1.0",
         "@streamparser/json": "^0.0.17",
         "ix": "^5.0.0"
+      }
+    },
+    "node_modules/@matrixai/table": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/table/-/table-1.2.0.tgz",
+      "integrity": "sha512-vMj9YygnigmtBVgbzhKQdchtRuPqGL6vutqRGTC0tcZKHYiNh08N6AGQMXoIUe+iYP9A1WNYg2M3LXZZ54xvGg==",
+      "dependencies": {
+        "resource-counter": "^1.2.4"
       }
     },
     "node_modules/@matrixai/timer": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@matrixai/events": "^3.2.3",
     "@matrixai/id": "^3.3.6",
     "@matrixai/logger": "^3.1.0",
+    "@matrixai/mdns": "^1.2.0",
     "@matrixai/quic": "^1.0.0",
     "@matrixai/resources": "^1.1.5",
     "@matrixai/rpc": "^0.2.4",

--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -175,7 +175,7 @@ class PolykeyAgent {
       mdns: {
         groups: config.defaultsSystem.mdnsGroups,
         port: config.defaultsSystem.mdnsPort,
-      }
+      },
     });
     // This can only happen if the caller didn't specify the node path and the
     // automatic detection failed
@@ -327,14 +327,14 @@ class PolykeyAgent {
         logger: logger.getChild(NodeGraph.name),
       });
       mdns = new MDNS({
-        logger: logger.getChild(MDNS.name)
+        logger: logger.getChild(MDNS.name),
       });
       await mdns.start({
         id: keyRing.getNodeId().toBuffer().readUint16BE(),
         hostname: nodesUtils.encodeNodeId(keyRing.getNodeId()),
         groups: optionsDefaulted.mdns.groups,
         port: optionsDefaulted.mdns.port,
-      })
+      });
       // Remove your own node ID if provided as a seed node
       const nodeIdOwnEncoded = nodesUtils.encodeNodeId(keyRing.getNodeId());
       delete optionsDefaulted.seedNodes[nodeIdOwnEncoded];
@@ -670,7 +670,7 @@ class PolykeyAgent {
         mdns: {
           groups: config.defaultsSystem.mdnsGroups,
           port: config.defaultsSystem.mdnsPort,
-        }
+        },
       });
       // Register event handlers
       this.certManager.addEventListener(
@@ -745,7 +745,7 @@ class PolykeyAgent {
         hostname: nodesUtils.encodeNodeId(this.keyRing.getNodeId()),
         groups: optionsDefaulted.mdns.groups,
         port: optionsDefaulted.mdns.port,
-      })
+      });
       await this.nodeManager.start();
       await this.nodeConnectionManager.start({
         host: optionsDefaulted.agentServiceHost,

--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -173,8 +173,8 @@ class PolykeyAgent {
           config.defaultsSystem.nodesConnectionHolePunchIntervalTime,
       },
       mdns: {
-        groups: config.defaultsSystem.agentMdnsGroups,
-        port: config.defaultsSystem.agentMdnsPort,
+        groups: config.defaultsSystem.mdnsGroups,
+        port: config.defaultsSystem.mdnsPort,
       }
     });
     // This can only happen if the caller didn't specify the node path and the

--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -711,6 +711,9 @@ class PolykeyAgent {
         host: optionsDefaulted.agentServiceHost,
         port: optionsDefaulted.agentServicePort,
         ipv6Only: optionsDefaulted.ipv6Only,
+        enableMdns: true,
+        mdnsGroups: optionsDefaulted.agentMdnsGroups,
+        mdnsPort: optionsDefaulted.agentMdnsPort,
         manifest: agentServerManifest({
           acl: this.acl,
           db: this.db,

--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -650,6 +650,10 @@ class PolykeyAgent {
         | { recoveryCode: string }
         | { privateKey: Buffer }
         | { privateKeyPath: string };
+      mdns: {
+        groups: Array<string>;
+        port: number;
+      };
     }>;
     workers?: number;
     fresh?: boolean;
@@ -663,6 +667,10 @@ class PolykeyAgent {
         agentServicePort: config.defaultsUser.agentServicePort,
         workers: config.defaultsUser.workers,
         ipv6Only: config.defaultsUser.ipv6Only,
+        mdns: {
+          groups: config.defaultsSystem.mdnsGroups,
+          port: config.defaultsSystem.mdnsPort,
+        }
       });
       // Register event handlers
       this.certManager.addEventListener(

--- a/src/client/handlers/NodesAdd.ts
+++ b/src/client/handlers/NodesAdd.ts
@@ -53,7 +53,7 @@ class NodesAdd extends UnaryHandler<
     // Pinging to authenticate the node
     if (
       (input.ping ?? false) &&
-      !(await nodeManager.pingNode(nodeId, { host, port }))
+      !(await nodeManager.pingNode(nodeId, [{ host, port, scopes: ['external'] }]))
     ) {
       throw new nodeErrors.ErrorNodePingFailed(
         'Failed to authenticate target node',

--- a/src/client/handlers/NodesAdd.ts
+++ b/src/client/handlers/NodesAdd.ts
@@ -53,7 +53,9 @@ class NodesAdd extends UnaryHandler<
     // Pinging to authenticate the node
     if (
       (input.ping ?? false) &&
-      !(await nodeManager.pingNode(nodeId, [{ host, port, scopes: ['external'] }]))
+      !(await nodeManager.pingNode(nodeId, [
+        { host, port, scopes: ['external'] },
+      ]))
     ) {
       throw new nodeErrors.ErrorNodePingFailed(
         'Failed to authenticate target node',

--- a/src/client/handlers/NodesFind.ts
+++ b/src/client/handlers/NodesFind.ts
@@ -40,7 +40,9 @@ class NodesFind extends UnaryHandler<
       },
     );
     const addresses = await nodeConnectionManager.findNodeAll(nodeId);
-    if (addresses.length === 0) throw new nodesErrors.ErrorNodeGraphNodeIdNotFound();
+    if (addresses.length === 0) {
+      throw new nodesErrors.ErrorNodeGraphNodeIdNotFound();
+    }
 
     return { addresses };
   };

--- a/src/client/handlers/NodesFind.ts
+++ b/src/client/handlers/NodesFind.ts
@@ -1,8 +1,8 @@
 import type {
-  AddressMessage,
   ClientRPCRequestParams,
   ClientRPCResponseResult,
   NodeIdMessage,
+  NodesFindMessage,
 } from '../types';
 import type { NodeId } from '../../ids';
 import type NodeConnectionManager from '../../nodes/NodeConnectionManager';
@@ -17,11 +17,11 @@ class NodesFind extends UnaryHandler<
     nodeConnectionManager: NodeConnectionManager;
   },
   ClientRPCRequestParams<NodeIdMessage>,
-  ClientRPCResponseResult<AddressMessage>
+  ClientRPCResponseResult<NodesFindMessage>
 > {
   public handle = async (
     input: ClientRPCRequestParams<NodeIdMessage>,
-  ): Promise<ClientRPCResponseResult<AddressMessage>> => {
+  ): Promise<ClientRPCResponseResult<NodesFindMessage>> => {
     const { nodeConnectionManager } = this.container;
 
     const {
@@ -39,13 +39,10 @@ class NodesFind extends UnaryHandler<
         nodeId: input.nodeIdEncoded,
       },
     );
-    const address = await nodeConnectionManager.findNode(nodeId);
-    if (address == null) throw new nodesErrors.ErrorNodeGraphNodeIdNotFound();
+    const addresses = await nodeConnectionManager.findNodeAll(nodeId);
+    if (addresses.length === 0) throw new nodesErrors.ErrorNodeGraphNodeIdNotFound();
 
-    return {
-      host: address.host,
-      port: address.port,
-    };
+    return { addresses };
   };
 }
 

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -113,7 +113,7 @@ type NodesFindMessage = {
   addresses: Array<AddressMessage>;
 };
 
-type NodesGetMessage = NodeAddressMessage &  { bucketIndex: number };
+type NodesGetMessage = NodeAddressMessage & { bucketIndex: number };
 
 type NodesAddMessage = NodeAddressMessage & {
   force?: boolean;

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -109,7 +109,11 @@ type AddressMessage = {
 
 type NodeAddressMessage = NodeIdMessage & AddressMessage;
 
-type NodesGetMessage = NodeAddressMessage & { bucketIndex: number };
+type NodesFindMessage = {
+  addresses: Array<AddressMessage>;
+};
+
+type NodesGetMessage = NodeAddressMessage &  { bucketIndex: number };
 
 type NodesAddMessage = NodeAddressMessage & {
   force?: boolean;
@@ -327,6 +331,7 @@ export type {
   NodeIdMessage,
   AddressMessage,
   NodeAddressMessage,
+  NodesFindMessage,
   NodeConnectionMessage,
   ActionsListMessage,
   SetIdentityActionMessage,

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,12 +13,12 @@ const testnet: Record<string, NodeAddress> = {
   v7v9ptvcdbdf8p4upok3prpmu3938ns8v4g45dib7sm5hqvvehv70: {
     host: 'testnet.polykey.com' as Host,
     port: 1314 as Port,
-    scopes: ['external']
+    scopes: ['external'],
   },
   v270ktdd3cs3mp1r3q3dkmick92bn927mii9or4sgroeogd1peqb0: {
     host: 'testnet.polykey.com' as Host,
     port: 1314 as Port,
-    scopes: ['external']
+    scopes: ['external'],
   },
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -257,7 +257,7 @@ const config = {
      * The default values of `224.0.0.250` and `ff02::fa17` have been selected due to
      * the resemblance of `fa17` to the latin word `fait`, and `250` being the decimal representation of that.
      */
-    agentMdnsGroups: ['224.0.0.250', 'ff02::fa17'],
+    mdnsGroups: ['224.0.0.250', 'ff02::fa17'],
     /**
      * The port that the MDNS stack will operate on.
      *
@@ -266,7 +266,7 @@ const config = {
      * The default value has been selected as the decimal decimal representation of `fa17`,
      * which resembles the latin word `fait`.
      */
-    agentMdnsPort: 64023,
+    mdnsPort: 64023,
   },
   /**
    * Default user configuration.

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,10 +13,12 @@ const testnet: Record<string, NodeAddress> = {
   v7v9ptvcdbdf8p4upok3prpmu3938ns8v4g45dib7sm5hqvvehv70: {
     host: 'testnet.polykey.com' as Host,
     port: 1314 as Port,
+    scopes: ['external']
   },
   v270ktdd3cs3mp1r3q3dkmick92bn927mii9or4sgroeogd1peqb0: {
     host: 'testnet.polykey.com' as Host,
     port: 1314 as Port,
+    scopes: ['external']
   },
 };
 
@@ -246,6 +248,25 @@ const config = {
      * Interval for hole punching reverse node connections.
      */
     nodesConnectionHolePunchIntervalTime: 1_000, // 1 second
+    /**
+     * Multicast group addresses that the MDNS stack will operate on.
+     *
+     * These values are well-known, and hence must not be changed by the user.
+     *
+     * The default values of these groups must start with either `224.0` (IPv4) or `ff02` (IPv6).
+     * The default values of `224.0.0.250` and `ff02::fa17` have been selected due to
+     * the resemblance of `fa17` to the latin word `fait`, and `250` being the decimal representation of that.
+     */
+    agentMdnsGroups: ['224.0.0.250', 'ff02::fa17'],
+    /**
+     * The port that the MDNS stack will operate on.
+     *
+     * This is well-known, and hence must not be changed by the user.
+     *
+     * The default value has been selected as the decimal decimal representation of `fa17`,
+     * which resembles the latin word `fait`.
+     */
+    agentMdnsPort: 64023,
   },
   /**
    * Default user configuration.

--- a/src/network/utils.ts
+++ b/src/network/utils.ts
@@ -448,17 +448,29 @@ async function resolveHostnames(
   addresses: Array<NodeAddress>,
   existingAddresses: Set<string> = new Set(),
 ): Promise<Array<{ host: Host; port: Port; scopes: Array<NodeAddressScope> }>> {
-  const final: Array<{ host: Host; port: Port; scopes: Array<NodeAddressScope> }> = [];
+  const final: Array<{
+    host: Host;
+    port: Port;
+    scopes: Array<NodeAddressScope>;
+  }> = [];
   for (const address of addresses) {
     if (isHost(address.host)) {
       if (existingAddresses.has(`${address.host}|${address.port}`)) continue;
-      final.push({ host: address.host, port: address.port, scopes: address.scopes });
+      final.push({
+        host: address.host,
+        port: address.port,
+        scopes: address.scopes,
+      });
       existingAddresses.add(`${address.host}|${address.port}`);
       continue;
     }
     const resolvedAddresses = await resolveHostname(address.host);
     for (const resolvedHost of resolvedAddresses) {
-      const newAddress = { host: resolvedHost, port: address.port, scopes: address.scopes };
+      const newAddress = {
+        host: resolvedHost,
+        port: address.port,
+        scopes: address.scopes,
+      };
       if (!Validator.isValidIPv4String(resolvedHost)[0]) continue;
       if (existingAddresses.has(`${resolvedHost}|${address.port}`)) continue;
       final.push(newAddress);

--- a/src/nodes/NodeConnection.ts
+++ b/src/nodes/NodeConnection.ts
@@ -230,6 +230,10 @@ class NodeConnection<M extends ClientManifest> {
     if (networkUtils.isHostWildcard(targetHost)) {
       throw new nodesErrors.ErrorNodeConnectionHostWildcard();
     }
+    // FIXME: support link-local addresses like `fe80::1cc7:8829:3d67:240d%wlp0s20f3`, QUIC currently hangs main thread when attempting a connection to this targetHost
+    if (targetHost.startsWith('fe80') || targetHost.includes('%')) {
+      throw new nodesErrors.ErrorNodeConnectionHostLinkLocal();
+    }
     let validatedNodeId: NodeId | undefined;
     let quicClient: QUICClient;
     try {

--- a/src/nodes/NodeManager.ts
+++ b/src/nodes/NodeManager.ts
@@ -141,8 +141,8 @@ class NodeManager {
       );
       never();
     }
-    if (await this.pingNode(nodeId, { host, port }, { signal: ctx.signal })) {
-      await this.setNode(nodeId, { host, port }, false, false, 2000, ctx);
+    if (await this.pingNode(nodeId, [{ host, port, scopes: ['external'] }], { signal: ctx.signal })) {
+      await this.setNode(nodeId, { host, port, scopes: ['external'] }, false, false, 2000, ctx);
     }
   };
   public readonly pingAndSetNodeHandlerId: TaskHandlerId =
@@ -210,6 +210,7 @@ class NodeManager {
       {
         host: e.detail.remoteHost,
         port: e.detail.remotePort,
+        scopes: ['external']
       },
       false,
       false,
@@ -329,12 +330,12 @@ class NodeManager {
    * Determines whether a node in the Polykey network is online.
    * @return true if online, false if offline
    * @param nodeId - NodeId of the node we're pinging
-   * @param address - Optional Host and Port we want to ping
+   * @param addresses - Optional Host and Port we want to ping
    * @param ctx
    */
   public pingNode(
     nodeId: NodeId,
-    address?: NodeAddress,
+    addresses?: Array<NodeAddress>,
     ctx?: Partial<ContextTimedInput>,
   ): PromiseCancellable<boolean>;
   @timedCancellable(
@@ -343,25 +344,24 @@ class NodeManager {
   )
   public async pingNode(
     nodeId: NodeId,
-    address: NodeAddress | undefined,
+    addresses: Array<NodeAddress> | undefined,
     @context ctx: ContextTimed,
   ): Promise<boolean> {
     // We need to attempt a connection using the proxies
     // For now we will just do a forward connect + relay message
-    const targetAddress =
-      address ??
-      (await this.nodeConnectionManager.findNode(
+    const targetAddresses =
+      addresses ??
+      (await this.nodeConnectionManager.findNodeAll(
         nodeId,
         this.connectionConnectTimeoutTime,
         ctx,
       ));
-    if (targetAddress == null) {
+    if (targetAddresses == null) {
       return false;
     }
     return await this.nodeConnectionManager.pingNode(
       nodeId,
-      targetAddress.host,
-      targetAddress.port,
+      targetAddresses,
       ctx,
     );
   }
@@ -864,7 +864,7 @@ class NodeManager {
           };
           const nodeAddress = await this.getNodeAddress(nodeId, tran);
           if (nodeAddress == null) never();
-          if (await this.pingNode(nodeId, nodeAddress, pingCtx)) {
+          if (await this.pingNode(nodeId, [nodeAddress], pingCtx)) {
             // Succeeded so update
             await this.setNode(
               nodeId,

--- a/src/nodes/NodeManager.ts
+++ b/src/nodes/NodeManager.ts
@@ -141,8 +141,19 @@ class NodeManager {
       );
       never();
     }
-    if (await this.pingNode(nodeId, [{ host, port, scopes: ['external'] }], { signal: ctx.signal })) {
-      await this.setNode(nodeId, { host, port, scopes: ['external'] }, false, false, 2000, ctx);
+    if (
+      await this.pingNode(nodeId, [{ host, port, scopes: ['external'] }], {
+        signal: ctx.signal,
+      })
+    ) {
+      await this.setNode(
+        nodeId,
+        { host, port, scopes: ['external'] },
+        false,
+        false,
+        2000,
+        ctx,
+      );
     }
   };
   public readonly pingAndSetNodeHandlerId: TaskHandlerId =
@@ -210,7 +221,7 @@ class NodeManager {
       {
         host: e.detail.remoteHost,
         port: e.detail.remotePort,
-        scopes: ['external']
+        scopes: ['external'],
       },
       false,
       false,

--- a/src/nodes/agent/handlers/NodesConnectionSignalInitial.ts
+++ b/src/nodes/agent/handlers/NodesConnectionSignalInitial.ts
@@ -52,6 +52,7 @@ class NodesConnectionSignalInitial extends UnaryHandler<
     const address: NodeAddress = {
       host: remoteHost as Host,
       port: remotePort as Port,
+      scopes: ['external']
     };
     nodeConnectionManager.handleNodesConnectionSignalInitial(
       requestingNodeId,

--- a/src/nodes/agent/handlers/NodesConnectionSignalInitial.ts
+++ b/src/nodes/agent/handlers/NodesConnectionSignalInitial.ts
@@ -52,7 +52,7 @@ class NodesConnectionSignalInitial extends UnaryHandler<
     const address: NodeAddress = {
       host: remoteHost as Host,
       port: remotePort as Port,
-      scopes: ['external']
+      scopes: ['external'],
     };
     nodeConnectionManager.handleNodesConnectionSignalInitial(
       requestingNodeId,

--- a/src/nodes/errors.ts
+++ b/src/nodes/errors.ts
@@ -72,7 +72,8 @@ class ErrorNodeConnectionHostWildcard<T> extends ErrorNodeConnection<T> {
 }
 
 class ErrorNodeConnectionHostLinkLocal<T> extends ErrorNodeConnection<T> {
-  static description = 'A link-local IPv6 address was provided for the target host, attempts to connect will fail due to being unsupported';
+  static description =
+    'A link-local IPv6 address was provided for the target host, attempts to connect will fail due to being unsupported';
   exitCode = sysexits.USAGE;
 }
 

--- a/src/nodes/errors.ts
+++ b/src/nodes/errors.ts
@@ -71,6 +71,11 @@ class ErrorNodeConnectionHostWildcard<T> extends ErrorNodeConnection<T> {
   exitCode = sysexits.USAGE;
 }
 
+class ErrorNodeConnectionHostLinkLocal<T> extends ErrorNodeConnection<T> {
+  static description = 'A link-local IPv6 address was provided for the target host, attempts to connect will fail due to being unsupported';
+  exitCode = sysexits.USAGE;
+}
+
 class ErrorNodeConnectionSameNodeId<T> extends ErrorNodeConnection<T> {
   static description =
     'Provided NodeId is the same as this agent, attempts to connect is improper usage';
@@ -127,6 +132,14 @@ class ErrorNodeConnectionManagerNodeIdRequired<
   exitCode = sysexits.USAGE;
 }
 
+class ErrorNodeConnectionManagerNodeAddressRequired<
+  T,
+> extends ErrorNodeConnectionManager<T> {
+  static description =
+    'No NodeAddress was provided for establishing a multi connection';
+  exitCode = sysexits.USAGE;
+}
+
 class ErrorNodeConnectionManagerMultiConnectionFailed<
   T,
 > extends ErrorNodeConnectionManager<T> {
@@ -178,6 +191,7 @@ export {
   ErrorNodeConnectionMultiConnectionFailed,
   ErrorNodeConnectionHostWildcard,
   ErrorNodeConnectionSameNodeId,
+  ErrorNodeConnectionHostLinkLocal,
   ErrorNodeConnectionInternalError,
   ErrorNodeConnectionTransportUnknownError,
   ErrorNodeConnectionTransportGenericError,
@@ -186,6 +200,7 @@ export {
   ErrorNodeConnectionManagerStopping,
   ErrorNodeConnectionManagerInternalError,
   ErrorNodeConnectionManagerNodeIdRequired,
+  ErrorNodeConnectionManagerNodeAddressRequired,
   ErrorNodeConnectionManagerMultiConnectionFailed,
   ErrorNodeConnectionManagerConnectionNotFound,
   ErrorNodeConnectionManagerRequestRateExceeded,

--- a/src/nodes/types.ts
+++ b/src/nodes/types.ts
@@ -6,9 +6,12 @@ import type { Host, Hostname, Port } from '../network/types';
  */
 type NodeGraphSpace = '0' | '1';
 
+type NodeAddressScope = 'local' | 'external';
+
 type NodeAddress = {
   host: Host | Hostname;
   port: Port;
+  scopes: Array<NodeAddressScope>;
 };
 
 type NodeBucketIndex = number;
@@ -30,6 +33,7 @@ export type {
   NodeId,
   NodeIdString,
   NodeIdEncoded,
+  NodeAddressScope,
   NodeAddress,
   SeedNodes,
   NodeBucketIndex,

--- a/tests/client/handlers/gestalts.test.ts
+++ b/tests/client/handlers/gestalts.test.ts
@@ -1628,7 +1628,7 @@ describe('gestaltsGestaltTrustByNode', () => {
     await nodeManager.setNode(nodeIdRemote, {
       host: node.agentServiceHost,
       port: node.agentServicePort,
-      scopes: ['external']
+      scopes: ['external'],
     });
     discovery = await Discovery.createDiscovery({
       db,

--- a/tests/client/handlers/gestalts.test.ts
+++ b/tests/client/handlers/gestalts.test.ts
@@ -1628,6 +1628,7 @@ describe('gestaltsGestaltTrustByNode', () => {
     await nodeManager.setNode(nodeIdRemote, {
       host: node.agentServiceHost,
       port: node.agentServicePort,
+      scopes: ['external']
     });
     discovery = await Discovery.createDiscovery({
       db,

--- a/tests/client/handlers/nodes.test.ts
+++ b/tests/client/handlers/nodes.test.ts
@@ -420,6 +420,7 @@ describe('nodesFind', () => {
       .mockResolvedValue({
         host: '127.0.0.1' as Host,
         port: 11111 as Port,
+        scopes: ['local']
       });
     dataDir = await fs.promises.mkdtemp(
       path.join(os.tmpdir(), 'polykey-test-'),
@@ -516,8 +517,9 @@ describe('nodesFind', () => {
       nodeIdEncoded:
         'vrsc24a1er424epq77dtoveo93meij0pc8ig4uvs9jbeld78n9nl0' as NodeIdEncoded,
     });
-    expect(response.host).toBe('127.0.0.1');
-    expect(response.port).toBe(11111);
+    const address = response.addresses.at(0);
+    expect(address?.host).toBe('127.0.0.1');
+    expect(address?.port).toBe(11111);
   });
   test('cannot find an invalid node', async () => {
     await testsUtils.expectRemoteError(

--- a/tests/client/handlers/nodes.test.ts
+++ b/tests/client/handlers/nodes.test.ts
@@ -420,7 +420,7 @@ describe('nodesFind', () => {
       .mockResolvedValue({
         host: '127.0.0.1' as Host,
         port: 11111 as Port,
-        scopes: ['local']
+        scopes: ['local'],
       });
     dataDir = await fs.promises.mkdtemp(
       path.join(os.tmpdir(), 'polykey-test-'),

--- a/tests/discovery/Discovery.test.ts
+++ b/tests/discovery/Discovery.test.ts
@@ -209,6 +209,7 @@ describe('Discovery', () => {
     await nodeGraph.setNode(nodeA.keyRing.getNodeId(), {
       host: nodeA.agentServiceHost,
       port: nodeA.agentServicePort,
+      scopes: ['external']
     });
     await nodeB.acl.setNodeAction(nodeA.keyRing.getNodeId(), 'claim');
     await nodeA.nodeManager.claimNode(nodeB.keyRing.getNodeId());

--- a/tests/discovery/Discovery.test.ts
+++ b/tests/discovery/Discovery.test.ts
@@ -209,7 +209,7 @@ describe('Discovery', () => {
     await nodeGraph.setNode(nodeA.keyRing.getNodeId(), {
       host: nodeA.agentServiceHost,
       port: nodeA.agentServicePort,
-      scopes: ['external']
+      scopes: ['external'],
     });
     await nodeB.acl.setNodeAction(nodeA.keyRing.getNodeId(), 'claim');
     await nodeA.nodeManager.claimNode(nodeB.keyRing.getNodeId());

--- a/tests/network/utils.test.ts
+++ b/tests/network/utils.test.ts
@@ -2,6 +2,21 @@ import type { Host, Hostname, Port } from '@/network/types';
 import * as networkUtils from '@/network/utils';
 
 describe('utils', () => {
+  test('validating hosts', () => {
+    // IPv4
+    expect(networkUtils.isHost('127.0.0.1')).toBeTrue();
+    // IPv6
+    expect(networkUtils.isHost('::')).toBeTrue();
+    expect(networkUtils.isHost('::0')).toBeTrue();
+    expect(networkUtils.isHost('2001:db8::')).toBeTrue();
+    expect(networkUtils.isHost('::1234:5678')).toBeTrue();
+    expect(networkUtils.isHost('2001:db8::1234:5678')).toBeTrue();
+    expect(networkUtils.isHost('2001:db8:1::ab9:C0A8:102')).toBeTrue();
+    expect(networkUtils.isHost('2001:db8:3333:4444:5555:6666:7777:8888')).toBeTrue();
+    expect(networkUtils.isHost('2001:0db8:0001:0000:0000:0ab9:C0A8:0102')).toBeTrue();
+    // Link-Local
+    expect(networkUtils.isHost('fe80::210:5aff:feaa:20a2%eth0')).toBeTrue();
+  });
   test('building addresses', async () => {
     expect(networkUtils.buildAddress('127.0.0.1' as Host, 0 as Port)).toBe(
       '127.0.0.1:0',

--- a/tests/network/utils.test.ts
+++ b/tests/network/utils.test.ts
@@ -12,8 +12,12 @@ describe('utils', () => {
     expect(networkUtils.isHost('::1234:5678')).toBeTrue();
     expect(networkUtils.isHost('2001:db8::1234:5678')).toBeTrue();
     expect(networkUtils.isHost('2001:db8:1::ab9:C0A8:102')).toBeTrue();
-    expect(networkUtils.isHost('2001:db8:3333:4444:5555:6666:7777:8888')).toBeTrue();
-    expect(networkUtils.isHost('2001:0db8:0001:0000:0000:0ab9:C0A8:0102')).toBeTrue();
+    expect(
+      networkUtils.isHost('2001:db8:3333:4444:5555:6666:7777:8888'),
+    ).toBeTrue();
+    expect(
+      networkUtils.isHost('2001:0db8:0001:0000:0000:0ab9:C0A8:0102'),
+    ).toBeTrue();
     // Link-Local
     expect(networkUtils.isHost('fe80::210:5aff:feaa:20a2%eth0')).toBeTrue();
   });

--- a/tests/nodes/NodeConnectionManager.general.test.ts
+++ b/tests/nodes/NodeConnectionManager.general.test.ts
@@ -220,7 +220,6 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
-      enableMdns: false,
     });
     await taskManager.startProcessing();
 
@@ -251,7 +250,6 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
-      enableMdns: false,
     });
     await taskManager.startProcessing();
     // Mocking pinging to always return true
@@ -293,7 +291,6 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
-      enableMdns: false,
     });
     await taskManager.startProcessing();
     // Mocking pinging to always return true
@@ -327,7 +324,6 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
-      enableMdns: false,
     });
     await taskManager.startProcessing();
     // Mocking pinging to always return true
@@ -397,7 +393,6 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
-      enableMdns: false,
     });
     await taskManager.startProcessing();
 

--- a/tests/nodes/NodeConnectionManager.general.test.ts
+++ b/tests/nodes/NodeConnectionManager.general.test.ts
@@ -127,6 +127,7 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     serverAddressA = {
       host: remotePolykeyAgentA.agentServiceHost as Host,
       port: remotePolykeyAgentA.agentServicePort as Port,
+      scopes: ['external']
     };
     remotePolykeyAgentB = await PolykeyAgent.createPolykeyAgent({
       password,
@@ -219,6 +220,7 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
+      enableMdns: false,
     });
     await taskManager.startProcessing();
 
@@ -227,6 +229,7 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     const nodeAddress: NodeAddress = {
       host: localHost as Host,
       port: 11111 as Port,
+      scopes: ['external'],
     };
     await nodeGraph.setNode(nodeId, nodeAddress);
     // Expect no error thrown
@@ -248,6 +251,7 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
+      enableMdns: false,
     });
     await taskManager.startProcessing();
     // Mocking pinging to always return true
@@ -266,6 +270,7 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     const nodeAddress: NodeAddress = {
       host: localHost as Host,
       port: 11111 as Port,
+      scopes: ['external'],
     };
     await remotePolykeyAgentA.nodeGraph.setNode(nodeId, nodeAddress);
 
@@ -288,6 +293,7 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
+      enableMdns: false,
     });
     await taskManager.startProcessing();
     // Mocking pinging to always return true
@@ -305,7 +311,7 @@ describe(`${NodeConnectionManager.name} general test`, () => {
 
     // Expect no error thrown
     const findNodePromise = nodeConnectionManager.findNode(nodeId);
-    await expect(findNodePromise).resolves.toBeUndefined();
+    await expect(findNodePromise).resolves.toBe(undefined);
 
     await nodeConnectionManager.stop();
   });
@@ -321,6 +327,7 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
+      enableMdns: false,
     });
     await taskManager.startProcessing();
     // Mocking pinging to always return true
@@ -341,9 +348,10 @@ describe(`${NodeConnectionManager.name} general test`, () => {
         serverNodeIdA,
         i,
       );
-      const nodeAddress = {
+      const nodeAddress: NodeAddress = {
         host: (i + '.' + i + '.' + i + '.' + i) as Host,
         port: i as Port,
+        scopes: ['external'],
       };
       await remotePolykeyAgentA.nodeGraph.setNode(closeNodeId, nodeAddress);
       addedClosestNodes.push([
@@ -389,6 +397,7 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
+      enableMdns: false,
     });
     await taskManager.startProcessing();
 
@@ -413,8 +422,11 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     expect(
       await remotePolykeyAgentA.nodeConnectionManager.pingNode(
         remotePolykeyAgentB.keyRing.getNodeId(),
-        remotePolykeyAgentB.agentServiceHost,
-        remotePolykeyAgentB.agentServicePort,
+        [{
+          host: remotePolykeyAgentB.agentServiceHost,
+          port: remotePolykeyAgentB.agentServicePort,
+          scopes: ['external']
+        }]
       ),
     ).toBeTrue();
 
@@ -439,9 +451,10 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     });
 
     const serverNodeId = remotePolykeyAgentA.keyRing.getNodeId();
-    const serverAddress = {
+    const serverAddress: NodeAddress = {
       host: remotePolykeyAgentA.agentServiceHost as Host,
       port: remotePolykeyAgentA.agentServicePort as Port,
+      scopes: ['external']
     };
     await nodeGraph.setNode(serverNodeId, serverAddress);
 
@@ -492,17 +505,21 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     });
 
     const serverNodeId = remotePolykeyAgentA.keyRing.getNodeId();
-    const serverAddress = {
+    const serverAddress: NodeAddress = {
       host: remotePolykeyAgentA.agentServiceHost,
       port: remotePolykeyAgentA.agentServicePort,
+      scopes: ['external']
     };
     await nodeGraph.setNode(serverNodeId, serverAddress);
     // Establish connection between remote A and B
     expect(
       await remotePolykeyAgentA.nodeConnectionManager.pingNode(
         remotePolykeyAgentB.keyRing.getNodeId(),
-        remotePolykeyAgentB.agentServiceHost,
-        remotePolykeyAgentB.agentServicePort,
+        [{
+          host: remotePolykeyAgentB.agentServiceHost,
+          port: remotePolykeyAgentB.agentServicePort,
+          scopes: ['external']
+        }]
       ),
     ).toBeTrue();
 
@@ -622,8 +639,11 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     expect(
       await nodeConnectionManager.pingNode(
         remotePolykeyAgentB.keyRing.getNodeId(),
-        remotePolykeyAgentB.agentServiceHost,
-        remotePolykeyAgentB.agentServicePort,
+        [{
+          host: remotePolykeyAgentB.agentServiceHost,
+          port: remotePolykeyAgentB.agentServicePort,
+          scopes: ['external']
+        }]
       ),
     ).toBeTrue();
     const keyPair = keysUtils.generateKeyPair();
@@ -639,6 +659,7 @@ describe(`${NodeConnectionManager.name} general test`, () => {
           {
             host: '127.0.0.1' as Host,
             port: 55555 as Port,
+            scopes: ['external']
           },
           signature.toString('base64url'),
         );

--- a/tests/nodes/NodeConnectionManager.general.test.ts
+++ b/tests/nodes/NodeConnectionManager.general.test.ts
@@ -127,7 +127,7 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     serverAddressA = {
       host: remotePolykeyAgentA.agentServiceHost as Host,
       port: remotePolykeyAgentA.agentServicePort as Port,
-      scopes: ['external']
+      scopes: ['external'],
     };
     remotePolykeyAgentB = await PolykeyAgent.createPolykeyAgent({
       password,
@@ -417,11 +417,13 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     expect(
       await remotePolykeyAgentA.nodeConnectionManager.pingNode(
         remotePolykeyAgentB.keyRing.getNodeId(),
-        [{
-          host: remotePolykeyAgentB.agentServiceHost,
-          port: remotePolykeyAgentB.agentServicePort,
-          scopes: ['external']
-        }]
+        [
+          {
+            host: remotePolykeyAgentB.agentServiceHost,
+            port: remotePolykeyAgentB.agentServicePort,
+            scopes: ['external'],
+          },
+        ],
       ),
     ).toBeTrue();
 
@@ -449,7 +451,7 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     const serverAddress: NodeAddress = {
       host: remotePolykeyAgentA.agentServiceHost as Host,
       port: remotePolykeyAgentA.agentServicePort as Port,
-      scopes: ['external']
+      scopes: ['external'],
     };
     await nodeGraph.setNode(serverNodeId, serverAddress);
 
@@ -503,18 +505,20 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     const serverAddress: NodeAddress = {
       host: remotePolykeyAgentA.agentServiceHost,
       port: remotePolykeyAgentA.agentServicePort,
-      scopes: ['external']
+      scopes: ['external'],
     };
     await nodeGraph.setNode(serverNodeId, serverAddress);
     // Establish connection between remote A and B
     expect(
       await remotePolykeyAgentA.nodeConnectionManager.pingNode(
         remotePolykeyAgentB.keyRing.getNodeId(),
-        [{
-          host: remotePolykeyAgentB.agentServiceHost,
-          port: remotePolykeyAgentB.agentServicePort,
-          scopes: ['external']
-        }]
+        [
+          {
+            host: remotePolykeyAgentB.agentServiceHost,
+            port: remotePolykeyAgentB.agentServicePort,
+            scopes: ['external'],
+          },
+        ],
       ),
     ).toBeTrue();
 
@@ -634,11 +638,13 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     expect(
       await nodeConnectionManager.pingNode(
         remotePolykeyAgentB.keyRing.getNodeId(),
-        [{
-          host: remotePolykeyAgentB.agentServiceHost,
-          port: remotePolykeyAgentB.agentServicePort,
-          scopes: ['external']
-        }]
+        [
+          {
+            host: remotePolykeyAgentB.agentServiceHost,
+            port: remotePolykeyAgentB.agentServicePort,
+            scopes: ['external'],
+          },
+        ],
       ),
     ).toBeTrue();
     const keyPair = keysUtils.generateKeyPair();
@@ -654,7 +660,7 @@ describe(`${NodeConnectionManager.name} general test`, () => {
           {
             host: '127.0.0.1' as Host,
             port: 55555 as Port,
-            scopes: ['external']
+            scopes: ['external'],
           },
           signature.toString('base64url'),
         );

--- a/tests/nodes/NodeConnectionManager.lifecycle.test.ts
+++ b/tests/nodes/NodeConnectionManager.lifecycle.test.ts
@@ -89,7 +89,6 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManagerPeer2.start({
       host: localHost,
-      enableMdns: false,
     });
 
     // Setting up client dependencies
@@ -142,7 +141,6 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
-      enableMdns: false,
     });
 
     await nodeConnectionManager.stop();
@@ -157,13 +155,11 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
-      enableMdns: false,
     });
 
     await nodeConnectionManager.stop();
     await nodeConnectionManager.start({
       host: localHost,
-      enableMdns: false,
     });
     await nodeConnectionManager.stop();
   });
@@ -181,7 +177,6 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
-      enableMdns: false,
     });
 
     const acquire =
@@ -202,7 +197,6 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
-      enableMdns: false,
     });
 
     await nodeConnectionManager.withConnF(serverNodeId1, async () => {
@@ -222,7 +216,6 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
-      enableMdns: false,
     });
 
     await nodeConnectionManager.withConnF(serverNodeId1, async () => {
@@ -254,7 +247,6 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
-      enableMdns: false,
     });
     // @ts-ignore: kidnap protected property
     const connectionMap = nodeConnectionManager.connections;
@@ -282,7 +274,6 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
-      enableMdns: false,
     });
     // @ts-ignore: kidnap protected property
     const connectionMap = nodeConnectionManager.connections;
@@ -318,7 +309,6 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
-      enableMdns: false,
     });
     await nodeConnectionManager.withConnF(serverNodeId1, async () => {
       // Do nothing
@@ -344,7 +334,6 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
-      enableMdns: false,
     });
     const waitProm = promise<void>();
     const tryConnection = () => {
@@ -378,7 +367,6 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
-      enableMdns: false,
     });
     await nodeConnectionManager.withConnF(serverNodeId1, async () => {
       // Do nothing
@@ -411,7 +399,6 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
-      enableMdns: false,
     });
     await nodeConnectionManager.withConnF(serverNodeId1, async () => {
       // Do nothing
@@ -436,7 +423,6 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
-      enableMdns: false,
     });
     const result = await nodeConnectionManager.pingNode(
       serverNodeId1,
@@ -461,7 +447,6 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
-      enableMdns: false,
     });
     const result = await nodeConnectionManager.pingNode(
       serverNodeId1,
@@ -487,7 +472,6 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
-      enableMdns: false,
     });
     const result = await nodeConnectionManager.pingNode(
       clientNodeId,

--- a/tests/nodes/NodeConnectionManager.lifecycle.test.ts
+++ b/tests/nodes/NodeConnectionManager.lifecycle.test.ts
@@ -89,6 +89,7 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManagerPeer2.start({
       host: localHost,
+      enableMdns: false,
     });
 
     // Setting up client dependencies
@@ -114,6 +115,7 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     serverAddress1 = {
       host: nodeConnectionManagerPeer1.host,
       port: nodeConnectionManagerPeer1.port,
+      scopes: ['external'],
     };
   });
 
@@ -140,6 +142,7 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
+      enableMdns: false,
     });
 
     await nodeConnectionManager.stop();
@@ -154,11 +157,13 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
+      enableMdns: false,
     });
 
     await nodeConnectionManager.stop();
     await nodeConnectionManager.start({
       host: localHost,
+      enableMdns: false,
     });
     await nodeConnectionManager.stop();
   });
@@ -176,6 +181,7 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
+      enableMdns: false,
     });
 
     const acquire =
@@ -196,6 +202,7 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
+      enableMdns: false,
     });
 
     await nodeConnectionManager.withConnF(serverNodeId1, async () => {
@@ -215,6 +222,7 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
+      enableMdns: false,
     });
 
     await nodeConnectionManager.withConnF(serverNodeId1, async () => {
@@ -246,6 +254,7 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
+      enableMdns: false,
     });
     // @ts-ignore: kidnap protected property
     const connectionMap = nodeConnectionManager.connections;
@@ -273,6 +282,7 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
+      enableMdns: false,
     });
     // @ts-ignore: kidnap protected property
     const connectionMap = nodeConnectionManager.connections;
@@ -308,6 +318,7 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
+      enableMdns: false,
     });
     await nodeConnectionManager.withConnF(serverNodeId1, async () => {
       // Do nothing
@@ -333,6 +344,7 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
+      enableMdns: false,
     });
     const waitProm = promise<void>();
     const tryConnection = () => {
@@ -366,6 +378,7 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
+      enableMdns: false,
     });
     await nodeConnectionManager.withConnF(serverNodeId1, async () => {
       // Do nothing
@@ -398,6 +411,7 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
+      enableMdns: false,
     });
     await nodeConnectionManager.withConnF(serverNodeId1, async () => {
       // Do nothing
@@ -422,11 +436,15 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
+      enableMdns: false,
     });
     const result = await nodeConnectionManager.pingNode(
       serverNodeId1,
-      localHost as Host,
-      nodeConnectionManagerPeer1.port,
+      [{
+        host: localHost as Host,
+        port: nodeConnectionManagerPeer1.port,
+        scopes: ['local']
+      }],
     );
     expect(result).toBeTrue();
     expect(nodeConnectionManager.hasConnection(serverNodeId1)).toBeTrue();
@@ -443,11 +461,15 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
+      enableMdns: false,
     });
     const result = await nodeConnectionManager.pingNode(
       serverNodeId1,
-      localHost as Host,
-      12345 as Port,
+      [{
+        host: localHost as Host,
+        port: 12345 as Port,
+        scopes: ['local']
+      }],
       { timer: 100 },
     );
     expect(result).toBeFalse();
@@ -465,11 +487,15 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost,
+      enableMdns: false,
     });
     const result = await nodeConnectionManager.pingNode(
       clientNodeId,
-      localHost as Host,
-      nodeConnectionManagerPeer1.port,
+      [{
+        host: localHost as Host,
+        port: nodeConnectionManagerPeer1.port,
+        scopes: ['local']
+      }],
     );
     expect(result).toBeFalse();
     expect(nodeConnectionManager.hasConnection(clientNodeId)).toBeFalse();
@@ -493,9 +519,9 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     const connectedNodes = await nodeConnectionManager.getMultiConnection(
       [serverNodeId1],
       [
-        { host: '127.0.0.1' as Host, port: nodeConnectionManagerPeer1.port },
-        { host: '127.0.0.2' as Host, port: nodeConnectionManagerPeer1.port },
-        { host: '127.0.0.3' as Host, port: nodeConnectionManagerPeer1.port },
+        { host: '127.0.0.1' as Host, port: nodeConnectionManagerPeer1.port, scopes: ['external'] },
+        { host: '127.0.0.2' as Host, port: nodeConnectionManagerPeer1.port, scopes: ['external'] },
+        { host: '127.0.0.3' as Host, port: nodeConnectionManagerPeer1.port, scopes: ['external'] },
       ],
       { timer: 200 },
     );
@@ -523,12 +549,12 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     const connectedNodes = await nodeConnectionManager.getMultiConnection(
       [serverNodeId1, serverNodeId2],
       [
-        { host: '127.0.0.1' as Host, port: nodeConnectionManagerPeer1.port },
-        { host: '127.0.0.2' as Host, port: nodeConnectionManagerPeer1.port },
-        { host: '127.0.0.3' as Host, port: nodeConnectionManagerPeer1.port },
-        { host: '127.0.0.1' as Host, port: nodeConnectionManagerPeer2.port },
-        { host: '127.0.0.2' as Host, port: nodeConnectionManagerPeer2.port },
-        { host: '127.0.0.3' as Host, port: nodeConnectionManagerPeer2.port },
+        { host: '127.0.0.1' as Host, port: nodeConnectionManagerPeer1.port, scopes: ['external'] },
+        { host: '127.0.0.2' as Host, port: nodeConnectionManagerPeer1.port, scopes: ['external'] },
+        { host: '127.0.0.3' as Host, port: nodeConnectionManagerPeer1.port, scopes: ['external'] },
+        { host: '127.0.0.1' as Host, port: nodeConnectionManagerPeer2.port, scopes: ['external'] },
+        { host: '127.0.0.2' as Host, port: nodeConnectionManagerPeer2.port, scopes: ['external'] },
+        { host: '127.0.0.3' as Host, port: nodeConnectionManagerPeer2.port, scopes: ['external'] },
       ],
       { timer: 200 },
     );
@@ -557,7 +583,7 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
 
     const connectedNodes = await nodeConnectionManager.getMultiConnection(
       [serverNodeId1, serverNodeId2],
-      [{ host: '127.0.0.1' as Host, port: nodeConnectionManagerPeer1.port }],
+      [{ host: '127.0.0.1' as Host, port: nodeConnectionManagerPeer1.port, scopes: ['external'] }],
       { timer: 200 },
     );
     expect(connectedNodes.length).toBe(1);
@@ -587,12 +613,12 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     const connectedNodesProm = nodeConnectionManager.getMultiConnection(
       [serverNodeId1, serverNodeId2],
       [
-        { host: '127.0.0.1' as Host, port: nodeConnectionManagerPeer1.port },
-        { host: '127.0.0.2' as Host, port: nodeConnectionManagerPeer1.port },
-        { host: '127.0.0.3' as Host, port: nodeConnectionManagerPeer1.port },
-        { host: '127.0.0.1' as Host, port: nodeConnectionManagerPeer2.port },
-        { host: '127.0.0.2' as Host, port: nodeConnectionManagerPeer2.port },
-        { host: '127.0.0.3' as Host, port: nodeConnectionManagerPeer2.port },
+        { host: '127.0.0.1' as Host, port: nodeConnectionManagerPeer1.port, scopes: ['external'] },
+        { host: '127.0.0.2' as Host, port: nodeConnectionManagerPeer1.port, scopes: ['external'] },
+        { host: '127.0.0.3' as Host, port: nodeConnectionManagerPeer1.port, scopes: ['external'] },
+        { host: '127.0.0.1' as Host, port: nodeConnectionManagerPeer2.port, scopes: ['external'] },
+        { host: '127.0.0.2' as Host, port: nodeConnectionManagerPeer2.port, scopes: ['external'] },
+        { host: '127.0.0.3' as Host, port: nodeConnectionManagerPeer2.port, scopes: ['external'] },
       ],
       { timer: 2000 },
     );

--- a/tests/nodes/NodeConnectionManager.lifecycle.test.ts
+++ b/tests/nodes/NodeConnectionManager.lifecycle.test.ts
@@ -424,14 +424,13 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     await nodeConnectionManager.start({
       host: localHost,
     });
-    const result = await nodeConnectionManager.pingNode(
-      serverNodeId1,
-      [{
+    const result = await nodeConnectionManager.pingNode(serverNodeId1, [
+      {
         host: localHost as Host,
         port: nodeConnectionManagerPeer1.port,
-        scopes: ['local']
-      }],
-    );
+        scopes: ['local'],
+      },
+    ]);
     expect(result).toBeTrue();
     expect(nodeConnectionManager.hasConnection(serverNodeId1)).toBeTrue();
 
@@ -450,11 +449,13 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     });
     const result = await nodeConnectionManager.pingNode(
       serverNodeId1,
-      [{
-        host: localHost as Host,
-        port: 12345 as Port,
-        scopes: ['local']
-      }],
+      [
+        {
+          host: localHost as Host,
+          port: 12345 as Port,
+          scopes: ['local'],
+        },
+      ],
       { timer: 100 },
     );
     expect(result).toBeFalse();
@@ -473,14 +474,13 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     await nodeConnectionManager.start({
       host: localHost,
     });
-    const result = await nodeConnectionManager.pingNode(
-      clientNodeId,
-      [{
+    const result = await nodeConnectionManager.pingNode(clientNodeId, [
+      {
         host: localHost as Host,
         port: nodeConnectionManagerPeer1.port,
-        scopes: ['local']
-      }],
-    );
+        scopes: ['local'],
+      },
+    ]);
     expect(result).toBeFalse();
     expect(nodeConnectionManager.hasConnection(clientNodeId)).toBeFalse();
 
@@ -503,9 +503,21 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     const connectedNodes = await nodeConnectionManager.getMultiConnection(
       [serverNodeId1],
       [
-        { host: '127.0.0.1' as Host, port: nodeConnectionManagerPeer1.port, scopes: ['external'] },
-        { host: '127.0.0.2' as Host, port: nodeConnectionManagerPeer1.port, scopes: ['external'] },
-        { host: '127.0.0.3' as Host, port: nodeConnectionManagerPeer1.port, scopes: ['external'] },
+        {
+          host: '127.0.0.1' as Host,
+          port: nodeConnectionManagerPeer1.port,
+          scopes: ['external'],
+        },
+        {
+          host: '127.0.0.2' as Host,
+          port: nodeConnectionManagerPeer1.port,
+          scopes: ['external'],
+        },
+        {
+          host: '127.0.0.3' as Host,
+          port: nodeConnectionManagerPeer1.port,
+          scopes: ['external'],
+        },
       ],
       { timer: 200 },
     );
@@ -533,12 +545,36 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     const connectedNodes = await nodeConnectionManager.getMultiConnection(
       [serverNodeId1, serverNodeId2],
       [
-        { host: '127.0.0.1' as Host, port: nodeConnectionManagerPeer1.port, scopes: ['external'] },
-        { host: '127.0.0.2' as Host, port: nodeConnectionManagerPeer1.port, scopes: ['external'] },
-        { host: '127.0.0.3' as Host, port: nodeConnectionManagerPeer1.port, scopes: ['external'] },
-        { host: '127.0.0.1' as Host, port: nodeConnectionManagerPeer2.port, scopes: ['external'] },
-        { host: '127.0.0.2' as Host, port: nodeConnectionManagerPeer2.port, scopes: ['external'] },
-        { host: '127.0.0.3' as Host, port: nodeConnectionManagerPeer2.port, scopes: ['external'] },
+        {
+          host: '127.0.0.1' as Host,
+          port: nodeConnectionManagerPeer1.port,
+          scopes: ['external'],
+        },
+        {
+          host: '127.0.0.2' as Host,
+          port: nodeConnectionManagerPeer1.port,
+          scopes: ['external'],
+        },
+        {
+          host: '127.0.0.3' as Host,
+          port: nodeConnectionManagerPeer1.port,
+          scopes: ['external'],
+        },
+        {
+          host: '127.0.0.1' as Host,
+          port: nodeConnectionManagerPeer2.port,
+          scopes: ['external'],
+        },
+        {
+          host: '127.0.0.2' as Host,
+          port: nodeConnectionManagerPeer2.port,
+          scopes: ['external'],
+        },
+        {
+          host: '127.0.0.3' as Host,
+          port: nodeConnectionManagerPeer2.port,
+          scopes: ['external'],
+        },
       ],
       { timer: 200 },
     );
@@ -567,7 +603,13 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
 
     const connectedNodes = await nodeConnectionManager.getMultiConnection(
       [serverNodeId1, serverNodeId2],
-      [{ host: '127.0.0.1' as Host, port: nodeConnectionManagerPeer1.port, scopes: ['external'] }],
+      [
+        {
+          host: '127.0.0.1' as Host,
+          port: nodeConnectionManagerPeer1.port,
+          scopes: ['external'],
+        },
+      ],
       { timer: 200 },
     );
     expect(connectedNodes.length).toBe(1);
@@ -597,12 +639,36 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
     const connectedNodesProm = nodeConnectionManager.getMultiConnection(
       [serverNodeId1, serverNodeId2],
       [
-        { host: '127.0.0.1' as Host, port: nodeConnectionManagerPeer1.port, scopes: ['external'] },
-        { host: '127.0.0.2' as Host, port: nodeConnectionManagerPeer1.port, scopes: ['external'] },
-        { host: '127.0.0.3' as Host, port: nodeConnectionManagerPeer1.port, scopes: ['external'] },
-        { host: '127.0.0.1' as Host, port: nodeConnectionManagerPeer2.port, scopes: ['external'] },
-        { host: '127.0.0.2' as Host, port: nodeConnectionManagerPeer2.port, scopes: ['external'] },
-        { host: '127.0.0.3' as Host, port: nodeConnectionManagerPeer2.port, scopes: ['external'] },
+        {
+          host: '127.0.0.1' as Host,
+          port: nodeConnectionManagerPeer1.port,
+          scopes: ['external'],
+        },
+        {
+          host: '127.0.0.2' as Host,
+          port: nodeConnectionManagerPeer1.port,
+          scopes: ['external'],
+        },
+        {
+          host: '127.0.0.3' as Host,
+          port: nodeConnectionManagerPeer1.port,
+          scopes: ['external'],
+        },
+        {
+          host: '127.0.0.1' as Host,
+          port: nodeConnectionManagerPeer2.port,
+          scopes: ['external'],
+        },
+        {
+          host: '127.0.0.2' as Host,
+          port: nodeConnectionManagerPeer2.port,
+          scopes: ['external'],
+        },
+        {
+          host: '127.0.0.3' as Host,
+          port: nodeConnectionManagerPeer2.port,
+          scopes: ['external'],
+        },
       ],
       { timer: 2000 },
     );

--- a/tests/nodes/NodeConnectionManager.mdns.test.ts
+++ b/tests/nodes/NodeConnectionManager.mdns.test.ts
@@ -72,8 +72,8 @@ describe(`${NodeConnectionManager.name} MDNS test`, () => {
     await mdnsPeer.start({
       id: serverNodeId.at(0),
       hostname: serverNodeIdEncoded,
-      groups: config.defaultsSystem.agentMdnsGroups,
-      port: config.defaultsSystem.agentMdnsPort
+      groups: config.defaultsSystem.mdnsGroups,
+      port: config.defaultsSystem.mdnsPort
     })
     nodeConnectionManagerPeer = new NodeConnectionManager({
       keyRing: keyRingPeer,
@@ -113,8 +113,8 @@ describe(`${NodeConnectionManager.name} MDNS test`, () => {
     await mdns.start({
       id: clientNodeId.at(0),
       hostname: clientNodeIdEncoded,
-      groups: config.defaultsSystem.agentMdnsGroups,
-      port: config.defaultsSystem.agentMdnsPort
+      groups: config.defaultsSystem.mdnsGroups,
+      port: config.defaultsSystem.mdnsPort
     })
   });
 

--- a/tests/nodes/NodeConnectionManager.mdns.test.ts
+++ b/tests/nodes/NodeConnectionManager.mdns.test.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import fs from 'fs';
 import os from 'os';
 import { DB } from '@matrixai/db';
-import { MDNS, events as mdnsEvents } from '@matrixai/mdns';
+import { MDNS } from '@matrixai/mdns';
 import Logger, { formatting, LogLevel, StreamHandler } from '@matrixai/logger';
 import KeyRing from '@/keys/KeyRing';
 import NodeGraph from '@/nodes/NodeGraph';
@@ -12,8 +12,7 @@ import NodeConnection from '@/nodes/NodeConnection';
 import NodeConnectionManager from '@/nodes/NodeConnectionManager';
 import * as nodesUtils from '@/nodes/utils';
 import * as keysUtils from '@/keys/utils';
-import { promise } from '@/utils';
-import config  from '@/config';
+import config from '@/config';
 import * as tlsUtils from '../utils/tls';
 
 describe(`${NodeConnectionManager.name} MDNS test`, () => {
@@ -82,7 +81,7 @@ describe(`${NodeConnectionManager.name} MDNS test`, () => {
       nodeGraph: {} as NodeGraph,
       tlsConfig: serverTlsConfig,
       seedNodes: undefined,
-      mdns: mdnsPeer
+      mdns: mdnsPeer,
     });
     await nodeConnectionManagerPeer.start({
       host: localHost,
@@ -147,10 +146,13 @@ describe(`${NodeConnectionManager.name} MDNS test`, () => {
     });
 
     // Expect no error thrown
-    const foundAddresses = await nodeConnectionManager.findNodeLocal(serverNodeId);
+    const foundAddresses =
+      await nodeConnectionManager.findNodeLocal(serverNodeId);
 
     expect(foundAddresses).toBeArray();
-    expect(foundAddresses).toIncludeAllPartialMembers([{ port: nodeConnectionManagerPeer.port, scopes: ['local'] }])
+    expect(foundAddresses).toIncludeAllPartialMembers([
+      { port: nodeConnectionManagerPeer.port, scopes: ['local'] },
+    ]);
 
     await nodeConnectionManager.stop();
   });
@@ -169,8 +171,7 @@ describe(`${NodeConnectionManager.name} MDNS test`, () => {
       host: localHost,
     });
 
-    const acquire =
-      await nodeConnectionManager.acquireConnection(serverNodeId);
+    const acquire = await nodeConnectionManager.acquireConnection(serverNodeId);
     const [release] = await acquire();
     expect(nodeConnectionManager.hasConnection(serverNodeId)).toBeTrue();
     await release();

--- a/tests/nodes/NodeConnectionManager.mdns.test.ts
+++ b/tests/nodes/NodeConnectionManager.mdns.test.ts
@@ -73,8 +73,9 @@ describe(`${NodeConnectionManager.name} MDNS test`, () => {
       id: serverNodeId.at(0),
       hostname: serverNodeIdEncoded,
       groups: config.defaultsSystem.mdnsGroups,
-      port: config.defaultsSystem.mdnsPort
-    })
+      // This is different so that we do not conflict with the MDNS stack on other Polykey agents when running these tests
+      port: 64022,
+    });
     nodeConnectionManagerPeer = new NodeConnectionManager({
       keyRing: keyRingPeer,
       logger: logger.getChild(`${NodeConnectionManager.name}Peer`),
@@ -114,8 +115,9 @@ describe(`${NodeConnectionManager.name} MDNS test`, () => {
       id: clientNodeId.at(0),
       hostname: clientNodeIdEncoded,
       groups: config.defaultsSystem.mdnsGroups,
-      port: config.defaultsSystem.mdnsPort
-    })
+      // This is different so that we do not conflict with the MDNS stack on other Polykey agents when running these tests
+      port: 64022,
+    });
   });
 
   afterEach(async () => {

--- a/tests/nodes/NodeConnectionManager.mdns.test.ts
+++ b/tests/nodes/NodeConnectionManager.mdns.test.ts
@@ -142,21 +142,12 @@ describe(`${NodeConnectionManager.name} MDNS test`, () => {
       seedNodes: undefined,
     });
 
-    const serviceProm = promise();
-    mdns.addEventListener(mdnsEvents.EventMDNSService.name, (evt: mdnsEvents.EventMDNSService) => {
-      if (evt.detail.name === serverNodeIdEncoded) {
-        serviceProm.resolveP();
-      }
-    });
-
     await nodeConnectionManager.start({
       host: localHost,
     });
 
-    await serviceProm.p;
-
     // Expect no error thrown
-    const foundAddresses = nodeConnectionManager.findNodeLocal(serverNodeId);
+    const foundAddresses = await nodeConnectionManager.findNodeLocal(serverNodeId);
 
     expect(foundAddresses).toBeArray();
     expect(foundAddresses).toIncludeAllPartialMembers([{ port: nodeConnectionManagerPeer.port, scopes: ['local'] }])
@@ -174,18 +165,10 @@ describe(`${NodeConnectionManager.name} MDNS test`, () => {
       connectionConnectTimeoutTime: 1000,
     });
 
-    const { p: serviceP, resolveP: resolveServiceP  } = promise();
-    mdns.addEventListener(mdnsEvents.EventMDNSService.name, (evt: mdnsEvents.EventMDNSService) => {
-      if (evt.detail.name === serverNodeIdEncoded) {
-        resolveServiceP();
-      }
-    });
-
     await nodeConnectionManager.start({
       host: localHost,
     });
 
-    await serviceP;
     const acquire =
       await nodeConnectionManager.acquireConnection(serverNodeId);
     const [release] = await acquire();

--- a/tests/nodes/NodeConnectionManager.mdns.test.ts
+++ b/tests/nodes/NodeConnectionManager.mdns.test.ts
@@ -1,0 +1,207 @@
+import type { Host, Port, TLSConfig } from '@/network/types';
+import type { NodeAddress } from '@/nodes/types';
+import type { NodeId, NodeIdEncoded, NodeIdString } from '@/ids';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import { DB } from '@matrixai/db';
+import Logger, { formatting, LogLevel, StreamHandler } from '@matrixai/logger';
+import KeyRing from '@/keys/KeyRing';
+import NodeGraph from '@/nodes/NodeGraph';
+import * as nodesUtils from '@/nodes/utils';
+import * as keysUtils from '@/keys/utils';
+import NodeConnectionManager from '@/nodes/NodeConnectionManager';
+import { promise, sleep } from '@/utils';
+import * as nodesErrors from '@/nodes/errors';
+import NodeConnection from '@/nodes/NodeConnection';
+import * as tlsUtils from '../utils/tls';
+import { PromiseCancellable } from '@matrixai/async-cancellable';
+import { events as mdnsEvents } from '@matrixai/mdns';
+
+describe(`${NodeConnectionManager.name} lifecycle test`, () => {
+  const logger = new Logger(`${NodeConnection.name} test`, LogLevel.WARN, [
+    new StreamHandler(
+      formatting.format`${formatting.level}:${formatting.keys}:${formatting.msg}`,
+    ),
+  ]);
+  const localHost = '::' as Host;
+  const password = 'password';
+
+  let dataDir: string;
+
+  let serverTlsConfig: TLSConfig;
+  let clientTlsConfig: TLSConfig;
+  let serverNodeId: NodeId;
+  let clientNodeId: NodeId;
+  let serverNodeIdEncoded: NodeIdEncoded;
+  let keyRingPeer: KeyRing;
+  let nodeConnectionManagerPeer: NodeConnectionManager;
+  let serverAddress: NodeAddress;
+
+  let keyRing: KeyRing;
+  let db: DB;
+  let nodeGraph: NodeGraph;
+
+  let nodeConnectionManager: NodeConnectionManager;
+
+  beforeEach(async () => {
+    dataDir = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'polykey-test-'),
+    );
+    const keysPathPeer = path.join(dataDir, 'keysPeer');
+    keyRingPeer = await KeyRing.createKeyRing({
+      password,
+      keysPath: keysPathPeer,
+      logger,
+      options: {
+        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+        passwordMemLimit: keysUtils.passwordMemLimits.min,
+        strictMemoryLock: false,
+      },
+    });
+    const serverKeyPair = keyRingPeer.keyPair;
+    const clientKeyPair = keysUtils.generateKeyPair();
+    serverNodeId = keysUtils.publicKeyToNodeId(serverKeyPair.publicKey);
+    clientNodeId = keysUtils.publicKeyToNodeId(clientKeyPair.publicKey);
+    serverNodeIdEncoded = nodesUtils.encodeNodeId(serverNodeId);
+    serverTlsConfig = await tlsUtils.createTLSConfig(serverKeyPair);
+    clientTlsConfig = await tlsUtils.createTLSConfig(clientKeyPair);
+
+    nodeConnectionManagerPeer = new NodeConnectionManager({
+      keyRing: keyRingPeer,
+      logger: logger.getChild(`${NodeConnectionManager.name}Peer`),
+      nodeGraph: {} as NodeGraph,
+      tlsConfig: serverTlsConfig,
+      seedNodes: undefined,
+    });
+    await nodeConnectionManagerPeer.start({
+      host: localHost,
+      enableMdns: true
+    });
+
+    // Setting up client dependencies
+    const keysPath = path.join(dataDir, 'keys');
+    keyRing = await KeyRing.createKeyRing({
+      password,
+      keysPath,
+      logger,
+      options: {
+        passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+        passwordMemLimit: keysUtils.passwordMemLimits.min,
+        strictMemoryLock: false,
+      },
+    });
+    const dbPath = path.join(dataDir, 'db');
+    db = await DB.createDB({
+      dbPath,
+      logger,
+    });
+    nodeGraph = await NodeGraph.createNodeGraph({
+      db,
+      keyRing,
+      logger,
+    });
+    serverAddress = {
+      host: nodeConnectionManagerPeer.host,
+      port: nodeConnectionManagerPeer.port,
+      scopes: ['local']
+    };
+  });
+
+  afterEach(async () => {
+    await nodeConnectionManager?.stop();
+    await nodeGraph.stop();
+    await nodeGraph.destroy();
+    await db.stop();
+    await db.destroy();
+    await keyRing.stop();
+    await keyRing.destroy();
+
+    await nodeConnectionManagerPeer.stop();
+  });
+
+  test('finds node (contacts remote node)', async () => {
+    nodeConnectionManager = new NodeConnectionManager({
+      keyRing,
+      nodeGraph,
+      options: {
+        connectionConnectTimeoutTime: 1000,
+      },
+      logger: logger.getChild(`${NodeConnectionManager.name}Local`),
+      tlsConfig: clientTlsConfig,
+      seedNodes: undefined,
+    });
+
+    const serviceProm = promise();
+    // @ts-ignore: protected property
+    nodeConnectionManager.mdns.addEventListener(mdnsEvents.EventMDNSService.name, (evt: mdnsEvents.EventMDNSService) => {
+      if (evt.detail.name === serverNodeIdEncoded) {
+        serviceProm.resolveP();
+      }
+    });
+
+    await nodeConnectionManager.start({
+      host: localHost,
+      enableMdns: true
+    });
+
+    // Mocking pinging to always return true
+    const mockedPingNode = jest.spyOn(
+      NodeConnectionManager.prototype,
+      'pingNode',
+    );
+    mockedPingNode.mockImplementation(
+      () => new PromiseCancellable((resolve) => resolve(true)),
+    );
+    logger.info('DOING TEST');
+
+    await serviceProm.p;
+
+    // Expect no error thrown
+    const foundAddresses = nodeConnectionManager.findNodeLocal(serverNodeId);
+
+    expect(foundAddresses).toBeArray();
+    expect(foundAddresses).toIncludeAllPartialMembers([{ port: nodeConnectionManagerPeer.port, scopes: ['local'] }])
+
+    await nodeConnectionManager.stop();
+  });
+  test('withConnF should create connection', async () => {
+    nodeConnectionManager = new NodeConnectionManager({
+      keyRing,
+      logger: logger.getChild(NodeConnectionManager.name),
+      nodeGraph,
+      tlsConfig: clientTlsConfig,
+      seedNodes: undefined,
+    });
+
+    const serviceProm = promise();
+    // @ts-ignore: protected property
+    nodeConnectionManager.mdns.addEventListener(mdnsEvents.EventMDNSService.name, (evt: mdnsEvents.EventMDNSService) => {
+      if (evt.detail.name === serverNodeIdEncoded) {
+        serviceProm.resolveP();
+      }
+    });
+
+    // TODO: ipv6 only connection still fails
+    // currently, it only succeeds when it finds the ipv4Mappedipv6 address
+    await nodeConnectionManager.start({
+      host: localHost,
+      enableMdns: true
+    });
+
+    await serviceProm.p;
+
+    await nodeConnectionManager.withConnF(serverNodeId, async () => {
+      expect(nodeConnectionManager.hasConnection(serverNodeId)).toBeTrue();
+    });
+
+    // @ts-ignore: Kidnap protected property
+    const connectionMap = nodeConnectionManager.connections;
+    const connection = connectionMap.get(
+      serverNodeId.toString() as NodeIdString,
+    );
+    await connection!.connection.destroy({ force: true });
+
+    await nodeConnectionManager.stop();
+  });
+});

--- a/tests/nodes/NodeConnectionManager.seednodes.test.ts
+++ b/tests/nodes/NodeConnectionManager.seednodes.test.ts
@@ -238,7 +238,7 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
       [nodesUtils.encodeNodeId(localNodeId)]: {
         host: '127.0.0.1' as Host,
         port: 55123 as Port,
-        scopes: ['external']
+        scopes: ['external'],
       },
     };
     nodeConnectionManager = new NodeConnectionManager({
@@ -292,7 +292,7 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
       [nodesUtils.encodeNodeId(remoteNodeId2)]: {
         host: '127.0.0.1' as Host,
         port: 55124 as Port,
-        scopes: ['external']
+        scopes: ['external'],
       },
     };
     nodeConnectionManager = new NodeConnectionManager({

--- a/tests/nodes/NodeConnectionManager.seednodes.test.ts
+++ b/tests/nodes/NodeConnectionManager.seednodes.test.ts
@@ -222,7 +222,6 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
 
     await nodeConnectionManager.start({
       host: localHost as Host,
-      enableMdns: false,
     });
     await taskManager.startProcessing();
 
@@ -386,7 +385,6 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
     await Promise.all(setNodeProms);
     await nodeConnectionManager.start({
       host: localHost as Host,
-      enableMdns: false,
     });
     await taskManager.startProcessing();
 
@@ -447,7 +445,6 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
     await Promise.all(setNodeProms);
     await nodeConnectionManager.start({
       host: localHost as Host,
-      enableMdns: false,
     });
     await taskManager.startProcessing();
 
@@ -505,7 +502,6 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
     await Promise.all(setNodeProms);
     await nodeConnectionManager.start({
       host: localHost as Host,
-      enableMdns: false,
     });
     await taskManager.startProcessing();
 
@@ -564,7 +560,6 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
     await Promise.all(setNodeProms);
     await nodeConnectionManager.start({
       host: localHost as Host,
-      enableMdns: false,
     });
     await taskManager.startProcessing();
 

--- a/tests/nodes/NodeConnectionManager.seednodes.test.ts
+++ b/tests/nodes/NodeConnectionManager.seednodes.test.ts
@@ -1,6 +1,6 @@
 import type { Host, Port, TLSConfig } from '@/network/types';
 import type { NodeId, NodeIdEncoded } from '@/ids';
-import type { NodeAddress } from '@/nodes/types';
+import type { NodeAddress, SeedNodes } from '@/nodes/types';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -30,9 +30,10 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
     ),
   ]);
   const localHost = '127.0.0.1';
-  const testAddress = {
+  const testAddress: NodeAddress = {
     host: '127.0.0.1' as Host,
     port: 55555 as Port,
+    scopes: ['local'],
   };
   const password = 'password';
 
@@ -87,6 +88,7 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
     remoteAddress1 = {
       host: remotePolykeyAgent1.agentServiceHost,
       port: remotePolykeyAgent1.agentServicePort,
+      scopes: ['external'],
     };
 
     const nodePathB = path.join(dataDir, 'agentB');
@@ -108,6 +110,7 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
     remoteAddress2 = {
       host: remotePolykeyAgent2.agentServiceHost,
       port: remotePolykeyAgent2.agentServicePort,
+      scopes: ['external'],
     };
 
     // Setting up client dependencies
@@ -219,6 +222,7 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
 
     await nodeConnectionManager.start({
       host: localHost as Host,
+      enableMdns: false,
     });
     await taskManager.startProcessing();
 
@@ -231,10 +235,11 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
   });
   test('syncNodeGraph handles own nodeId', async () => {
     const localNodeId = keyRing.getNodeId();
-    const seedNodes = {
+    const seedNodes: SeedNodes = {
       [nodesUtils.encodeNodeId(localNodeId)]: {
         host: '127.0.0.1' as Host,
         port: 55123 as Port,
+        scopes: ['external']
       },
     };
     nodeConnectionManager = new NodeConnectionManager({
@@ -284,10 +289,11 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
     await nodeConnectionManager.stop();
   });
   test('syncNodeGraph handles offline seed node', async () => {
-    const seedNodes = {
+    const seedNodes: SeedNodes = {
       [nodesUtils.encodeNodeId(remoteNodeId2)]: {
         host: '127.0.0.1' as Host,
         port: 55124 as Port,
+        scopes: ['external']
       },
     };
     nodeConnectionManager = new NodeConnectionManager({
@@ -380,6 +386,7 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
     await Promise.all(setNodeProms);
     await nodeConnectionManager.start({
       host: localHost as Host,
+      enableMdns: false,
     });
     await taskManager.startProcessing();
 
@@ -440,6 +447,7 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
     await Promise.all(setNodeProms);
     await nodeConnectionManager.start({
       host: localHost as Host,
+      enableMdns: false,
     });
     await taskManager.startProcessing();
 
@@ -497,6 +505,7 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
     await Promise.all(setNodeProms);
     await nodeConnectionManager.start({
       host: localHost as Host,
+      enableMdns: false,
     });
     await taskManager.startProcessing();
 
@@ -555,6 +564,7 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
     await Promise.all(setNodeProms);
     await nodeConnectionManager.start({
       host: localHost as Host,
+      enableMdns: false,
     });
     await taskManager.startProcessing();
 

--- a/tests/nodes/NodeConnectionManager.timeout.test.ts
+++ b/tests/nodes/NodeConnectionManager.timeout.test.ts
@@ -67,6 +67,7 @@ describe(`${NodeConnectionManager.name} timeout test`, () => {
     remoteAddress1 = {
       host: remotePolykeyAgent1.agentServiceHost,
       port: remotePolykeyAgent1.agentServicePort,
+      scopes: ['external'],
     };
 
     // Setting up client dependencies
@@ -116,6 +117,7 @@ describe(`${NodeConnectionManager.name} timeout test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
+      enableMdns: false,
     });
 
     await nodeGraph.setNode(remoteNodeId1, remoteAddress1);
@@ -155,6 +157,7 @@ describe(`${NodeConnectionManager.name} timeout test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
+      enableMdns: false,
     });
 
     await nodeGraph.setNode(remoteNodeId1, remoteAddress1);
@@ -211,12 +214,14 @@ describe(`${NodeConnectionManager.name} timeout test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
+      enableMdns: false,
     });
 
     const randomNodeId = generateRandomNodeId();
     await nodeGraph.setNode(randomNodeId, {
       host: '127.0.0.1' as Host,
       port: 12321 as Port,
+      scopes: ['local'],
     });
     await expect(
       nodeConnectionManager.withConnF(randomNodeId, async () => {
@@ -236,12 +241,14 @@ describe(`${NodeConnectionManager.name} timeout test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
+      enableMdns: false,
     });
 
     const randomNodeId = generateRandomNodeId();
     await nodeGraph.setNode(randomNodeId, {
       host: '127.0.0.1' as Host,
       port: 12321 as Port,
+      scopes: ['local'],
     });
     await expect(
       nodeConnectionManager.withConnF(
@@ -267,12 +274,14 @@ describe(`${NodeConnectionManager.name} timeout test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
+      enableMdns: false,
     });
 
     const randomNodeId = generateRandomNodeId();
     await nodeGraph.setNode(randomNodeId, {
       host: '127.0.0.1' as Host,
       port: 12321 as Port,
+      scopes: ['local'],
     });
     const abortController = new AbortController();
     const ctx = {

--- a/tests/nodes/NodeConnectionManager.timeout.test.ts
+++ b/tests/nodes/NodeConnectionManager.timeout.test.ts
@@ -117,7 +117,6 @@ describe(`${NodeConnectionManager.name} timeout test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
-      enableMdns: false,
     });
 
     await nodeGraph.setNode(remoteNodeId1, remoteAddress1);
@@ -157,7 +156,6 @@ describe(`${NodeConnectionManager.name} timeout test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
-      enableMdns: false,
     });
 
     await nodeGraph.setNode(remoteNodeId1, remoteAddress1);
@@ -214,7 +212,6 @@ describe(`${NodeConnectionManager.name} timeout test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
-      enableMdns: false,
     });
 
     const randomNodeId = generateRandomNodeId();
@@ -241,7 +238,6 @@ describe(`${NodeConnectionManager.name} timeout test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
-      enableMdns: false,
     });
 
     const randomNodeId = generateRandomNodeId();
@@ -274,7 +270,6 @@ describe(`${NodeConnectionManager.name} timeout test`, () => {
     });
     await nodeConnectionManager.start({
       host: localHost as Host,
-      enableMdns: false,
     });
 
     const randomNodeId = generateRandomNodeId();

--- a/tests/nodes/NodeManager.test.ts
+++ b/tests/nodes/NodeManager.test.ts
@@ -168,6 +168,7 @@ describe(`${NodeManager.name} test`, () => {
     await nodeManager.setNode(nodeId, {
       host: '' as Host,
       port: 11111 as Port,
+      scopes: ['external']
     });
 
     const nodeData = (await nodeGraph.getNode(nodeId))!;
@@ -178,6 +179,7 @@ describe(`${NodeManager.name} test`, () => {
     await nodeManager.setNode(nodeId, {
       host: '' as Host,
       port: 22222 as Port,
+      scopes: ['external']
     });
 
     const newNodeData = (await nodeGraph.getNode(nodeId))!;
@@ -362,6 +364,7 @@ describe(`${NodeManager.name} test`, () => {
     const serverNodeAddress: NodeAddress = {
       host: server.agentServiceHost,
       port: server.agentServicePort,
+      scopes: ['external'],
     };
     await nodeGraph.setNode(serverNodeId, serverNodeAddress);
 
@@ -397,7 +400,7 @@ describe(`${NodeManager.name} test`, () => {
     await nodeManager.start();
 
     const nodeId = keyRing.getNodeId();
-    const address = { host: localHost as Host, port: port as Port };
+    const address: NodeAddress = { host: localHost as Host, port: port as Port, scopes: ['external'] };
     // Let's fill a bucket
     for (let i = 0; i < nodeGraph.nodeBucketLimit; i++) {
       const newNode = nodesTestUtils.generateNodeIdForBucket(nodeId, 100, i);
@@ -432,7 +435,7 @@ describe(`${NodeManager.name} test`, () => {
     await nodeManager.start();
 
     const nodeId = keyRing.getNodeId();
-    const address = { host: localHost as Host, port: port as Port };
+    const address: NodeAddress = { host: localHost as Host, port: port as Port, scopes: ['external'] };
     // Let's fill a bucket
     for (let i = 0; i < nodeGraph.nodeBucketLimit; i++) {
       const newNode = nodesTestUtils.generateNodeIdForBucket(nodeId, 100, i);
@@ -474,7 +477,7 @@ describe(`${NodeManager.name} test`, () => {
     await nodeManager.start();
 
     const nodeId = keyRing.getNodeId();
-    const address = { host: localHost as Host, port: port as Port };
+    const address: NodeAddress = { host: localHost as Host, port: port as Port, scopes: ['external'] };
     // Let's fill a bucket
     for (let i = 0; i < nodeGraph.nodeBucketLimit; i++) {
       const newNode = testNodesUtils.generateNodeIdForBucket(nodeId, 100, i);

--- a/tests/nodes/NodeManager.test.ts
+++ b/tests/nodes/NodeManager.test.ts
@@ -168,7 +168,7 @@ describe(`${NodeManager.name} test`, () => {
     await nodeManager.setNode(nodeId, {
       host: '' as Host,
       port: 11111 as Port,
-      scopes: ['external']
+      scopes: ['external'],
     });
 
     const nodeData = (await nodeGraph.getNode(nodeId))!;
@@ -179,7 +179,7 @@ describe(`${NodeManager.name} test`, () => {
     await nodeManager.setNode(nodeId, {
       host: '' as Host,
       port: 22222 as Port,
-      scopes: ['external']
+      scopes: ['external'],
     });
 
     const newNodeData = (await nodeGraph.getNode(nodeId))!;
@@ -400,7 +400,11 @@ describe(`${NodeManager.name} test`, () => {
     await nodeManager.start();
 
     const nodeId = keyRing.getNodeId();
-    const address: NodeAddress = { host: localHost as Host, port: port as Port, scopes: ['external'] };
+    const address: NodeAddress = {
+      host: localHost as Host,
+      port: port as Port,
+      scopes: ['external'],
+    };
     // Let's fill a bucket
     for (let i = 0; i < nodeGraph.nodeBucketLimit; i++) {
       const newNode = nodesTestUtils.generateNodeIdForBucket(nodeId, 100, i);
@@ -435,7 +439,11 @@ describe(`${NodeManager.name} test`, () => {
     await nodeManager.start();
 
     const nodeId = keyRing.getNodeId();
-    const address: NodeAddress = { host: localHost as Host, port: port as Port, scopes: ['external'] };
+    const address: NodeAddress = {
+      host: localHost as Host,
+      port: port as Port,
+      scopes: ['external'],
+    };
     // Let's fill a bucket
     for (let i = 0; i < nodeGraph.nodeBucketLimit; i++) {
       const newNode = nodesTestUtils.generateNodeIdForBucket(nodeId, 100, i);
@@ -477,7 +485,11 @@ describe(`${NodeManager.name} test`, () => {
     await nodeManager.start();
 
     const nodeId = keyRing.getNodeId();
-    const address: NodeAddress = { host: localHost as Host, port: port as Port, scopes: ['external'] };
+    const address: NodeAddress = {
+      host: localHost as Host,
+      port: port as Port,
+      scopes: ['external'],
+    };
     // Let's fill a bucket
     for (let i = 0; i < nodeGraph.nodeBucketLimit; i++) {
       const newNode = testNodesUtils.generateNodeIdForBucket(nodeId, 100, i);

--- a/tests/nodes/agent/handlers/nodesClosestLocalNode.test.ts
+++ b/tests/nodes/agent/handlers/nodesClosestLocalNode.test.ts
@@ -176,6 +176,7 @@ describe('nodesClosestLocalNode', () => {
       await nodeGraph.setNode(nodeId, {
         host: 'localhost' as Host,
         port: 55555 as Port,
+        scopes: ['local']
       });
       nodes.push(nodesUtils.encodeNodeId(nodeId));
     }

--- a/tests/nodes/agent/handlers/nodesClosestLocalNode.test.ts
+++ b/tests/nodes/agent/handlers/nodesClosestLocalNode.test.ts
@@ -176,7 +176,7 @@ describe('nodesClosestLocalNode', () => {
       await nodeGraph.setNode(nodeId, {
         host: 'localhost' as Host,
         port: 55555 as Port,
-        scopes: ['local']
+        scopes: ['local'],
       });
       nodes.push(nodesUtils.encodeNodeId(nodeId));
     }

--- a/tests/nodes/utils.ts
+++ b/tests/nodes/utils.ts
@@ -73,11 +73,13 @@ async function nodesConnect(localNode: PolykeyAgent, remoteNode: PolykeyAgent) {
   await localNode.nodeManager.setNode(remoteNode.keyRing.getNodeId(), {
     host: remoteNode.agentServiceHost,
     port: remoteNode.agentServicePort,
+    scopes: ['external']
   });
   // Add local node's details to remote node
   await remoteNode.nodeManager.setNode(localNode.keyRing.getNodeId(), {
     host: localNode.agentServiceHost,
     port: localNode.agentServicePort,
+    scopes: ['external']
   });
 }
 

--- a/tests/nodes/utils.ts
+++ b/tests/nodes/utils.ts
@@ -73,13 +73,13 @@ async function nodesConnect(localNode: PolykeyAgent, remoteNode: PolykeyAgent) {
   await localNode.nodeManager.setNode(remoteNode.keyRing.getNodeId(), {
     host: remoteNode.agentServiceHost,
     port: remoteNode.agentServicePort,
-    scopes: ['external']
+    scopes: ['external'],
   });
   // Add local node's details to remote node
   await remoteNode.nodeManager.setNode(localNode.keyRing.getNodeId(), {
     host: localNode.agentServiceHost,
     port: localNode.agentServicePort,
-    scopes: ['external']
+    scopes: ['external'],
   });
 }
 

--- a/tests/notifications/NotificationsManager.test.ts
+++ b/tests/notifications/NotificationsManager.test.ts
@@ -148,6 +148,7 @@ describe('NotificationsManager', () => {
     await nodeGraph.setNode(receiver.keyRing.getNodeId(), {
       host: receiver.agentServiceHost,
       port: receiver.agentServicePort,
+      scopes: ['external']
     });
   }, globalThis.defaultTimeout);
   afterEach(async () => {

--- a/tests/notifications/NotificationsManager.test.ts
+++ b/tests/notifications/NotificationsManager.test.ts
@@ -148,7 +148,7 @@ describe('NotificationsManager', () => {
     await nodeGraph.setNode(receiver.keyRing.getNodeId(), {
       host: receiver.agentServiceHost,
       port: receiver.agentServicePort,
-      scopes: ['external']
+      scopes: ['external'],
     });
   }, globalThis.defaultTimeout);
   afterEach(async () => {

--- a/tests/vaults/VaultManager.test.ts
+++ b/tests/vaults/VaultManager.test.ts
@@ -517,12 +517,12 @@ describe('VaultManager', () => {
       await remoteKeynode1.nodeGraph.setNode(remoteKeynode2Id, {
         host: remoteKeynode2.agentServiceHost,
         port: remoteKeynode2.agentServicePort,
-        scopes: ['external']
+        scopes: ['external'],
       });
       await remoteKeynode2.nodeGraph.setNode(remoteKeynode1Id, {
         host: remoteKeynode1.agentServiceHost,
         port: remoteKeynode1.agentServicePort,
-        scopes: ['external']
+        scopes: ['external'],
       });
 
       await remoteKeynode1.gestaltGraph.setNode({
@@ -581,12 +581,12 @@ describe('VaultManager', () => {
       await nodeGraph.setNode(remoteKeynode1Id, {
         host: remoteKeynode1.agentServiceHost,
         port: remoteKeynode1.agentServicePort,
-        scopes: ['external']
+        scopes: ['external'],
       });
       await nodeGraph.setNode(remoteKeynode2Id, {
         host: remoteKeynode2.agentServiceHost,
         port: remoteKeynode2.agentServicePort,
-        scopes: ['external']
+        scopes: ['external'],
       });
     });
     afterEach(async () => {
@@ -1388,7 +1388,7 @@ describe('VaultManager', () => {
         await nodeGraph.setNode(targetNodeId, {
           host: remoteKeynode1.agentServiceHost,
           port: remoteKeynode1.agentServicePort,
-          scopes: ['external']
+          scopes: ['external'],
         });
 
         await remoteKeynode1.gestaltGraph.setNode({

--- a/tests/vaults/VaultManager.test.ts
+++ b/tests/vaults/VaultManager.test.ts
@@ -517,10 +517,12 @@ describe('VaultManager', () => {
       await remoteKeynode1.nodeGraph.setNode(remoteKeynode2Id, {
         host: remoteKeynode2.agentServiceHost,
         port: remoteKeynode2.agentServicePort,
+        scopes: ['external']
       });
       await remoteKeynode2.nodeGraph.setNode(remoteKeynode1Id, {
         host: remoteKeynode1.agentServiceHost,
         port: remoteKeynode1.agentServicePort,
+        scopes: ['external']
       });
 
       await remoteKeynode1.gestaltGraph.setNode({
@@ -579,10 +581,12 @@ describe('VaultManager', () => {
       await nodeGraph.setNode(remoteKeynode1Id, {
         host: remoteKeynode1.agentServiceHost,
         port: remoteKeynode1.agentServicePort,
+        scopes: ['external']
       });
       await nodeGraph.setNode(remoteKeynode2Id, {
         host: remoteKeynode2.agentServiceHost,
         port: remoteKeynode2.agentServicePort,
+        scopes: ['external']
       });
     });
     afterEach(async () => {
@@ -1384,6 +1388,7 @@ describe('VaultManager', () => {
         await nodeGraph.setNode(targetNodeId, {
           host: remoteKeynode1.agentServiceHost,
           port: remoteKeynode1.agentServicePort,
+          scopes: ['external']
         });
 
         await remoteKeynode1.gestaltGraph.setNode({


### PR DESCRIPTION
### Description

This PR integrates MDNS into the NodeConnectionManager to allow for the discovery of nodes on the local network, as well as disable holepunching for connections to local network addresses.

This PR should only focus on the Step 1 of #537 spec, as modifying the node graph to accept multiple IP addresses will require ACL changes that default disable the sharing of local addresses with seed nodes, as well as expansion to support multiple IP addresses.

This PR will encapsulate MDNS in the NodeConnectionManager, as well as make methods such as `getConnection` to be able to query MDNS for known hosts through the newly added `findNodesAll` and `findNodesLocal` methods. `findNodesAll` is a method that calls both the original `findNode` and `findNodesLocal` to aggregate a list of all NodeAddresses. This is notably only used in connection-related methods rather than those related to Kademlia (NodeGraph).

When the NodeConnectionManager is started, MDNS will be started, with a Polykey service registered, and a query for Polykey services started.

When the NodeConnectionManager is stopped, MDNS will be stopped alongside all pending queries, and deregistering all registered services.

Current scopes: `external` and `local`.

### Issues Related
<!-- List all issues fixed by this PR. -->
* Related #537 

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Integrate MDNS into NodeConnectionManager
- [x] 2. Separate MDNS and Kademlia Behaviour
- [x] 3. Update NodeConnectionManager Methods to Support Multiple IP Addresses
  - [x]  `getConnectionWithAddress`
  - [x] `getConnection` 
- [x] 4. Select a well-known port and multicast address for Polykey usage.
- [x] 5. Modify Network Domain to Support Link-Local Addresses with a Interface ID Suffix.
- [x] 6. Creating of connections should happen in stages, where local addresses should be tried for first before external addresses 

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
