### PR TITLE
Addressing crashes from failing background connections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@matrixai/id": "^3.3.6",
         "@matrixai/logger": "^3.1.0",
         "@matrixai/mdns": "^1.2.3",
-        "@matrixai/quic": "^1.0.0",
+        "@matrixai/quic": "^1.1.0",
         "@matrixai/resources": "^1.1.5",
         "@matrixai/rpc": "^0.2.4",
         "@matrixai/timer": "^1.1.2",
@@ -1561,9 +1561,9 @@
       "integrity": "sha512-ulDEYPv7asdKvqahuAY35c1selLdzDwHqugK92hfkzvlDCwXRRelDkR+Er33md/PtnpqHemgkuDPanZ4fiYZ8w=="
     },
     "node_modules/@matrixai/quic": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic/-/quic-1.0.0.tgz",
-      "integrity": "sha512-sJ+tnXHgngsTIH+AQrPxWeCw1IpbcXFdzhKNVQLPlvkCGPkkvGTUddCddpyqunN72dcQdLQDG6aFQG3bhrItsw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic/-/quic-1.1.0.tgz",
+      "integrity": "sha512-AGurTHx5qylkWrrN0c42jR/dqLElDs2gejSXn8PkgqpLDuU+jqPsbtT3BZdRT96vbCP+gU58YcpdCuKJv7EvCg==",
       "dependencies": {
         "@matrixai/async-cancellable": "^1.1.1",
         "@matrixai/async-init": "^1.10.0",
@@ -1577,16 +1577,16 @@
         "ip-num": "^1.5.0"
       },
       "optionalDependencies": {
-        "@matrixai/quic-darwin-arm64": "1.0.0",
-        "@matrixai/quic-darwin-x64": "1.0.0",
-        "@matrixai/quic-linux-x64": "1.0.0",
-        "@matrixai/quic-win32-x64": "1.0.0"
+        "@matrixai/quic-darwin-arm64": "1.1.0",
+        "@matrixai/quic-darwin-x64": "1.1.0",
+        "@matrixai/quic-linux-x64": "1.1.0",
+        "@matrixai/quic-win32-x64": "1.1.0"
       }
     },
     "node_modules/@matrixai/quic-darwin-arm64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-arm64/-/quic-darwin-arm64-1.0.0.tgz",
-      "integrity": "sha512-b6QW5PNNSFArnTQZJI6qLD4mi1w9/9Hfba+yc1gP3xdIuIFdwib+kM7YbnNIgG4WGsQ0bhk42tOmOqr68Ql2qQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-arm64/-/quic-darwin-arm64-1.1.0.tgz",
+      "integrity": "sha512-PlMjRHCXoIdN2X3uh0GRPj8WD32tFgvnlGJFl5kng2R8SjLWNiT3afFLW6G0Gwb7Net4iVBUvU6b2S5B9AgaxA==",
       "cpu": [
         "arm64"
       ],
@@ -1596,9 +1596,9 @@
       ]
     },
     "node_modules/@matrixai/quic-darwin-x64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-x64/-/quic-darwin-x64-1.0.0.tgz",
-      "integrity": "sha512-GQXBsNV07gztUsGSktD225eYtpdraVu4ysO5oFDnKMMlp6irP3tdmbHFDHrG6zBuChFJwg/RGd91EWFmGl0byQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-x64/-/quic-darwin-x64-1.1.0.tgz",
+      "integrity": "sha512-jjVaQv3j5EiXO0ORWICv2VHY59KiwmptCHXkA8VDsbqYXRS8DrafCAzhOEt5WCk6u7cjz6m9uiqMqFSqEFDVqQ==",
       "cpu": [
         "x64"
       ],
@@ -1608,9 +1608,9 @@
       ]
     },
     "node_modules/@matrixai/quic-linux-x64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-linux-x64/-/quic-linux-x64-1.0.0.tgz",
