### PR TITLE
`Provider.checkToken` will no longer treat empty `refreshToken` strings as invalid tokens and fixed use of `__proto__` as `identityId` in `IdentitiesManager`

### DIFF
--- a/src/identities/IdentitiesManager.ts
+++ b/src/identities/IdentitiesManager.ts
@@ -206,7 +206,15 @@ class IdentitiesManager {
       );
     }
     const providerTokens = await this.getTokens(providerId);
-    providerTokens[identityId] = providerToken;
+    // This has to be done in case the key is `__proto__`.
+    // Otherwise, the object will not be correctly serialized.
+    // https://github.com/MatrixAI/Polykey/issues/608
+    Object.defineProperty(providerTokens, identityId, {
+      value: providerToken,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
     const providerIdPath = [
       ...this.identitiesTokensDbPath,
       providerId,

--- a/src/identities/Provider.ts
+++ b/src/identities/Provider.ts
@@ -58,21 +58,25 @@ abstract class Provider {
    * If the refresh token exists, and is still valid, then it will attempt to
    * refresh the token.
    * If you pass in identityId, expect that the new token will be persisted.
+   * If either `providerToken.accessTokenExpiresIn` or `providerToken.refreshTokenExpiresIn` is set to 0,
+   * their related tokens will be treated as never-expiring.
    */
   public async checkToken(
     providerToken: ProviderToken,
     identityId?: IdentityId,
   ): Promise<ProviderToken> {
     const now = Math.floor(Date.now() / 1000);
+    // This will mean that if accessTokenExpiresIn = 0, the token never expires
     if (
       providerToken.accessTokenExpiresIn &&
       providerToken.accessTokenExpiresIn >= now
     ) {
-      if (!providerToken.refreshToken) {
+      if (providerToken.refreshToken == null) {
         throw new identitiesErrors.ErrorProviderUnauthenticated(
           'Access token expired',
         );
       }
+      // This will mean that refreshTokenExpiresIn = 0 does not throw
       if (
         providerToken.refreshTokenExpiresIn &&
         providerToken.refreshTokenExpiresIn >= now

--- a/src/identities/types.ts
+++ b/src/identities/types.ts
@@ -33,6 +33,9 @@ type IdentitySignedClaim = {
 
 /**
  * Authentication tokens to the identity provider
+ *
+ * If `accessTokenExpiresIn` is set to 0, the `accessToken` will never expire.
+ * If `refreshTokenExpiresIn` is set to 0, the `refreshToken` will never expire.
  */
 type ProviderToken = {
   accessToken: string;

--- a/tests/identities/TestProvider.ts
+++ b/tests/identities/TestProvider.ts
@@ -63,7 +63,8 @@ class TestProvider extends Provider {
   }
 
   public async refreshToken(): Promise<ProviderToken> {
-    throw new identitiesErrors.ErrorProviderUnimplemented();
+    // Always gives back the abc123 token
+    return { accessToken: 'abc123' };
   }
 
   public async getAuthIdentityIds(): Promise<Array<IdentityId>> {


### PR DESCRIPTION
### Description


#### Provider

The `handleClaimIdentity` test in `tests/identities/IdentitiesManager.test.ts` was failing on `handleClaimIdentity`. This was because it was treating refreshTokens of empty strings as invalid tokens. This is no longer the case.


```
FAIL  tests/identities/IdentitiesManager.test.ts
  IdentitiesManager
    ✓ IdentitiesManager readiness (85 ms)
    ✓ get, set and unset tokens (with seed=-201149676) (395 ms)
    ✓ start and stop preserves state (with seed=-201149676) (234 ms)
    ✓ fresh start deletes all state (with seed=-201149676) (255 ms)
    ✓ register and unregister providers (39 ms)
    ✓ using TestProvider (with seed=-201149676) (1553 ms)
    ✕ handleClaimIdentity (with seed=1486144507) (939 ms)

  ● IdentitiesManager › handleClaimIdentity (with seed=1486144507)

    Property failed after 1 tests
    { seed: 1486144507, path: "0:0:0:0:0:0:0:0:0:0:0:0:0:3:0:1:1:0:3:0:0:0:1:1:0:1:3:2:0:1", endOnFailure: true }
    Counterexample: ["",{"accessToken":"          ","refreshToken":"","accessTokenExpiresIn":1698190047,"refreshTokenExpiresIn":0}]
    Shrunk 29 time(s)
    Got ErrorProviderUnimplemented:

      64 |
      65 |   public async refreshToken(): Promise<ProviderToken> {
    > 66 |     throw new identitiesErrors.ErrorProviderUnimplemented();
         |           ^
      67 |   }
      68 |
      69 |   public async getAuthIdentityIds(): Promise<Array<IdentityId>> {

      at TestProvider.refreshToken (tests/identities/TestProvider.ts:66:11)
      at TestProvider.refreshToken [as checkToken] (src/identities/Provider.ts:85:25)
      at TestProvider.checkToken [as publishClaim] (tests/identities/TestProvider.ts:152:16)
      at src/identities/IdentitiesManager.ts:272:39
      at constructor_.addClaim (src/sigchain/Sigchain.ts:449:20)
      at withF (node_modules/@matrixai/resources/src/utils.ts:24:12)
      at constructor_.handleClaimIdentity (src/identities/IdentitiesManager.ts:261:5)
      at numRuns (tests/identities/IdentitiesManager.test.ts:361:7)
      at AsyncProperty.run (node_modules/fast-check/lib/check/property/AsyncProperty.generic.js:49:28)
      Hint: Enable verbose mode in order to have the list of all failing values encountered during the run
      at buildError (node_modules/fast-check/lib/check/runner/utils/RunDetailsFormatter.js:131:15)
      at asyncThrowIfFailed (node_modules/fast-check/lib/check/runner/utils/RunDetailsFormatter.js:148:11)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 6 passed, 7 total
Snapshots:   0 total
Time:        4.02 s
Ran all test suites matching /.\/tests\/identities\/IdentitiesManager.test.ts/i.
GLOBAL TEARDOWN
Destroying Global Data Dir: /tmp/polykey-test-global-weOx7R
```

It is also defined now that any expiry values in AccessToken set to 0, now have their related tokens treated as never-expiring. This was already the case before this PR, but inline comments have been added to document this.

```ts
public async checkToken(
    providerToken: ProviderToken,
    identityId?: IdentityId,
  ): Promise<ProviderToken> {
    const now = Math.floor(Date.now() / 1000);
    // this will mean that accessTokenExpiresIn = 0 will be false
    if (
      providerToken.accessTokenExpiresIn &&
      providerToken.accessTokenExpiresIn >= now
    ) {
      if (providerToken.refreshToken == null) {
        throw new identitiesErrors.ErrorProviderUnauthenticated(
          'Access token expired',
        );
      }
      // this will mean that refreshTokenExpiresIn = 0 does not throw
      if (
        providerToken.refreshTokenExpiresIn &&
        providerToken.refreshTokenExpiresIn >= now
      ) {
        throw new identitiesErrors.ErrorProviderUnauthenticated(
          'Refresh token expired',
        );
      }
      return await this.refreshToken(providerToken, identityId);
    }
    return providerToken;
  }
```

#### Prototype Pollution

During testing, I noticed two other tests in `IdentitiesManager.test.ts` failing. This was because of fastcheck sometimes generating a string value of `__proto__` for the `identityId`. The `identityId` is used as the key for the object that comes out of RocksDB, there is a problem with prototype pollution. This is not only a security issue, but also that `JSON.stringify` does not serialize the `__proto__` property of an object, so certain the provider keys for that identity will never work. This PR uses `Object.defineProperty`to correctly set the `__proto__` property on the `providerTokens` object.

### Issues Related
* https://github.com/MatrixAI/Polykey-CLI/issues/40#issuecomment-1778016364
* Fixes #608 

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Fix conditional check of valid `refreshToken`
- [x] 2. Inline documentation
- [x] 3. Define implementation for `TestProvider.refreshToken`
- [x] 4. Add errors to throw when prototype pollution of `identityId` is attempted

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
