### PR TITLE
Adding privateKeyPath back to PolykeyAgent 

### DIFF
--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -2,7 +2,7 @@ import type { DeepPartial, FileSystem } from './types';
 import type { PolykeyWorkerManagerInterface } from './workers/types';
 import type { TLSConfig } from './network/types';
 import type { SeedNodes } from './nodes/types';
-import type { Key, PasswordOpsLimit, PasswordMemLimit } from './keys/types';
+import type { Key, PasswordOpsLimit, PasswordMemLimit, PrivateKey } from "./keys/types";
 import path from 'path';
 import process from 'process';
 import Logger from '@matrixai/logger';
@@ -61,6 +61,8 @@ type PolykeyAgentOptions = {
     certDuration: number;
     certRenewLeadTime: number;
     recoveryCode: string;
+    privateKeyPath: string;
+    privateKey: PrivateKey;
   };
   client: {
     keepAliveTimeoutTime: number;


### PR DESCRIPTION
### Description

In 

https://github.com/MatrixAI/Polykey/pull/582

Changes were made to `PolykeyAgentOptions `and it was flattened to remove dependency on types, this resulted in `privateKeyPath `being removed from `PolykeyAgentOptions `which is causing issues in `Polykey-CLI`. 

This PR aims to add it back to PolykeyAgentOptions.

```ts
    privateKey: string;
    privateKeyPath: string;
```

### Tasks

- [x] 1. Add  `privateKey` and `privateKeyPath` back to `PolykeyAgentOptions`.

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
