### PR TITLE
Fixing identities claim to be in-line with identities discover and identities trust, by introducing a new parser parseGestaltIdentityId

### DIFF
--- a/src/ids/index.ts
+++ b/src/ids/index.ts
@@ -338,6 +338,21 @@ function parseGestaltId(data: any): GestaltId {
   return ['identity', [providerId, identityId]];
 }
 
+function parseGestaltIdentityId(data: any): ['identity', ProviderIdentityId] {
+  if (typeof data !== 'string') {
+    throw new validationErrors.ErrorParse('Gestalt identity ID must be string');
+  }
+  const match = (data as string).match(/^(.+):(.+)$/);
+  if (match == null) {
+    throw new validationErrors.ErrorParse(
+      'Gestalt identity ID must be `Provider ID:Identity ID`',
+    );
+  }
+  const providerId = parseProviderId(match[1]);
+  const identityId = parseIdentityId(match[2]);
+  return ['identity', [providerId, identityId]];
+}
+
 function encodeGestaltId(gestaltId: GestaltId): GestaltIdEncoded {
   switch (gestaltId[0]) {
     case 'node':
@@ -476,6 +491,7 @@ export {
   encodeProviderIdentityId,
   decodeProviderIdentityId,
   parseGestaltId,
+  parseGestaltIdentityId,
   encodeGestaltId,
   encodeGestaltNodeId,
   encodeGestaltIdentityId,


### PR DESCRIPTION
RELATED TO https://github.com/MatrixAI/Polykey-CLI/pull/29

### Description

For the CLI fix, we need a new function to parse the gestalt identity, this introduces `parseGestaltIdentityId` in Polykey to achieve the same.

The `pk identities claim` currently takes two parameters in order to claim an identity. 

```
pk identities claim github.com cmcdragonkai
```

This is not consistent with other two commands `trust` and `discover`. 

```
pk identities trust github.com:cmcdragonkai
pk identities discover github.com:cmcdragonkai
```

These two commands are not using the `ProviderIdentityId` type. 

```
type ProviderIdentityId = [ProviderId, IdentityId];
```

This is because the encoded form of this type is `["github.com", "cmcdragonkai"]`.

Instead we need to use a parser similar to `binParsers.parseGestaltId`  (which is used by the trust and discover commands), however this parser, parses both node IDs and identities. 

What we need to do is to extract the identity parsing portion of `binParsers.parseGestaltId`.

```typescript
function parseGestaltId(data: any): GestaltId {
  if (typeof data !== 'string') {
    throw new validationErrors.ErrorParse('Gestalt ID must be string');
  }
  const nodeId = decodeNodeId(data);
  if (nodeId != null) {
    return ['node', nodeId];
  }
  const match = (data as string).match(/^(.+):(.+)$/);
  if (match == null) {
    throw new validationErrors.ErrorParse(
      'Gestalt ID must be either a Node ID or `Provider ID:Identity ID`',
    );
  }
  const providerId = parseProviderId(match[1]);
  const identityId = parseIdentityId(match[2]);
  return ['identity', [providerId, identityId]];
}
```

It will be:

```ts
  const match = (data as string).match(/^(.+):(.+)$/);
  if (match == null) {
    throw new validationErrors.ErrorParse(
      'Gestalt ID must be either a Node ID or `Provider ID:Identity ID`',
    );
  }
  const providerId = parseProviderId(match[1]);
  const identityId = parseIdentityId(match[2]);
  return ['identity', [providerId, identityId]];
```

This will be called `parseGestaltIdentityId`.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #[28](https://github.com/MatrixAI/Polykey-CLI/issues/28) 

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Introduce `parseGestaltIdentityId`

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
