### PR TITLE
feat: connection with ICE now gets target port from signalling node

### DIFF
--- a/src/nodes/NodeConnection.ts
+++ b/src/nodes/NodeConnection.ts
@@ -8,6 +8,7 @@ import type {
   QUICSocket,
   ClientCryptoOps,
   QUICConnection,
+  Host as QUICHost,
 } from '@matrixai/quic';
 import type { ContextTimedInput } from '@matrixai/contexts/dist/types';
 import type { X509Certificate } from '@peculiar/x509';
@@ -20,6 +21,7 @@ import {
   QUICClient,
   events as quicEvents,
   errors as quicErrors,
+  utils as quicUtils,
 } from '@matrixai/quic';
 import { RPCClient } from '@matrixai/rpc';
 import { middleware as rpcUtilsMiddleware } from '@matrixai/rpc';
@@ -464,9 +466,11 @@ class NodeConnection<M extends ClientManifest> {
   }) {
     this.validatedNodeId = validatedNodeId;
     this.nodeId = nodeId;
-    this.host = host;
+    this.host = quicUtils.toCanonicalIP(host) as unknown as Host;
     this.port = port;
-    this.localHost = localHost;
+    this.localHost = quicUtils.resolvesZeroIP(
+      localHost as unknown as QUICHost,
+    ) as unknown as Host;
     this.localPort = localPort;
     this.certChain = certChain;
     this.hostname = hostname;

--- a/src/nodes/NodeConnectionManager.ts
+++ b/src/nodes/NodeConnectionManager.ts
@@ -1071,7 +1071,6 @@ class NodeConnectionManager {
       this.logger.debug(
         `single connection already existed, cleaning up ${address.host}:${address.port}`,
       );
-      throw Error('haha error go brrrr');
       // 3. if already exists then clean up
       await connection.destroy({ force: true });
       // I can only see this happening as a race condition with creating a forward connection and receiving a reverse.

--- a/src/nodes/agent/handlers/NodesConnectionSignalInitial.ts
+++ b/src/nodes/agent/handlers/NodesConnectionSignalInitial.ts
@@ -2,6 +2,7 @@ import type {
   AgentRPCRequestParams,
   AgentRPCResponseResult,
   HolePunchSignalMessage,
+  AddressMessage,
 } from '../types';
 import type NodeConnectionManager from '../../../nodes/NodeConnectionManager';
 import type { Host, Port } from '../../../network/types';
@@ -19,13 +20,13 @@ class NodesConnectionSignalInitial extends UnaryHandler<
     nodeConnectionManager: NodeConnectionManager;
   },
   AgentRPCRequestParams<HolePunchSignalMessage>,
-  AgentRPCResponseResult
+  AgentRPCResponseResult<AddressMessage>
 > {
   public handle = async (
     input: AgentRPCRequestParams<HolePunchSignalMessage>,
     _cancel,
     meta: Record<string, JSONValue> | undefined,
-  ): Promise<AgentRPCResponseResult> => {
+  ): Promise<AgentRPCResponseResult<AddressMessage>> => {
     const { nodeConnectionManager } = this.container;
     // Connections should always be validated
     const requestingNodeId = agentUtils.nodeIdFromMeta(meta);
@@ -54,13 +55,17 @@ class NodesConnectionSignalInitial extends UnaryHandler<
       port: remotePort as Port,
       scopes: ['global'],
     };
-    nodeConnectionManager.handleNodesConnectionSignalInitial(
-      requestingNodeId,
-      targetNodeId,
-      address,
-      input.signature,
-    );
-    return {};
+    const targetAddress =
+      await nodeConnectionManager.handleNodesConnectionSignalInitial(
+        requestingNodeId,
+        targetNodeId,
+        address,
+        input.signature,
+      );
+    return {
+      host: targetAddress.host,
+      port: targetAddress.port,
+    };
   };
 }
 

