### PR TITLE
Feature sync node graph fix

### DIFF
--- a/src/nodes/NodeConnection.ts
+++ b/src/nodes/NodeConnection.ts
@@ -16,9 +16,14 @@ import { CreateDestroy } from '@matrixai/async-init/dist/CreateDestroy';
 import { status } from '@matrixai/async-init';
 import { timedCancellable, context } from '@matrixai/contexts/dist/decorators';
 import { AbstractEvent, EventAll } from '@matrixai/events';
-import { QUICClient, events as quicEvents } from '@matrixai/quic';
+import {
+  QUICClient,
+  events as quicEvents,
+  errors as quicErrors,
+} from '@matrixai/quic';
 import { RPCClient } from '@matrixai/rpc';
 import { middleware as rpcUtilsMiddleware } from '@matrixai/rpc';
+import { errors as contextErrors } from '@matrixai/contexts';
 import * as nodesErrors from './errors';
 import * as nodesEvents from './events';
 import * as networkUtils from '../network/utils';
@@ -226,40 +231,56 @@ class NodeConnection<M extends ClientManifest> {
       throw new nodesErrors.ErrorNodeConnectionHostWildcard();
     }
     let validatedNodeId: NodeId | undefined;
-    const quicClient = await QUICClient.createQUICClient(
-      {
-        host: targetHost,
-        port: targetPort,
-        socket: quicSocket,
-        config: {
-          keepAliveIntervalTime: connectionKeepAliveIntervalTime,
-          maxIdleTimeout: connectionKeepAliveTimeoutTime,
-          verifyPeer: true,
-          verifyCallback: async (certPEMs) => {
-            const result = await networkUtils.verifyServerCertificateChain(
-              targetNodeIds,
-              certPEMs,
-            );
-            if (result.result === 'success') {
-              validatedNodeId = result.nodeId;
-              return;
-            } else {
-              return result.value;
-            }
+    let quicClient: QUICClient;
+    try {
+      quicClient = await QUICClient.createQUICClient(
+        {
+          host: targetHost,
+          port: targetPort,
+          socket: quicSocket,
+          config: {
+            keepAliveIntervalTime: connectionKeepAliveIntervalTime,
+            maxIdleTimeout: connectionKeepAliveTimeoutTime,
+            verifyPeer: true,
+            verifyCallback: async (certPEMs) => {
+              const result = await networkUtils.verifyServerCertificateChain(
+                targetNodeIds,
+                certPEMs,
+              );
+              if (result.result === 'success') {
+                validatedNodeId = result.nodeId;
+                return;
+              } else {
+                return result.value;
+              }
+            },
+            ca: undefined,
+            key: tlsConfig.keyPrivatePem,
+            cert: tlsConfig.certChainPem,
           },
-          ca: undefined,
-          key: tlsConfig.keyPrivatePem,
-          cert: tlsConfig.certChainPem,
+          crypto: {
+            ops: crypto,
+          },
+          reasonToCode: nodesUtils.reasonToCode,
+          codeToReason: nodesUtils.codeToReason,
+          logger: logger.getChild(QUICClient.name),
         },
-        crypto: {
-          ops: crypto,
-        },
-        reasonToCode: nodesUtils.reasonToCode,
-        codeToReason: nodesUtils.codeToReason,
-        logger: logger.getChild(QUICClient.name),
-      },
-      ctx,
-    );
+        ctx,
+      );
+    } catch (e) {
+      if (
+        e instanceof contextErrors.ErrorContextsTimedTimeOut ||
+        e instanceof quicErrors.ErrorQUICClientCreateTimeout ||
+        e instanceof quicErrors.ErrorQUICConnectionStartTimeout ||
+        e instanceof quicErrors.ErrorQUICConnectionIdleTimeout
+      ) {
+        throw new nodesErrors.ErrorNodeConnectionTimeout(
+          `Timed out after ${ctx.timer.delay}ms`,
+          { cause: e },
+        );
+      }
+      throw e;
+    }
     const quicConnection = quicClient.connection;
     // FIXME: right now I'm not sure it's possible for streams to be emitted while setting up here.
     //  If we get any while setting up they need to be re-emitted after set up. Otherwise cleaned up.

--- a/src/nodes/NodeConnection.ts
+++ b/src/nodes/NodeConnection.ts
@@ -68,7 +68,7 @@ class NodeConnection<M extends ClientManifest> {
   protected handleEventNodeConnectionError = (
     evt: nodesEvents.EventNodeConnectionError,
   ): void => {
-    this.logger.warn(`NodeConnection error caused by ${evt.detail.message}`);
+    this.logger.debug(`NodeConnection error caused by ${evt.detail.message}`);
     this.dispatchEvent(new nodesEvents.EventNodeConnectionClose());
   };
 
@@ -81,7 +81,7 @@ class NodeConnection<M extends ClientManifest> {
   protected handleEventNodeConnectionClose = async (
     _evt: nodesEvents.EventNodeConnectionClose,
   ): Promise<void> => {
-    this.logger.warn(`close event triggering NodeConnection.destroy`);
+    this.logger.debug(`close event triggering NodeConnection.destroy`);
     // This will trigger the destruction of this NodeConnection.
     if (this[status] !== 'destroying') {
       await this.destroy({ force: true });
@@ -111,9 +111,12 @@ class NodeConnection<M extends ClientManifest> {
   protected handleEventQUICError = (
     evt: quicEvents.EventQUICConnectionError,
   ): void => {
-    const err = new nodesErrors.ErrorNodeConnectionInternalError(undefined, {
-      cause: evt.detail,
-    });
+    const err = new nodesErrors.ErrorNodeConnectionInternalError(
+      evt.detail.message,
+      {
+        cause: evt.detail,
+      },
+    );
     this.dispatchEvent(
       new nodesEvents.EventNodeConnectionError({ detail: err }),
     );

--- a/src/nodes/NodeConnectionManager.ts
+++ b/src/nodes/NodeConnectionManager.ts
@@ -816,7 +816,7 @@ class NodeConnectionManager {
         connectionsResults,
         { timer: ctx.timer, signal },
       ).finally(() => {
-        if (connectionsResults.size === resolvedAddresses.length) {
+        if (connectionsResults.size === nodeIds.length) {
           // We have found all nodes, clean up remaining connections
           abortController.abort(cleanUpReason);
         }
@@ -1554,21 +1554,22 @@ class NodeConnectionManager {
    * The main use-case is to connect to multiple seed nodes on the same hostname.
    * @param nodeIds
    * @param addresses
-   * @param limit
    * @param ctx
    */
   public getMultiConnection(
     nodeIds: Array<NodeId>,
     addresses: Array<NodeAddress>,
-    limit?: number,
-    ctx?: Partial<ContextTimed>,
+    ctx?: Partial<ContextTimedInput>,
   ): PromiseCancellable<Array<NodeId>>;
   @ready(new nodesErrors.ErrorNodeConnectionManagerNotRunning())
-  @timedCancellable(true)
+  @timedCancellable(
+    true,
+    (nodeConnectionManager: NodeConnectionManager) =>
+      nodeConnectionManager.connectionConnectTimeoutTime,
+  )
   public async getMultiConnection(
     nodeIds: Array<NodeId>,
     addresses: Array<NodeAddress>,
-    limit: number | undefined,
     @context ctx: ContextTimed,
   ): Promise<Array<NodeId>> {
     const locks: Array<LockRequest<Lock>> = nodeIds.map((nodeId) => {

--- a/src/nodes/NodeConnectionManager.ts
+++ b/src/nodes/NodeConnectionManager.ts
@@ -825,7 +825,7 @@ class NodeConnectionManager {
     // We race the connections with timeout
     try {
       this.logger.debug(`awaiting connections`);
-      await Promise.race([Promise.all(connProms)]);
+      await Promise.allSettled(connProms);
       this.logger.debug(`awaiting connections resolved`);
     } finally {
       // Cleaning up

--- a/tests/nodes/NodeConnection.test.ts
+++ b/tests/nodes/NodeConnection.test.ts
@@ -4,10 +4,10 @@ import type { RPCStream } from '@matrixai/rpc';
 import { QUICServer, QUICSocket, events as quicEvents } from '@matrixai/quic';
 import Logger, { formatting, LogLevel, StreamHandler } from '@matrixai/logger';
 import { errors as quicErrors } from '@matrixai/quic';
-import { ErrorContextsTimedTimeOut } from '@matrixai/contexts/dist/errors';
 import { RPCServer } from '@matrixai/rpc';
 import * as nodesUtils from '@/nodes/utils';
 import * as nodesEvents from '@/nodes/events';
+import * as nodesErrors from '@/nodes/errors';
 import * as keysUtils from '@/keys/utils';
 import NodeConnection from '@/nodes/NodeConnection';
 import { promise } from '@/utils';
@@ -164,8 +164,7 @@ describe(`${NodeConnection.name}`, () => {
       { timer: 100 },
     ).then(extractNodeConnection);
     await expect(nodeConnectionProm).rejects.toThrow(
-      // QuicErrors.ErrorQUICClientCreateTimeOut, // FIXME: this is not throwing the right error
-      ErrorContextsTimedTimeOut,
+      nodesErrors.ErrorNodeConnectionTimeout,
     );
   });
   test('connection drops out (socket stops responding)', async () => {


### PR DESCRIPTION
### Description

This PR addresses some minor issues with `syncNodeGraph` and the multi connection logic.

### Issues Fixed

* No direct issues fixed, just a collection of small incidental fixes.

### Tasks

* [X] 1. Fix issue with `NodeManager.syncNodeGraph` throwing when a connection fails.
* [X] 2. NCM `establishMultiConnection` should only throw if no connections were established.
* [X] 3. Expand tests relating to multi connection logic.
* [X] 4. `NodeConnection` throws a nodes domain timeout error on connection timeout.
* ~5. Something is holding the process open, related to the `keepAliveIntervalTime`. Investigate.~ https://github.com/MatrixAI/js-timer/issues/15

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
