### PR TITLE
Fix `recoveryCode`, `privateKey`, `privateKeyPath` options usage in `PolykeyAgentOptions`

### DIFF
--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -2,7 +2,12 @@ import type { DeepPartial, FileSystem } from './types';
 import type { PolykeyWorkerManagerInterface } from './workers/types';
 import type { TLSConfig } from './network/types';
 import type { SeedNodes } from './nodes/types';
-import type { Key, PasswordOpsLimit, PasswordMemLimit, PrivateKey } from "./keys/types";
+import type {
+  Key,
+  PasswordOpsLimit,
+  PasswordMemLimit,
+  PrivateKey,
+} from './keys/types';
 import path from 'path';
 import process from 'process';
 import Logger from '@matrixai/logger';
@@ -62,7 +67,7 @@ type PolykeyAgentOptions = {
     certRenewLeadTime: number;
     recoveryCode: string;
     privateKeyPath: string;
-    privateKey: PrivateKey;
+    privateKey: Buffer;
   };
   client: {
     keepAliveTimeoutTime: number;

--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -2,11 +2,7 @@ import type { DeepPartial, FileSystem, ObjectEmpty } from './types';
 import type { PolykeyWorkerManagerInterface } from './workers/types';
 import type { TLSConfig } from './network/types';
 import type { SeedNodes } from './nodes/types';
-import type {
-  Key,
-  PasswordOpsLimit,
-  PasswordMemLimit,
-} from './keys/types';
+import type { Key, PasswordOpsLimit, PasswordMemLimit } from './keys/types';
 import path from 'path';
 import process from 'process';
 import Logger from '@matrixai/logger';


### PR DESCRIPTION
### Description

This PR builds on #600 by implementing types that were added in the last PR, these include

```ts
    recoveryCode: string;
    privateKey: Buffer;
    privateKeyPath: string;
```

These types are a part of `src/keys/KeyRing` which is responsible for setting up the KeyRing, which is crucial in setting up the root key pair. 

These types are implemented in keyRing as so: 

```ts
 public async start(
    options: {
      password: string;
      fresh?: boolean;
    } & (
      | ObjectEmpty
      | { recoveryCode: RecoveryCode }
      | { privateKey: PrivateKey }
      | { privateKeyPath: string }
    ),
  ): Promise<void> {
    const { fresh = false, ...setupKeyPairOptions } = options;
    this.logger.info(`Starting ${this.constructor.name}`);
    if (fresh) {
      await this.fs.promises.rm(this.keysPath, {
        force: true,
        recursive: true,
      });
    }
    await this.fs.promises.mkdir(this.keysPath, { recursive: true });
    const [keyPair, recoveryCode] =
      await this.setupKeyPair(setupKeyPairOptions);
    const dbKey = await this.setupDbKey(keyPair);
    const [passwordHash, passwordSalt] = await this.setupPasswordHash(
      options.password,
    );
    bufferLock(keyPair.publicKey, this.strictMemoryLock);
    bufferLock(keyPair.privateKey, this.strictMemoryLock);
    bufferLock(keyPair.secretKey, this.strictMemoryLock);
    bufferLock(dbKey, this.strictMemoryLock);
    bufferLock(passwordHash, this.strictMemoryLock);
    bufferLock(passwordSalt, this.strictMemoryLock);
    this._keyPair = keyPair as KeyPairLocked;
    this._dbKey = dbKey;
    this.passwordHash = {
      hash: passwordHash,
      salt: passwordSalt,
    };
    if (recoveryCode != null) {
      const recoveryCodeData = Buffer.from(recoveryCode, 'utf-8');
      bufferLock(recoveryCodeData, this.strictMemoryLock);
      this._recoveryCodeData = recoveryCodeData as RecoveryCodeLocked;
    }
    this.logger.info(`Started ${this.constructor.name}`);
  }
```

In `PolykeyAgent`, the start function of `KeyRing` is called in the `start` function of `PolykeyAgent`. 

Therefore, the further part of this PR is to pass the types in the start function of `PolykeyAgent`, which would be something like this: 

```ts
 public async start({
    password,
    options = {},
    fresh = false,
  }: {
    password: string;
    options?: DeepPartial<{
      clientServiceHost: string;
      clientServicePort: number;
      agentServiceHost: string;
      agentServicePort: number;
      ipv6Only: boolean;
      workers: number;
      keys: {
        recoveryCode: string;
        privateKey: Buffer;
        privateKeyPath: string;
      }
    }>;
    workers?: number;
    fresh?: boolean;
  }) {
    const optionsDefaulted = utils.mergeObjects(options, {
      clientServiceHost: config.defaultsUser.clientServiceHost,
      clientServicePort: config.defaultsUser.clientServicePort,
      agentServiceHost: config.defaultsUser.agentServiceHost,
      agentServicePort: config.defaultsUser.agentServicePort,
      workers: config.defaultsUser.workers,
      ipv6Only: config.defaultsUser.ipv6Only,
    });
    ```
    
These are then called in when starting the keyRing, which would be something like this: 

```ts
      await this.keyRing.start({
        password,
        fresh,
        recoveryCode: optionsDefaulted.recoveryCode,
        privateKey: optionsDefaulted.privateKey,
        privateKeyPath: optionsDefaulted.privateKeyPath,
      });
```

Also, a thing to note here is that, recoverCode, privateKey and privateKeyPath can be independently supplied, which is ensured by: 

```ts
    } & (
      | ObjectEmpty
      | { recoveryCode: RecoveryCode }
      | { privateKey: PrivateKey }
      | { privateKeyPath: string }
    ),
```

in KeyRing start. 

Consequently, they are similarly implemented in PolykeyAgent types 

```ts
type PolykeyAgentOptions = {
  nodePath: string;
  clientServiceHost: string;
  clientServicePort: number;
  agentServiceHost: string;
  agentServicePort: number;
  seedNodes: SeedNodes;
  workers: number;
  ipv6Only: boolean;
  keys: {
    passwordOpsLimit: PasswordOpsLimit;
    passwordMemLimit: PasswordMemLimit;
    strictMemoryLock: boolean;
    certDuration: number;
    certRenewLeadTime: number;
    recoveryCode: string;
    privateKey: Buffer;
    privateKeyPath: string;
  };
  client: {
    keepAliveTimeoutTime: number;
    keepAliveIntervalTime: number;
    rpcCallTimeoutTime: number;
    rpcParserBufferSize: number;
  };
  nodes: {
    connectionIdleTimeoutTime: number;
    connectionFindConcurrencyLimit: number;
    connectionConnectTimeoutTime: number;
    connectionKeepAliveTimeoutTime: number;
    connectionKeepAliveIntervalTime: number;
    connectionHolePunchIntervalTime: number;
    rpcCallTimeoutTime: number;
    rpcParserBufferSize: number;
  };
} & (
  | ObjectEmpty
  | { recoveryCode: RecoveryCode }
  | { privateKey: PrivateKey }
  | { privateKeyPath: string }
  );
```

### Tasks

- [x] 1. Lintfix #600 
- [x] 2. Make privateKey type to Buffer from privateKey 
- [x] 3. privateKey declared above privateKeyPath
- [x] 4. PolykeyAgent start requires the options privateKey  and PrivateKeyPath to be specified.
- [x] 5. Also add recoveryCode to options and deep partial it into agent.start.

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