-      "integrity": "sha512-nADXVULD9jn7qaMo+9ftL6izpSYSM3wW/vcgKXTr4YCI1E/CsKPTrI8esanKbPfdnJ7ELlIRA9QddDgAEyWwQQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-linux-x64/-/quic-linux-x64-1.1.0.tgz",
+      "integrity": "sha512-MCPjuCLC9oCNRnNr+S6QWY26SjFREPeRMWXwg+1v34dT6Xu0WVdcLfOqFPBalEPGyb4NWbMkRz7ZZDLHpQ1FXQ==",
       "cpu": [
         "x64"
       ],
@@ -1620,9 +1620,9 @@
       ]
     },
     "node_modules/@matrixai/quic-win32-x64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-win32-x64/-/quic-win32-x64-1.0.0.tgz",
-      "integrity": "sha512-uRtMw3VjFGpyOEFDsHuLJu7lzZSMUhpXZalINA2uVOzWDHjKu0vd35W/J/SxhSAhiaBeeYIPj59exSFGQW43uA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-win32-x64/-/quic-win32-x64-1.1.0.tgz",
+      "integrity": "sha512-nvlctqR6ETC+KG7oJ3TxnI3i1zMFhkrIaw8453B43ljfIiHI46BsKJNuRrXqzx0FwulzJQor5C3BrzpGqtY8Ag==",
       "cpu": [
         "x64"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@matrixai/id": "^3.3.6",
         "@matrixai/logger": "^3.1.0",
         "@matrixai/mdns": "^1.2.3",
-        "@matrixai/quic": "^1.1.0",
+        "@matrixai/quic": "^1.1.1",
         "@matrixai/resources": "^1.1.5",
         "@matrixai/rpc": "^0.2.4",
         "@matrixai/timer": "^1.1.2",
@@ -1561,9 +1561,9 @@
       "integrity": "sha512-ulDEYPv7asdKvqahuAY35c1selLdzDwHqugK92hfkzvlDCwXRRelDkR+Er33md/PtnpqHemgkuDPanZ4fiYZ8w=="
     },
     "node_modules/@matrixai/quic": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic/-/quic-1.1.0.tgz",
-      "integrity": "sha512-AGurTHx5qylkWrrN0c42jR/dqLElDs2gejSXn8PkgqpLDuU+jqPsbtT3BZdRT96vbCP+gU58YcpdCuKJv7EvCg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic/-/quic-1.1.1.tgz",
+      "integrity": "sha512-C3CizeW/0lQ+tu+J9sKB7Sl7vx4CJq1t875B5Y5C5Ao0cZcjK1Xi10lSRILcce1RdoCpUGlbVFosat7YdONiGg==",
       "dependencies": {
         "@matrixai/async-cancellable": "^1.1.1",
         "@matrixai/async-init": "^1.10.0",
@@ -1577,16 +1577,16 @@
         "ip-num": "^1.5.0"
       },
       "optionalDependencies": {
-        "@matrixai/quic-darwin-arm64": "1.1.0",
-        "@matrixai/quic-darwin-x64": "1.1.0",
-        "@matrixai/quic-linux-x64": "1.1.0",
-        "@matrixai/quic-win32-x64": "1.1.0"
+        "@matrixai/quic-darwin-arm64": "1.1.1",
+        "@matrixai/quic-darwin-x64": "1.1.1",
+        "@matrixai/quic-linux-x64": "1.1.1",
+        "@matrixai/quic-win32-x64": "1.1.1"
       }
     },
     "node_modules/@matrixai/quic-darwin-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-arm64/-/quic-darwin-arm64-1.1.0.tgz",
-      "integrity": "sha512-PlMjRHCXoIdN2X3uh0GRPj8WD32tFgvnlGJFl5kng2R8SjLWNiT3afFLW6G0Gwb7Net4iVBUvU6b2S5B9AgaxA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-arm64/-/quic-darwin-arm64-1.1.1.tgz",
+      "integrity": "sha512-tTtJ1ppYzanlZLXnIBcyHPf+yzVCmn3CJHnA5ymMOJBfGN1zB6+ZPbuEWql/4+DveBn0qTMgbWzWGhv4xpi3Kg==",
       "cpu": [
         "arm64"
       ],