--- a/tests/nodes/NodeConnection.test.ts
+++ b/tests/nodes/NodeConnection.test.ts
@@ -82,7 +82,6 @@ describe(`${NodeConnection.name}`, () => {
       logger: logger.getChild(`${QUICServer.name}`),
     });
     rpcServer = new RPCServer({
-      handlerTimeoutTime: 5000,
       fromError: networkUtils.fromError,
       logger: logger.getChild(`${RPCServer.name}`),
     });

--- a/tests/nodes/NodeConnectionManager.general.test.ts
+++ b/tests/nodes/NodeConnectionManager.general.test.ts
@@ -652,9 +652,9 @@ describe(`${NodeConnectionManager.name} general test`, () => {
     const targetNodeId = remotePolykeyAgentB.keyRing.getNodeId();
     const data = Buffer.concat([sourceNodeId, targetNodeId]);
     const signature = keysUtils.signWithPrivateKey(keyPair, data);
-    expect(() => {
+    await expect(async () => {
       for (let i = 0; i < 30; i++) {
-        nodeConnectionManager.handleNodesConnectionSignalInitial(
+        await nodeConnectionManager.handleNodesConnectionSignalInitial(
           sourceNodeId,
           targetNodeId,
           {
@@ -665,7 +665,9 @@ describe(`${NodeConnectionManager.name} general test`, () => {
           signature.toString('base64url'),
         );
       }
-    }).toThrow(nodesErrors.ErrorNodeConnectionManagerRequestRateExceeded);
+    }).rejects.toThrow(
+      nodesErrors.ErrorNodeConnectionManagerRequestRateExceeded,
+    );
 
     const signalMapA =
       // @ts-ignore: kidnap protected property

--- a/tests/nodes/NodeConnectionManager.lifecycle.test.ts
+++ b/tests/nodes/NodeConnectionManager.lifecycle.test.ts
@@ -239,7 +239,6 @@ describe(`${NodeConnectionManager.name} lifecycle test`, () => {
 
     await nodeConnectionManager.stop();
   });
-  // TODO: work in progress testing
   test('concurrent connections should result in only 1 connection', async () => {
     // A connection is concurrently established in the forward and reverse
     // direction, we only want one connection to exist afterwards.

--- a/tests/nodes/agent/handlers/nodesConnectionSignalInitial.test.ts
+++ b/tests/nodes/agent/handlers/nodesConnectionSignalInitial.test.ts
@@ -147,6 +147,13 @@ describe('nodesHolePunchSignal', () => {
     // Data is just `<sourceNodeId><targetNodeId>` concatenated
     const data = Buffer.concat([sourceNodeId, targetNodeId]);
     const signature = keysUtils.signWithPrivateKey(keyPair, data);
+    dummyNodeConnectionManager.handleNodesConnectionSignalInitial.mockResolvedValue(
+      {
+        host: '127.0.0.1',
+        port: 55555,
+        scopes: ['global'],
+      },
+    );
     await rpcClient.methods.nodesConnectionSignalInitial({
       targetNodeIdEncoded,
       signature: signature.toString('base64url'),


### PR DESCRIPTION
### Description

This PR tries to address the issue with #605. It's hard to say what the exact problem is but I'm assuming the forward connection isn't getting the most up to date information.

To attempt to fix this, this PR does the following.

1. The `NodesConnectionSignalInitial` returns the host and port of the target node from the perspective of the signalling node.
2. When doing ICE, the `nodesConnectionSignalInitial` is called returns the new address. The new port is then used when attempting the connection. 

### Issues Fixed

* Related #605 - I'm not saying it's fixed because the current solution is based on conjecture. I'll need to do manual testing to know that it addressed the problem. And we'll need some test environments that provide different kinds of NATs to test against.
* Fixes #614 

### Tasks

- 1. [X] Fix the signalling process to return the target's port from the perspective of the signalling node
- 2. [x] Fix `IPv6` mapped `IPv4` addresses being used in the NodeGraph. #614 

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