@@ -1596,9 +1596,9 @@
       ]
     },
     "node_modules/@matrixai/quic-darwin-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-x64/-/quic-darwin-x64-1.1.0.tgz",
-      "integrity": "sha512-jjVaQv3j5EiXO0ORWICv2VHY59KiwmptCHXkA8VDsbqYXRS8DrafCAzhOEt5WCk6u7cjz6m9uiqMqFSqEFDVqQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-x64/-/quic-darwin-x64-1.1.1.tgz",
+      "integrity": "sha512-XBhAO/fdY44s78zqhTwtUit5IU6ewZ3IZAbmKXDXQCpUQwJEORd9BV6kLfS+apiB8FGNgmaCsUoO8DoUMXr1eA==",
       "cpu": [
         "x64"
       ],
@@ -1608,9 +1608,9 @@
       ]
     },
     "node_modules/@matrixai/quic-linux-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-linux-x64/-/quic-linux-x64-1.1.0.tgz",
-      "integrity": "sha512-MCPjuCLC9oCNRnNr+S6QWY26SjFREPeRMWXwg+1v34dT6Xu0WVdcLfOqFPBalEPGyb4NWbMkRz7ZZDLHpQ1FXQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-linux-x64/-/quic-linux-x64-1.1.1.tgz",
+      "integrity": "sha512-EOT9u53Sw0NW6pesSYXO0KFdsh0sMXmrUr+9ZrlqlIIKRylPEUcvGgL5d1QTyMtNnwXoCl2azSkmX1QYg4tHFw==",
       "cpu": [
         "x64"
       ],
@@ -1620,9 +1620,9 @@
       ]
     },
     "node_modules/@matrixai/quic-win32-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@matrixai/quic-win32-x64/-/quic-win32-x64-1.1.0.tgz",
-      "integrity": "sha512-nvlctqR6ETC+KG7oJ3TxnI3i1zMFhkrIaw8453B43ljfIiHI46BsKJNuRrXqzx0FwulzJQor5C3BrzpGqtY8Ag==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-win32-x64/-/quic-win32-x64-1.1.1.tgz",
+      "integrity": "sha512-czHsmQ5YfYR2QXx4GxHaT9KveeeAnivHu3uUd+4KxKlTHBN8XM36X4y7ZuNxGvJjhhitidJ88NwxTQWe54hZGg==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@matrixai/id": "^3.3.6",
     "@matrixai/logger": "^3.1.0",
     "@matrixai/mdns": "^1.2.3",
-    "@matrixai/quic": "^1.1.0",
+    "@matrixai/quic": "^1.1.1",
     "@matrixai/resources": "^1.1.5",
     "@matrixai/rpc": "^0.2.4",
     "@matrixai/timer": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@matrixai/id": "^3.3.6",
     "@matrixai/logger": "^3.1.0",
     "@matrixai/mdns": "^1.2.3",
-    "@matrixai/quic": "^1.0.0",
+    "@matrixai/quic": "^1.1.0",
     "@matrixai/resources": "^1.1.5",
     "@matrixai/rpc": "^0.2.4",
     "@matrixai/timer": "^1.1.2",

--- a/src/nodes/NodeConnection.ts
+++ b/src/nodes/NodeConnection.ts
@@ -26,6 +26,7 @@ import { middleware as rpcUtilsMiddleware } from '@matrixai/rpc';
 import { errors as contextErrors } from '@matrixai/contexts';
 import * as nodesErrors from './errors';
 import * as nodesEvents from './events';
+import { ConnectionErrorReason, ConnectionErrorCode } from './types';
 import * as networkUtils from '../network/utils';
 import * as nodesUtils from '../nodes/utils';
 import { never } from '../utils';
@@ -487,8 +488,8 @@ class NodeConnection<M extends ClientManifest> {
       force
         ? {
             isApp: true,
-            errorCode: 1,
-            reason: Buffer.from('NodeConnection is forcing destruction'),
+            errorCode: ConnectionErrorCode.ForceClose,
+            reason: Buffer.from(ConnectionErrorReason.ForceClose),
             force,
           }
         : {},

--- a/src/nodes/NodeConnection.ts
+++ b/src/nodes/NodeConnection.ts
@@ -364,7 +364,7 @@ class NodeConnection<M extends ClientManifest> {
     return nodeConnection;
   }
 
-  static async createNodeConnectionReverse<M extends ClientManifest>({
+  static createNodeConnectionReverse<M extends ClientManifest>({
     certChain,
     nodeId,
     quicConnection,
@@ -376,7 +376,7 @@ class NodeConnection<M extends ClientManifest> {
     quicConnection: QUICConnection;
     manifest: M;
     logger?: Logger;
-  }): Promise<NodeConnection<M>> {
+  }): NodeConnection<M> {
     logger.info(`Creating ${this.name}`);
     // Creating RPCClient
     const rpcClient = new RPCClient<M>({
@@ -489,7 +489,7 @@ class NodeConnection<M extends ClientManifest> {
             isApp: true,
             errorCode: 1,
             reason: Buffer.from('NodeConnection is forcing destruction'),
-            force: true,
+            force,
           }
         : {},
     );

--- a/src/nodes/NodeConnection.ts
+++ b/src/nodes/NodeConnection.ts
@@ -313,7 +313,11 @@ class NodeConnection<M extends ClientManifest> {
       connection.getRemoteCertsChain(),
     );
 
-    const newLogger = logger.getParent() ?? new Logger(this.name);
+    const newLogger = (logger.getParent() ?? new Logger(this.name)).getChild(
+      `${this.name} [${nodesUtils.encodeNodeId(nodeId)}@${
+        quicConnection.remoteHost
+      }:${quicConnection.remotePort}]`,
+    );
     const nodeConnection = new this<M>({
       validatedNodeId,
       nodeId,
@@ -326,11 +330,7 @@ class NodeConnection<M extends ClientManifest> {
       quicClient,
       quicConnection,
       rpcClient,
-      logger: newLogger.getChild(
-        `${this.name} [${nodesUtils.encodeNodeId(nodeId)}@${
-          quicConnection.remoteHost
-        }:${quicConnection.remotePort}]`,
-      ),
+      logger: newLogger,
     });
     // TODO: remove this later based on testing
     quicConnection.removeEventListener(
@@ -361,7 +361,7 @@ class NodeConnection<M extends ClientManifest> {
       nodeConnection.handleEventQUICClientDestroyed,
     );
     quicClient.addEventListener(EventAll.name, nodeConnection.handleEventAll);
-    logger.info(`Created ${this.name}`);
+    newLogger.info(`Created ${this.name}`);
     return nodeConnection;
   }
 

--- a/src/nodes/NodeConnectionManager.ts
+++ b/src/nodes/NodeConnectionManager.ts
@@ -1632,8 +1632,8 @@ class NodeConnectionManager {
             nodeId,
             [
               {
-                host: nextNodeAddress.address.host,
-                port: nextNodeAddress.address.port,
+                host: nodeData.address.host,
+                port: nodeData.address.port,
                 scopes: ['external'],
               },
             ],

--- a/src/nodes/NodeManager.ts
+++ b/src/nodes/NodeManager.ts
@@ -186,13 +186,7 @@ class NodeManager {
                   nodeId,
                 )}`,
               );
-              return this.nodeConnectionManager.withConnF(
-                nodeId,
-                async () => {
-                  // Do nothing, we just want to establish a connection
-                },
-                ctx,
-              );
+              return this.pingNode(nodeId, undefined, ctx);
             }
           }),
         );
@@ -400,7 +394,7 @@ class NodeManager {
     @context ctx: ContextTimed,
   ): Promise<Record<ClaimId, SignedClaim>> {
     // Verify the node's chain with its own public key
-    return this.nodeConnectionManager.withConnF(
+    return await this.nodeConnectionManager.withConnF(
       targetNodeId,
       async (connection) => {
         const claims: Record<ClaimId, SignedClaim> = {};

--- a/src/nodes/types.ts
+++ b/src/nodes/types.ts
@@ -29,6 +29,14 @@ type NodeData = {
 
 type SeedNodes = Record<NodeIdEncoded, NodeAddress>;
 
+enum ConnectionErrorCode {
+  ForceClose = 1,
+}
+
+enum ConnectionErrorReason {
+  ForceClose = 'NodeConnection is forcing destruction',
+}
+
 export type {
   NodeId,
   NodeIdString,
@@ -42,3 +50,5 @@ export type {
   NodeData,
   NodeGraphSpace,
 };
+
+export { ConnectionErrorCode, ConnectionErrorReason };

--- a/src/nodes/utils.ts
+++ b/src/nodes/utils.ts
@@ -3,7 +3,7 @@ import type { CertificatePEM } from '../keys/types';
 import type { KeyPath } from '@matrixai/db';
 import { utils as dbUtils } from '@matrixai/db';
 import { IdInternal } from '@matrixai/id';
-import { utils as quicUtils } from '@matrixai/quic';
+import { utils as quicUtils, errors as quicErrors } from '@matrixai/quic';
 import { errors as rpcErrors } from '@matrixai/rpc';
 import lexi from 'lexicographic-integer';
 import * as nodesErrors from './errors';
@@ -301,7 +301,9 @@ function isConnectionError(e): boolean {
   return (
     e instanceof nodesErrors.ErrorNodeConnectionDestroyed ||
     e instanceof nodesErrors.ErrorNodeConnectionTimeout ||
-    e instanceof nodesErrors.ErrorNodeConnectionMultiConnectionFailed
+    e instanceof nodesErrors.ErrorNodeConnectionMultiConnectionFailed ||
+    e instanceof quicErrors.ErrorQUICConnectionPeer ||
+    e instanceof quicErrors.ErrorQUICConnectionLocal
   );
 }
 

--- a/tests/nodes/NodeConnection.test.ts
+++ b/tests/nodes/NodeConnection.test.ts
@@ -354,15 +354,14 @@ describe(`${NodeConnection.name}`, () => {
         const { nodeId, certChain } = nodesUtils.parseRemoteCertsChain(
           quicConnection.getRemoteCertsChain(),
         );
-        const nodeConnection = await NodeConnection.createNodeConnectionReverse(
-          {
-            nodeId,
-            certChain,
-            manifest: {},
-            quicConnection,
-            logger,
-          },
-        ).then(extractNodeConnection);
+        const nodeConnection = NodeConnection.createNodeConnectionReverse({
+          nodeId,
+          certChain,
+          manifest: {},
+          quicConnection,
+          logger,
+        });
+        extractNodeConnection(nodeConnection);
         nodeConnectionReverseProm.resolveP(nodeConnection);
       },
       { once: true },
@@ -399,15 +398,14 @@ describe(`${NodeConnection.name}`, () => {
         const { nodeId, certChain } = nodesUtils.parseRemoteCertsChain(
           quicConnection.getRemoteCertsChain(),
         );
-        const nodeConnection = await NodeConnection.createNodeConnectionReverse(
-          {
-            nodeId,
-            certChain,
-            manifest: {},
-            quicConnection,
-            logger,
-          },
-        ).then(extractNodeConnection);
+        const nodeConnection = NodeConnection.createNodeConnectionReverse({
+          nodeId,
+          certChain,
+          manifest: {},
+          quicConnection,
+          logger,
+        });
+        extractNodeConnection(nodeConnection);
         nodeConnection.addEventListener(
           nodesEvents.EventNodeConnectionStream.name,
           (e: nodesEvents.EventNodeConnectionStream) => {

--- a/tests/nodes/NodeConnectionManager.seednodes.test.ts
+++ b/tests/nodes/NodeConnectionManager.seednodes.test.ts
@@ -7,6 +7,7 @@ import os from 'os';
 import Logger, { formatting, LogLevel, StreamHandler } from '@matrixai/logger';
 import { DB } from '@matrixai/db';
 import { PromiseCancellable } from '@matrixai/async-cancellable';
+import { events as quicEvents } from '@matrixai/quic';
 import * as nodesUtils from '@/nodes/utils';
 import NodeConnectionManager from '@/nodes/NodeConnectionManager';
 import NodeConnection from '@/nodes/NodeConnection';
@@ -229,6 +230,70 @@ describe(`${NodeConnectionManager.name} seednodes test`, () => {
     expect(await nodeGraph.getNode(remoteNodeId1)).toBeDefined();
     expect(await nodeGraph.getNode(remoteNodeId2)).toBeDefined();
     expect(await nodeGraph.getNode(dummyNodeId)).toBeUndefined();
+
+    await nodeConnectionManager.stop();
+  });
+  test('syncNodeGraph handles connection rejections from peer', async () => {
+    // Force close connections.
+    // @ts-ignore: kidnap protected property
+    const quicServer = remotePolykeyAgent1.nodeConnectionManager.quicServer;
+    quicServer.addEventListener(
+      quicEvents.EventQUICServerConnection.name,
+      async (evt: quicEvents.EventQUICServerConnection) => {
+        await evt.detail.stop({
+          isApp: true,
+          errorCode: 42,
+          reason: Buffer.from('life the universe and everything'),
+          force: true,
+        });
+      },
+    );
+
+    const seedNodes = {
+      [remoteNodeIdEncoded1]: remoteAddress1,
+    };
+    nodeConnectionManager = new NodeConnectionManager({
+      keyRing,
+      logger: logger.getChild(NodeConnectionManager.name),
+      nodeGraph,
+      connectionConnectTimeoutTime: 1000,
+      tlsConfig,
+      seedNodes,
+    });
+    nodeManager = new NodeManager({
+      db,
+      gestaltGraph,
+      keyRing,
+      nodeConnectionManager,
+      nodeGraph,
+      sigchain,
+      taskManager,
+      connectionConnectTimeoutTime: 1000,
+      logger,
+    });
+    await nodeManager.start();
+    // Add seed nodes to the nodeGraph
+    const setNodeProms = new Array<Promise<void>>();
+    for (const nodeIdEncoded in seedNodes) {
+      const nodeId = nodesUtils.decodeNodeId(nodeIdEncoded);
+      if (nodeId == null) utils.never();
+      const setNodeProm = nodeManager.setNode(
+        nodeId,
+        seedNodes[nodeIdEncoded],
+        true,
+      );
+      setNodeProms.push(setNodeProm);
+    }
+    await Promise.all(setNodeProms);
+
+    await remotePolykeyAgent1.nodeGraph.setNode(remoteNodeId2, remoteAddress2);
+
+    await nodeConnectionManager.start({
+      host: localHost as Host,
+    });
+    await taskManager.startProcessing();
+
+    await nodeManager.syncNodeGraph(true, 2000);
 
     await nodeConnectionManager.stop();
   });


### PR DESCRIPTION
### Description

This PR addresses stability fixes for failing connections.

It directly addresses this issue #592 

### Issues Fixed

* Fixes #592

### Tasks

* [x] 1. Prevent any connection failures in the background from bubbling up to the top of the program. The `NCM` should never throw when a connection fails.
* [x] 2. expand tests to include connection failures and concurrent connection failures.
* [x] 3. Remove magic number error codes from the nodes domain and use an `enum` to get the code and reason.  all forced connection stops should use this.
* [x] 4. Fix so that concurrent connections results in a single successful active connection.

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
