### PR TITLE
`audit` Domain

### DIFF
--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -749,6 +749,7 @@ class PolykeyAgent {
         manifest: clientServerManifest({
           polykeyAgent: this,
           acl: this.acl,
+          audit: this.audit,
           certManager: this.certManager,
           db: this.db,
           discovery: this.discovery,

--- a/src/PolykeyClient.ts
+++ b/src/PolykeyClient.ts
@@ -1,6 +1,7 @@
 import type { PromiseCancellable } from '@matrixai/async-cancellable';
 import type { ContextTimed, ContextTimedInput } from '@matrixai/contexts';
 import type { DeepPartial, FileSystem } from './types';
+import type { OverrideRPClientType } from './client/types';
 import type { NodeId } from './ids/types';
 import path from 'path';
 import Logger from '@matrixai/logger';
@@ -151,7 +152,9 @@ class PolykeyClient {
   protected logger: Logger;
   protected _nodeId: NodeId;
   protected _webSocketClient: WebSocketClient;
-  protected _rpcClient: RPCClient<typeof clientClientManifest>;
+  protected _rpcClient: OverrideRPClientType<
+    RPCClient<typeof clientClientManifest>
+  >;
 
   constructor({
     nodePath,
@@ -302,7 +305,7 @@ class PolykeyClient {
     });
     this._nodeId = nodeId_;
     this._webSocketClient = webSocketClient;
-    this._rpcClient = rpcClient;
+    this._rpcClient = rpcClient as typeof this._rpcClient;
     this.logger.info(`Started ${this.constructor.name}`);
   }
 

--- a/src/audit/Audit.ts
+++ b/src/audit/Audit.ts
@@ -1,0 +1,378 @@
+import type { DB, DBTransaction, LevelPath } from '@matrixai/db';
+import type {
+  TopicSubPath,
+  TopicPath,
+  TopicSubPathToAuditEvent,
+  AuditEvent,
+  MetricPath,
+  MetricPathToAuditMetric,
+  AuditMetricNodeConnection,
+} from './types';
+import type { AuditEventId } from '../ids/types';
+import type NodeConnectionManager from '../nodes/NodeConnectionManager';
+import type { AbstractEvent } from '@matrixai/events';
+import Logger from '@matrixai/logger';
+import { IdInternal } from '@matrixai/id';
+import {
+  CreateDestroyStartStop,
+  ready,
+} from '@matrixai/async-init/dist/CreateDestroyStartStop';
+import * as sortableIdUtils from '@matrixai/id/dist/IdSortable';
+import * as auditErrors from './errors';
+import * as auditEvents from './events';
+import * as auditUtils from './utils';
+import * as nodesEvents from '../nodes/events';
+import * as ids from '../ids';
+import * as utils from '../utils';
+
+interface Audit extends CreateDestroyStartStop {}
+@CreateDestroyStartStop(
+  new auditErrors.ErrorAuditRunning(),
+  new auditErrors.ErrorAuditDestroyed(),
+  {
+    eventStart: auditEvents.EventAuditStart,
+    eventStarted: auditEvents.EventAuditStarted,
+    eventStop: auditEvents.EventAuditStop,
+    eventStopped: auditEvents.EventAuditStopped,
+    eventDestroy: auditEvents.EventAuditDestroy,
+    eventDestroyed: auditEvents.EventAuditDestroyed,
+  },
+)
+class Audit {
+  static async createAudit({
+    db,
+    nodeConnectionManager,
+    logger = new Logger(this.name),
+    fresh = false,
+  }: {
+    db: DB;
+    nodeConnectionManager: NodeConnectionManager;
+    logger?: Logger;
+    fresh?: boolean;
+  }): Promise<Audit> {
+    logger.info(`Creating ${this.name}`);
+    const audit = new this({ db, nodeConnectionManager, logger });
+    await audit.start({ fresh });
+    logger.info(`Created ${this.name}`);
+    return audit;
+  }
+
+  protected logger: Logger;
+  protected db: DB;
+  protected nodeConnectionManager: NodeConnectionManager;
+
+  protected eventHandlerMap: Map<
+    typeof AbstractEvent,
+    {
+      target: EventTarget;
+      handler: (evt: AbstractEvent<unknown>) => Promise<void>;
+    }
+  > = new Map();
+  protected auditDbPath: LevelPath = [this.constructor.name];
+  protected dbLastAuditEventIdPath: LevelPath = [
+    this.constructor.name,
+    'lastAuditEventId',
+  ];
+  protected auditEventDbPath: LevelPath = [this.constructor.name, 'event'];
+  protected auditTopicDbPath: LevelPath = [this.constructor.name, 'topic'];
+  protected generateAuditEventId: () => AuditEventId;
+
+  constructor({
+    db,
+    nodeConnectionManager,
+    logger,
+  }: {
+    db: DB;
+    nodeConnectionManager: NodeConnectionManager;
+    logger: Logger;
+  }) {
+    this.logger = logger;
+    this.nodeConnectionManager = nodeConnectionManager;
+    this.db = db;
+  }
+
+  public async start({
+    fresh = false,
+  }: {
+    fresh?: boolean;
+  } = {}): Promise<void> {
+    this.logger.info(`Starting ${this.constructor.name}`);
+    if (fresh) {
+      await this.db.clear(this.auditDbPath);
+    }
+    const lastAuditEventId = await this.getLastAuditEventId();
+    this.generateAuditEventId =
+      auditUtils.createAuditEventIdGenerator(lastAuditEventId);
+    // Setup event handlers
+    this.setEventHandler(
+      this.nodeConnectionManager,
+      nodesEvents.EventNodeConnectionManagerConnectionForward,
+      auditUtils.nodeConnectionForwardTopicPath,
+      auditUtils.fromEventNodeConnectionManagerConnectionForward,
+    );
+    this.setEventHandler(
+      this.nodeConnectionManager,
+      nodesEvents.EventNodeConnectionManagerConnectionReverse,
+      auditUtils.nodeConnectionReverseTopicPath,
+      auditUtils.fromEventNodeConnectionManagerConnectionReverse,
+    );
+    this.logger.info(`Started ${this.constructor.name}`);
+  }
+
+  public async stop(): Promise<void> {
+    this.logger.info(`Stopping ${this.constructor.name}`);
+    for (const [eventConstructor, { target, handler }] of this
+      .eventHandlerMap) {
+      target.removeEventListener(eventConstructor.name, handler);
+    }
+    this.logger.info(`Stopped ${this.constructor.name}`);
+  }
+
+  public async destroy() {
+    this.logger.info(`Destroying ${this.constructor.name}`);
+    await this.db.clear(this.auditDbPath);
+    this.logger.info(`Destroyed ${this.constructor.name}`);
+  }
+
+  @ready(new auditErrors.ErrorAuditNotRunning(), false, ['starting'])
+  public async getLastAuditEventId(
+    tran?: DBTransaction,
+  ): Promise<AuditEventId | undefined> {
+    const lastAuditEventIdBuffer = await (tran ?? this.db).get(
+      this.dbLastAuditEventIdPath,
+      true,
+    );
+    if (lastAuditEventIdBuffer == null) return;
+    return IdInternal.fromBuffer<AuditEventId>(lastAuditEventIdBuffer);
+  }
+
+  @ready(new auditErrors.ErrorAuditNotRunning(), false, ['starting'])
+  protected setEventHandler<
+    T extends typeof AbstractEvent,
+    P extends TopicPath,
+  >(
+    target: EventTarget,
+    event: T,
+    topicPath: P,
+    toAuditEvent: (
+      evt: InstanceType<T>,
+    ) =>
+      | Promise<TopicSubPathToAuditEvent<P>['data']>
+      | TopicSubPathToAuditEvent<P>['data'],
+  ) {
+    const handler = async (evt: InstanceType<T>) => {
+      const eventData = await toAuditEvent(evt);
+      await this.db.withTransactionF(async (tran) => {
+        const event: AuditEvent = {
+          data: eventData,
+        };
+        await this.addAuditEvent(topicPath, event as any, tran);
+      });
+    };
+    target.addEventListener(event.name, handler);
+    this.eventHandlerMap.set(event, { target, handler: handler as any });
+  }
+
+  @ready(new auditErrors.ErrorAuditNotRunning())
+  protected async setAuditEvent<T extends TopicPath>(
+    topicPath: TopicPath,
+    auditEventId: AuditEventId,
+    auditEvent: TopicSubPathToAuditEvent<T>,
+    tran?: DBTransaction,
+  ) {
+    if (tran == null) {
+      return await this.db.withTransactionF((tran) =>
+        this.setAuditEvent(topicPath, auditEventId, auditEvent, tran),
+      );
+    }
+    const auditEventIdBuffer = auditEventId.toBuffer();
+    await tran.put([...this.auditEventDbPath, auditEventIdBuffer], auditEvent);
+    const subTopicArray: Array<string> = [];
+    for (const topic of topicPath) {
+      subTopicArray.push(topic);
+      await tran.put(
+        [...this.auditTopicDbPath, subTopicArray.join('.'), auditEventIdBuffer],
+        true,
+      );
+    }
+  }
+
+  @ready(new auditErrors.ErrorAuditNotRunning())
+  protected async addAuditEvent<T extends TopicPath>(
+    topicPath: TopicPath,
+    auditEvent: TopicSubPathToAuditEvent<T>,
+    tran?: DBTransaction,
+  ) {
+    if (tran == null) {
+      return await this.db.withTransactionF((tran) =>
+        this.addAuditEvent(topicPath, auditEvent, tran),
+      );
+    }
+    const auditEventId = this.generateAuditEventId();
+    await this.setAuditEvent(topicPath, auditEventId, auditEvent, tran);
+  }
+
+  @ready(new auditErrors.ErrorAuditNotRunning())
+  public async *getAuditEvents<T extends TopicSubPath>(
+    topicPath: T,
+    {
+      seek,
+      order,
+      limit,
+    }: {
+      seek?: AuditEventId;
+      order?: 'asc' | 'desc';
+      limit?: number;
+    } = {},
+    tran?: DBTransaction,
+  ): AsyncGenerator<
+    TopicSubPathToAuditEvent<T>,
+    void,
+    TopicSubPathToAuditEvent<T>
+  > {
+    if (tran == null) {
+      const getEvents = (tran) =>
+        this.getAuditEvents(
+          topicPath,
+          {
+            seek,
+            order,
+            limit,
+          },
+          tran,
+        );
+      return yield* this.db.withTransactionG(async function* (tran) {
+        return yield* getEvents(tran);
+      });
+    }
+    if (topicPath.length === 0) {
+      for await (const [, auditEvent] of tran.iterator<
+        TopicSubPathToAuditEvent<T>
+      >(this.auditEventDbPath, {
+        keys: false,
+        values: true,
+        valueAsBuffer: false,
+        reverse: order !== 'asc',
+        limit,
+        gte: seek?.toBuffer(),
+      })) {
+        yield auditEvent;
+      }
+      return;
+    }
+    const iterator = tran.iterator<void>(
+      [...this.auditTopicDbPath, topicPath.join('.')],
+      {
+        keys: true,
+        values: false,
+        valueAsBuffer: false,
+        reverse: order !== 'asc',
+        limit,
+      },
+    );
+    if (seek != null) {
+      iterator.seek(seek.toBuffer());
+    }
+    for await (const [keyPath] of iterator) {
+      const event = await tran.get<TopicSubPathToAuditEvent<T>>([
+        ...this.auditEventDbPath,
+        keyPath.at(-1)!,
+      ]);
+      if (event != null) {
+        yield event;
+      }
+    }
+  }
+
+  @ready(new auditErrors.ErrorAuditNotRunning())
+  public async getAuditMetric<T extends MetricPath>(
+    metricPath: T,
+    options: { from?: Date | number; to?: Date | number } = {},
+    tran?: DBTransaction,
+  ): Promise<MetricPathToAuditMetric<T>> {
+    if (tran == null) {
+      return await this.db.withTransactionF((tran) =>
+        this.getAuditMetric(metricPath, options, tran),
+      );
+    }
+
+    let fromEpoch =
+      options.from instanceof Date ? options.from.getTime() : options.from;
+    let toEpoch =
+      options.to instanceof Date ? options.to.getTime() : options.to;
+
+    let fromIdBuffer: Buffer | undefined;
+    if (fromEpoch != null) {
+      fromIdBuffer = ids
+        .generateAuditEventIdFromEpoch(fromEpoch, () => new Uint8Array())
+        .toBuffer();
+    }
+    let toIdBuffer: Buffer | undefined;
+    if (toEpoch != null) {
+      toIdBuffer = ids
+        .generateAuditEventIdFromEpoch(toEpoch, (size) =>
+          new Uint8Array(size).fill(0xff),
+        )
+        .toBuffer();
+    }
+
+    if (metricPath[0] === 'node') {
+      if (metricPath[1] === 'connection') {
+        let path: readonly string[] = auditUtils.nodeConnectionMetricPath;
+        if (metricPath[2] === 'inbound') {
+          path = auditUtils.nodeConnectionReverseTopicPath;
+        } else if (metricPath[2] === 'outbound') {
+          path = auditUtils.nodeConnectionForwardTopicPath;
+        }
+        const metric: AuditMetricNodeConnection = {
+          data: {
+            total: 0,
+            averagePerMinute: 0,
+            averagePerHour: 0,
+            averagePerDay: 0,
+          },
+        };
+        let lastKey: Buffer | undefined;
+        for await (const [keyPath] of tran.iterator(
+          [...this.auditTopicDbPath, path.join('.')],
+          {
+            keyAsBuffer: true,
+            keys: true,
+            values: false,
+            gte: fromIdBuffer,
+            lte: toIdBuffer,
+          },
+        )) {
+          const key = keyPath.at(-1)! as Buffer;
+          if (metric.data.total === 0) {
+            fromEpoch = sortableIdUtils.extractTs(key) * 1000;
+          } else {
+            lastKey = key;
+          }
+          metric.data.total += 1;
+        }
+        if (fromEpoch != null) {
+          if (lastKey != null) {
+            toEpoch = sortableIdUtils.extractTs(lastKey) * 1000;
+          } else {
+            toEpoch = Date.now();
+          }
+          const timeframeTime = toEpoch - fromEpoch;
+          const timeframeMinutes = timeframeTime / 60_000;
+          const timeframeHours = timeframeMinutes / 60;
+          const timeframeDays = timeframeHours / 24;
+          metric.data.averagePerMinute =
+            metric.data.total / Math.ceil(timeframeMinutes);
+          metric.data.averagePerHour =
+            metric.data.total / Math.ceil(timeframeHours);
+          metric.data.averagePerDay =
+            metric.data.total / Math.ceil(timeframeDays);
+        }
+        return metric as any;
+      }
+    }
+    utils.never();
+  }
+}
+
+export default Audit;

--- a/src/audit/errors.ts
+++ b/src/audit/errors.ts
@@ -1,0 +1,44 @@
+import ErrorPolykey from '../ErrorPolykey';
+import sysexits from '../utils/sysexits';
+
+class ErrorAudit<T> extends ErrorPolykey<T> {}
+
+class ErrorAuditRunning<T> extends ErrorAudit<T> {
+  static description = 'Audit is running';
+  exitCode = sysexits.USAGE;
+}
+
+class ErrorAuditNotRunning<T> extends ErrorAudit<T> {
+  static description = 'Audit is not running';
+  exitCode = sysexits.USAGE;
+}
+
+class ErrorAuditDestroyed<T> extends ErrorAudit<T> {
+  static description = 'Audit is destroyed';
+  exitCode = sysexits.USAGE;
+}
+
+class ErrorAuditNodeIdMissing<T> extends ErrorAudit<T> {
+  static description = 'Could not find NodeId';
+  exitCode = sysexits.NOUSER;
+}
+
+class ErrorAuditVaultIdMissing<T> extends ErrorAudit<T> {
+  static description = 'Could not find VaultId';
+  exitCode = sysexits.DATAERR;
+}
+
+class ErrorAuditNodeIdExists<T> extends ErrorAudit<T> {
+  static description = 'NodeId already exists';
+  exitCode = sysexits.DATAERR;
+}
+
+export {
+  ErrorAudit,
+  ErrorAuditRunning,
+  ErrorAuditNotRunning,
+  ErrorAuditDestroyed,
+  ErrorAuditNodeIdMissing,
+  ErrorAuditVaultIdMissing,
+  ErrorAuditNodeIdExists,
+};

--- a/src/audit/events.ts
+++ b/src/audit/events.ts
@@ -1,3 +1,4 @@
+import type { TopicPath, TopicSubPathToAuditEvent } from './types';
 import EventPolykey from '../EventPolykey';
 
 abstract class EventAudit<T = undefined> extends EventPolykey<T> {}
@@ -14,6 +15,16 @@ class EventAuditDestroy extends EventAudit {}
 
 class EventAuditDestroyed extends EventAudit {}
 
+abstract class EventAuditAuditEvent<T = null> extends EventAudit<T> {}
+
+class EventAuditAuditEventSet<
+  P extends TopicPath = TopicPath,
+  T extends TopicSubPathToAuditEvent<P> = TopicSubPathToAuditEvent<P>,
+> extends EventAuditAuditEvent<{
+  topicPath: P;
+  auditEvent: T;
+}> {}
+
 export {
   EventAudit,
   EventAuditStart,
@@ -22,4 +33,6 @@ export {
   EventAuditStopped,
   EventAuditDestroy,
   EventAuditDestroyed,
+  EventAuditAuditEvent,
+  EventAuditAuditEventSet,
 };

--- a/src/audit/events.ts
+++ b/src/audit/events.ts
@@ -1,0 +1,25 @@
+import EventPolykey from '../EventPolykey';
+
+abstract class EventAudit<T = undefined> extends EventPolykey<T> {}
+
+class EventAuditStart extends EventAudit {}
+
+class EventAuditStarted extends EventAudit {}
+
+class EventAuditStop extends EventAudit {}
+
+class EventAuditStopped extends EventAudit {}
+
+class EventAuditDestroy extends EventAudit {}
+
+class EventAuditDestroyed extends EventAudit {}
+
+export {
+  EventAudit,
+  EventAuditStart,
+  EventAuditStarted,
+  EventAuditStop,
+  EventAuditStopped,
+  EventAuditDestroy,
+  EventAuditDestroyed,
+};

--- a/src/audit/index.ts
+++ b/src/audit/index.ts
@@ -1,0 +1,5 @@
+export { default as Audit } from './Audit';
+export * as types from './types';
+export * as utils from './utils';
+export * as errors from './errors';
+export * as events from './events';

--- a/src/audit/types.ts
+++ b/src/audit/types.ts
@@ -1,0 +1,122 @@
+import type { POJO } from '../types';
+import type {
+  nodeConnectionInboundMetricPath,
+  nodeConnectionReverseTopicPath,
+  nodeConnectionOutboundMetricPath,
+  nodeConnectionForwardTopicPath,
+  nodeConnectionMetricPath,
+} from './utils';
+
+// Events
+
+type IsSubpath<
+  T extends readonly any[],
+  U extends readonly any[],
+> = U extends readonly [...T, ...infer _] ? true : false;
+
+type InferTypeFromSubpath<
+  T extends readonly any[],
+  U extends readonly any[],
+  E,
+> = IsSubpath<T, U> extends true ? E : never;
+
+/**
+ * Represents a capture of an event.
+ */
+type AuditEvent<T extends POJO = POJO> = {
+  data: T;
+};
+
+type TopicPath =
+  // Nodes
+  typeof nodeConnectionReverseTopicPath | typeof nodeConnectionForwardTopicPath;
+
+type TopicSubPath<T = TopicPath> =
+  | (T extends readonly [...infer Head, infer Tail]
+      ? [...Head, Tail] | TopicSubPath<Head>
+      : [])
+  | TopicPath;
+
+type TopicSubPathToAuditEvent<T extends TopicSubPath> =
+  // Nodes
+  | InferTypeFromSubpath<
+      T,
+      typeof nodeConnectionReverseTopicPath,
+      AuditEventNodeConnectionReverse
+    >
+  | InferTypeFromSubpath<
+      T,
+      typeof nodeConnectionForwardTopicPath,
+      AuditEventNodeConnectionForward
+    >;
+
+// Nodes
+
+type AuditEventNodeConnectionBase = AuditEvent<{
+  remoteNodeId: string;
+  remoteHost: string;
+  remotePort: number;
+}>;
+
+type AuditEventNodeConnection =
+  | AuditEventNodeConnectionReverse
+  | AuditEventNodeConnectionForward;
+
+type AuditEventNodeConnectionReverse = AuditEventNodeConnectionBase &
+  AuditEvent<{
+    type: 'reverse';
+  }>;
+
+type AuditEventNodeConnectionForward = AuditEventNodeConnectionBase &
+  AuditEvent<{
+    type: 'forward';
+  }>;
+
+// Metrics
+
+type MetricPath =
+  | typeof nodeConnectionMetricPath
+  | typeof nodeConnectionInboundMetricPath
+  | typeof nodeConnectionOutboundMetricPath;
+
+type MetricPathToAuditMetric<T extends MetricPath> =
+  // Nodes
+  T extends
+    | typeof nodeConnectionMetricPath
+    | typeof nodeConnectionInboundMetricPath
+    | typeof nodeConnectionOutboundMetricPath
+    ? AuditMetricNodeConnection
+    : never;
+
+/**
+ * Represents a capture of an event.
+ */
+type AuditMetric<T extends POJO = POJO> = {
+  data: T;
+};
+
+type AuditMetricNodeConnection = AuditMetric<{
+  total: number;
+  averagePerMinute: number;
+  averagePerHour: number;
+  averagePerDay: number;
+}>;
+
+export type {
+  // Event
+  IsSubpath,
+  InferTypeFromSubpath,
+  AuditEvent,
+  TopicPath,
+  TopicSubPathToAuditEvent,
+  TopicSubPath,
+  AuditEventNodeConnectionBase,
+  AuditEventNodeConnection,
+  AuditEventNodeConnectionReverse,
+  AuditEventNodeConnectionForward,
+  // Metric
+  MetricPath,
+  MetricPathToAuditMetric,
+  AuditMetric,
+  AuditMetricNodeConnection,
+};

--- a/src/audit/types.ts
+++ b/src/audit/types.ts
@@ -1,3 +1,4 @@
+import type { AuditEventId } from '../ids';
 import type { POJO } from '../types';
 import type {
   nodeConnectionInboundMetricPath,
@@ -24,8 +25,11 @@ type InferTypeFromSubpath<
  * Represents a capture of an event.
  */
 type AuditEvent<T extends POJO = POJO> = {
+  id: AuditEventId;
   data: T;
 };
+
+type AuditEventSerialized<T extends AuditEvent> = Omit<T, 'id'>;
 
 type TopicPath =
   // Nodes
@@ -107,6 +111,7 @@ export type {
   IsSubpath,
   InferTypeFromSubpath,
   AuditEvent,
+  AuditEventSerialized,
   TopicPath,
   TopicSubPathToAuditEvent,
   TopicSubPath,

--- a/src/audit/utils.ts
+++ b/src/audit/utils.ts
@@ -3,14 +3,43 @@ import type {
   AuditEventNodeConnectionReverse,
 } from './types';
 import type * as nodesEvents from '../nodes/events';
+import type { AuditEventId } from '../ids';
+import { IdInternal } from '@matrixai/id';
+import * as sortableIdUtils from '@matrixai/id/dist/IdSortable';
 import * as nodesUtils from '../nodes/utils';
 import {
   createAuditEventIdGenerator,
   encodeAuditEventId,
   decodeAuditEventId,
+  generateAuditEventIdFromTimestamp,
 } from '../ids';
 
 // Events
+
+function extractFromSeek(
+  seek: AuditEventId | number | Date,
+  randomSource?: (size: number) => Uint8Array,
+): {
+  auditEventId: AuditEventId;
+  timestamp: number;
+} {
+  let auditEventId: AuditEventId;
+  let timestamp: number | undefined;
+  if (seek instanceof IdInternal) {
+    auditEventId = seek;
+    timestamp = sortableIdUtils.extractTs(seek.toBuffer()) * 1000;
+  } else if (typeof seek === 'number') {
+    timestamp = seek;
+    auditEventId = generateAuditEventIdFromTimestamp(seek, randomSource);
+  } else {
+    timestamp = seek.getTime();
+    auditEventId = generateAuditEventIdFromTimestamp(timestamp, randomSource);
+  }
+  return {
+    auditEventId,
+    timestamp,
+  };
+}
 
 // Nodes
 
@@ -69,6 +98,7 @@ const nodeConnectionOutboundMetricPath = [
 ] as const;
 
 export {
+  extractFromSeek,
   createAuditEventIdGenerator,
   encodeAuditEventId,
   decodeAuditEventId,

--- a/src/audit/utils.ts
+++ b/src/audit/utils.ts
@@ -4,7 +4,11 @@ import type {
 } from './types';
 import type * as nodesEvents from '../nodes/events';
 import * as nodesUtils from '../nodes/utils';
-import { createAuditEventIdGenerator } from '../ids';
+import {
+  createAuditEventIdGenerator,
+  encodeAuditEventId,
+  decodeAuditEventId,
+} from '../ids';
 
 // Events
 
@@ -66,6 +70,8 @@ const nodeConnectionOutboundMetricPath = [
 
 export {
   createAuditEventIdGenerator,
+  encodeAuditEventId,
+  decodeAuditEventId,
   nodeConnectionReverseTopicPath,
   fromEventNodeConnectionManagerConnectionReverse,
   nodeConnectionForwardTopicPath,

--- a/src/audit/utils.ts
+++ b/src/audit/utils.ts
@@ -1,0 +1,77 @@
+import type {
+  AuditEventNodeConnectionForward,
+  AuditEventNodeConnectionReverse,
+} from './types';
+import type * as nodesEvents from '../nodes/events';
+import * as nodesUtils from '../nodes/utils';
+import { createAuditEventIdGenerator } from '../ids';
+
+// Events
+
+// Nodes
+
+const nodeConnectionReverseTopicPath = [
+  'node',
+  'connection',
+  'reverse',
+] as const;
+
+function fromEventNodeConnectionManagerConnectionReverse(
+  evt: nodesEvents.EventNodeConnectionManagerConnectionReverse,
+): AuditEventNodeConnectionReverse['data'] {
+  return {
+    remoteNodeId: nodesUtils.encodeNodeId(evt.detail.remoteNodeId),
+    remoteHost: evt.detail.remoteHost,
+    remotePort: evt.detail.remotePort,
+    type: 'reverse',
+  };
+}
+
+const nodeConnectionForwardTopicPath = [
+  'node',
+  'connection',
+  'forward',
+] as const;
+
+function fromEventNodeConnectionManagerConnectionForward(
+  evt: nodesEvents.EventNodeConnectionManagerConnectionForward,
+): AuditEventNodeConnectionForward['data'] {
+  return {
+    remoteNodeId: nodesUtils.encodeNodeId(evt.detail.remoteNodeId),
+    remoteHost: evt.detail.remoteHost,
+    remotePort: evt.detail.remotePort,
+    type: 'forward',
+  };
+}
+
+const nodeGraphTopicPath = ['node', 'graph'] as const;
+
+// Metrics
+
+// Nodes
+
+const nodeConnectionMetricPath = ['node', 'connection'] as const;
+
+const nodeConnectionInboundMetricPath = [
+  'node',
+  'connection',
+  'inbound',
+] as const;
+
+const nodeConnectionOutboundMetricPath = [
+  'node',
+  'connection',
+  'outbound',
+] as const;
+
+export {
+  createAuditEventIdGenerator,
+  nodeConnectionReverseTopicPath,
+  fromEventNodeConnectionManagerConnectionReverse,
+  nodeConnectionForwardTopicPath,
+  fromEventNodeConnectionManagerConnectionForward,
+  nodeGraphTopicPath,
+  nodeConnectionMetricPath,
+  nodeConnectionInboundMetricPath,
+  nodeConnectionOutboundMetricPath,
+};

--- a/src/client/callers/auditEventsGet.ts
+++ b/src/client/callers/auditEventsGet.ts
@@ -1,0 +1,40 @@
+import type { ReadableStream } from 'stream/web';
+import type { HandlerTypes } from '@matrixai/rpc';
+import type { ContextTimedInput } from '@matrixai/contexts';
+import type {
+  AuditEventToAuditEventSerialized,
+  TopicSubPath,
+  TopicSubPathToAuditEvent,
+} from '../../audit/types';
+import type { ClientRPCRequestParams, ClientRPCResponseResult } from '../types';
+import type AuditEventsGet from '../handlers/AuditEventsGet';
+import type { AuditEventIdEncoded } from '../../ids/types';
+import { ServerCaller } from '@matrixai/rpc';
+
+type CallerTypes = HandlerTypes<AuditEventsGet>;
+
+type AuditEventsGetTypeOverride = <T extends TopicSubPath>(
+  input: ClientRPCRequestParams<{
+    seek?: AuditEventIdEncoded;
+    order?: 'asc' | 'desc';
+    limit?: number;
+  }> & {
+    path: T;
+  },
+  ctx?: ContextTimedInput,
+) => Promise<
+  ReadableStream<
+    ClientRPCResponseResult<
+      AuditEventToAuditEventSerialized<TopicSubPathToAuditEvent<T>>
+    >
+  >
+>;
+
+const auditEventsGet = new ServerCaller<
+  CallerTypes['input'],
+  CallerTypes['output']
+>();
+
+export default auditEventsGet;
+
+export type { AuditEventsGetTypeOverride };

--- a/src/client/callers/auditEventsGet.ts
+++ b/src/client/callers/auditEventsGet.ts
@@ -15,9 +15,11 @@ type CallerTypes = HandlerTypes<AuditEventsGet>;
 
 type AuditEventsGetTypeOverride = <T extends TopicSubPath>(
   input: ClientRPCRequestParams<{
-    seek?: AuditEventIdEncoded;
+    seek?: AuditEventIdEncoded | number;
+    seekEnd?: AuditEventIdEncoded | number;
     order?: 'asc' | 'desc';
     limit?: number;
+    awaitFutureEvents?: boolean;
   }> & {
     path: T;
   },

--- a/src/client/callers/auditMetricGet.ts
+++ b/src/client/callers/auditMetricGet.ts
@@ -1,5 +1,6 @@
 import type { HandlerTypes } from '@matrixai/rpc';
 import type { ContextTimedInput } from '@matrixai/contexts';
+import type { AuditEventIdEncoded } from '../../ids';
 import type { MetricPath, MetricPathToAuditMetric } from '../../audit/types';
 import type { ClientRPCRequestParams, ClientRPCResponseResult } from '../types';
 import type AuditMetricGet from '../handlers/AuditMetricGet';
@@ -9,8 +10,8 @@ type CallerTypes = HandlerTypes<AuditMetricGet>;
 
 type AuditMetricGetTypeOverride = <T extends MetricPath>(
   input: ClientRPCRequestParams<{
-    from?: number;
-    to?: number;
+    seek?: AuditEventIdEncoded | number;
+    seekEnd?: AuditEventIdEncoded | number;
   }> & {
     path: T;
   },

--- a/src/client/callers/auditMetricGet.ts
+++ b/src/client/callers/auditMetricGet.ts
@@ -1,0 +1,27 @@
+import type { HandlerTypes } from '@matrixai/rpc';
+import type { ContextTimedInput } from '@matrixai/contexts';
+import type { MetricPath, MetricPathToAuditMetric } from '../../audit/types';
+import type { ClientRPCRequestParams, ClientRPCResponseResult } from '../types';
+import type AuditMetricGet from '../handlers/AuditMetricGet';
+import { UnaryCaller } from '@matrixai/rpc';
+
+type CallerTypes = HandlerTypes<AuditMetricGet>;
+
+type AuditMetricGetTypeOverride = <T extends MetricPath>(
+  input: ClientRPCRequestParams<{
+    from?: number;
+    to?: number;
+  }> & {
+    path: T;
+  },
+  ctx?: ContextTimedInput,
+) => Promise<ClientRPCResponseResult<MetricPathToAuditMetric<T>>>;
+
+const auditMetricGet = new UnaryCaller<
+  CallerTypes['input'],
+  CallerTypes['output']
+>();
+
+export default auditMetricGet;
+
+export type { AuditMetricGetTypeOverride };

--- a/src/client/callers/index.ts
+++ b/src/client/callers/index.ts
@@ -2,6 +2,8 @@ import agentLockAll from './agentLockAll';
 import agentStatus from './agentStatus';
 import agentStop from './agentStop';
 import agentUnlock from './agentUnlock';
+import auditEventsGet from './auditEventsGet';
+import auditMetricGet from './auditMetricGet';
 import gestaltsActionsGetByIdentity from './gestaltsActionsGetByIdentity';
 import gestaltsActionsGetByNode from './gestaltsActionsGetByNode';
 import gestaltsActionsSetByIdentity from './gestaltsActionsSetByIdentity';
@@ -75,6 +77,8 @@ const clientManifest = {
   agentStatus,
   agentStop,
   agentUnlock,
+  auditEventsGet,
+  auditMetricGet,
   gestaltsActionsGetByIdentity,
   gestaltsActionsGetByNode,
   gestaltsActionsSetByIdentity,
@@ -148,6 +152,7 @@ export {
   agentStatus,
   agentStop,
   agentUnlock,
+  auditEventsGet,
   gestaltsActionsGetByIdentity,
   gestaltsActionsGetByNode,
   gestaltsActionsSetByIdentity,

--- a/src/client/handlers/AuditEventsGet.ts
+++ b/src/client/handlers/AuditEventsGet.ts
@@ -1,0 +1,61 @@
+import type { ContextTimed } from '@matrixai/contexts';
+import type { ClientRPCRequestParams, ClientRPCResponseResult } from '../types';
+import type {
+  AuditEventSerialized,
+  AuditEventToAuditEventSerialized,
+  TopicSubPath,
+  TopicSubPathToAuditEvent,
+} from '../../audit/types';
+import type { Audit } from '../../audit';
+import type { AuditEventIdEncoded } from '../../ids';
+import { ServerHandler } from '@matrixai/rpc';
+import * as auditUtils from '../../audit/utils';
+
+class AuditEventsGet extends ServerHandler<
+  {
+    audit: Audit;
+  },
+  ClientRPCRequestParams<{
+    path: TopicSubPath & Array<string>;
+    seek?: AuditEventIdEncoded;
+    order?: 'asc' | 'desc';
+    limit?: number;
+  }>,
+  ClientRPCResponseResult<AuditEventSerialized>
+> {
+  public async *handle<T extends TopicSubPath>(
+    input: ClientRPCRequestParams<{
+      seek?: AuditEventIdEncoded;
+      order?: 'asc' | 'desc';
+      limit?: number;
+    }> & {
+      path: T;
+    },
+    _cancel,
+    _meta,
+    ctx: ContextTimed,
+  ): AsyncGenerator<
+    ClientRPCResponseResult<
+      AuditEventToAuditEventSerialized<TopicSubPathToAuditEvent<T>>
+    >
+  > {
+    const { audit } = this.container;
+    const iterator = audit.getAuditEvents(input.path, {
+      seek:
+        input.seek != null
+          ? auditUtils.decodeAuditEventId(input.seek)
+          : undefined,
+      order: input.order,
+      limit: input.limit,
+    });
+    ctx.signal.addEventListener('abort', async () => {
+      await iterator.return(ctx.signal.reason);
+    });
+    for await (const auditEvent of iterator) {
+      (auditEvent.id as any) = auditUtils.encodeAuditEventId(auditEvent.id);
+      yield auditEvent as any;
+    }
+  }
+}
+
+export default AuditEventsGet;

--- a/src/client/handlers/AuditMetricGet.ts
+++ b/src/client/handlers/AuditMetricGet.ts
@@ -1,0 +1,40 @@
+import type { ClientRPCRequestParams, ClientRPCResponseResult } from '../types';
+import type {
+  AuditMetric,
+  MetricPath,
+  MetricPathToAuditMetric,
+} from '../../audit/types';
+import type { Audit } from '../../audit';
+import { UnaryHandler } from '@matrixai/rpc';
+
+class AuditMetricGet extends UnaryHandler<
+  {
+    audit: Audit;
+  },
+  ClientRPCRequestParams<{
+    path: MetricPath & Array<string>;
+    from?: number;
+    to?: number;
+  }>,
+  ClientRPCResponseResult<AuditMetric>
+> {
+  public handle = async <T extends MetricPath>(
+    input: ClientRPCRequestParams<{
+      from?: number;
+      to?: number;
+    }> & {
+      path: T;
+    },
+    _cancel,
+    _meta,
+    _ctx,
+  ): Promise<ClientRPCResponseResult<MetricPathToAuditMetric<T>>> => {
+    const { audit } = this.container;
+    return (await audit.getAuditMetric(input.path, {
+      from: input.from,
+      to: input.to,
+    })) as any;
+  };
+}
+
+export default AuditMetricGet;

--- a/src/client/handlers/index.ts
+++ b/src/client/handlers/index.ts
@@ -1,6 +1,7 @@
 import type { DB } from '@matrixai/db';
 import type Logger from '@matrixai/logger';
 import type ACL from '../../acl/ACL';
+import type Audit from '../../audit/Audit';
 import type KeyRing from '../../keys/KeyRing';
 import type CertManager from '../../keys/CertManager';
 import type SessionManager from '../../sessions/SessionManager';
@@ -82,6 +83,8 @@ import VaultsSecretsNewDir from './VaultsSecretsNewDir';
 import VaultsSecretsRename from './VaultsSecretsRename';
 import VaultsSecretsStat from './VaultsSecretsStat';
 import VaultsVersion from './VaultsVersion';
+import AuditEventsGet from './AuditEventsGet';
+import AuditMetricGet from './AuditMetricGet';
 
 /**
  * Server manifest factory.
@@ -96,6 +99,7 @@ const serverManifest = (container: {
   identitiesManager: IdentitiesManager;
   discovery: Discovery;
   acl: ACL;
+  audit: Audit;
   notificationsManager: NotificationsManager;
   nodeManager: NodeManager;
   nodeConnectionManager: NodeConnectionManager;
@@ -109,6 +113,8 @@ const serverManifest = (container: {
     agentStatus: new AgentStatus(container),
     agentStop: new AgentStop(container),
     agentUnlock: new AgentUnlock(container),
+    auditEventsGet: new AuditEventsGet(container),
+    auditMetricGet: new AuditMetricGet(container),
     gestaltsActionsGetByIdentity: new GestaltsActionsGetByIdentity(container),
     gestaltsActionsGetByNode: new GestaltsActionsGetByNode(container),
     gestaltsActionsSetByIdentity: new GestaltsActionsSetByIdentity(container),

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,4 +1,9 @@
-import type { JSONObject, JSONRPCResponseResult } from '@matrixai/rpc';
+import type {
+  ClientManifest,
+  JSONObject,
+  JSONRPCResponseResult,
+  RPCClient,
+} from '@matrixai/rpc';
 import type {
   GestaltIdEncoded,
   IdentityId,
@@ -11,6 +16,8 @@ import type { CommitId, VaultAction, VaultName } from '../vaults/types';
 import type { CertificatePEM, JWKEncrypted, PublicKeyJWK } from '../keys/types';
 import type { Notification } from '../notifications/types';
 import type { ProviderToken } from '../identities/types';
+import type { AuditEventsGetTypeOverride } from './callers/auditEventsGet';
+import type { AuditMetricGetTypeOverride } from './callers/auditMetricGet';
 
 type ClientRPCRequestParams<T extends JSONObject = JSONObject> =
   JSONRPCResponseResult<
@@ -306,6 +313,18 @@ type SecretStatMessage = {
   };
 };
 
+// Type casting for tricky handlers
+
+type OverrideRPClientType<T extends RPCClient<ClientManifest>> = Omit<
+  T,
+  'methods'
+> & {
+  methods: {
+    auditEventsGet: AuditEventsGetTypeOverride;
+    auditMetricGet: AuditMetricGetTypeOverride;
+  } & T['methods'];
+};
+
 export type {
   ClientRPCRequestParams,
   ClientRPCResponseResult,
@@ -363,4 +382,7 @@ export type {
   SecretRenameMessage,
   SecretStatMessage,
   SignatureMessage,
+  OverrideRPClientType,
+  AuditEventsGetTypeOverride,
+  AuditMetricGetTypeOverride,
 };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -72,7 +72,7 @@ export {
  * reference all Polykey errors.
  * This is used by RPC to serialize errors from agent to client.
  */
-export * from './acl/errors';
+export * from './audit/errors';
 export * from './sessions/errors';
 export * from './keys/errors';
 export * from './vaults/errors';

--- a/src/ids/index.ts
+++ b/src/ids/index.ts
@@ -21,6 +21,7 @@ import type {
   NotificationId,
   NotificationIdEncoded,
   AuditEventId,
+  AuditEventIdEncoded,
 } from './types';
 import { IdInternal, IdSortable, IdRandom } from '@matrixai/id';
 import * as keysUtilsRandom from '../keys/utils/random';
@@ -41,6 +42,34 @@ function createAuditEventIdGenerator(
     randomSource: keysUtilsRandom.getRandomBytes,
   });
   return () => generator.get();
+}
+
+/**
+ * Encodes `AuditEventId` to `AuditEventIdEncoded`
+ */
+function encodeAuditEventId(auditEventId: AuditEventId): AuditEventIdEncoded {
+  return auditEventId.toBuffer().toString('hex') as AuditEventIdEncoded;
+}
+
+/**
+ * Decodes `AuditEventIdEncoded` to `AuditEventId`
+ */
+function decodeAuditEventId(
+  auditEventIdEncoded: unknown,
+): AuditEventId | undefined {
+  if (typeof auditEventIdEncoded !== 'string') {
+    return;
+  }
+  const auditEventIdBuffer = Buffer.from(auditEventIdEncoded, 'hex');
+  const auditEventId = IdInternal.fromBuffer<AuditEventId>(auditEventIdBuffer);
+  if (auditEventId == null) {
+    return;
+  }
+  // All `AuditEventId` are 16 bytes long
+  if (auditEventId.length !== 16) {
+    return;
+  }
+  return auditEventId;
 }
 
 /**
@@ -493,6 +522,8 @@ export {
   createPermIdGenerator,
   createAuditEventIdGenerator,
   generateAuditEventIdFromEpoch,
+  encodeAuditEventId,
+  decodeAuditEventId,
   createNodeIdGenerator,
   isNodeId,
   assertNodeId,

--- a/src/ids/index.ts
+++ b/src/ids/index.ts
@@ -78,7 +78,7 @@ function decodeAuditEventId(
  * @param epoch
  * @param randomSource
  */
-function generateAuditEventIdFromEpoch(
+function generateAuditEventIdFromTimestamp(
   epoch: number,
   randomSource: (size: number) => Uint8Array = keysUtilsRandom.getRandomBytes,
 ): AuditEventId {
@@ -521,7 +521,7 @@ function decodeNotificationId(
 export {
   createPermIdGenerator,
   createAuditEventIdGenerator,
-  generateAuditEventIdFromEpoch,
+  generateAuditEventIdFromTimestamp,
   encodeAuditEventId,
   decodeAuditEventId,
   createNodeIdGenerator,

--- a/src/ids/index.ts
+++ b/src/ids/index.ts
@@ -20,6 +20,7 @@ import type {
   GestaltLinkId,
   NotificationId,
   NotificationIdEncoded,
+  AuditEventId,
 } from './types';
 import { IdInternal, IdSortable, IdRandom } from '@matrixai/id';
 import * as keysUtilsRandom from '../keys/utils/random';
@@ -30,6 +31,33 @@ function createPermIdGenerator(): () => PermissionId {
     randomSource: keysUtilsRandom.getRandomBytes,
   });
   return () => generator.get();
+}
+
+function createAuditEventIdGenerator(
+  lastAuditEventId?: AuditEventId,
+): () => AuditEventId {
+  const generator = new IdSortable<AuditEventId>({
+    lastId: lastAuditEventId,
+    randomSource: keysUtilsRandom.getRandomBytes,
+  });
+  return () => generator.get();
+}
+
+/**
+ * Generates an auditId from an epoch timestamp.
+ *
+ * @param epoch
+ * @param randomSource
+ */
+function generateAuditEventIdFromEpoch(
+  epoch: number,
+  randomSource: (size: number) => Uint8Array = keysUtilsRandom.getRandomBytes,
+): AuditEventId {
+  const generator = new IdSortable<AuditEventId>({
+    timeSource: () => () => epoch,
+    randomSource,
+  });
+  return generator.get();
 }
 
 /**
@@ -463,6 +491,8 @@ function decodeNotificationId(
 
 export {
   createPermIdGenerator,
+  createAuditEventIdGenerator,
+  generateAuditEventIdFromEpoch,
   createNodeIdGenerator,
   isNodeId,
   assertNodeId,

--- a/src/ids/types.ts
+++ b/src/ids/types.ts
@@ -6,6 +6,11 @@ import type { Opaque } from '../types';
 type PermissionId = Opaque<'PermissionId', Id>;
 type PermissionIdString = Opaque<'PermissionIdString', string>;
 
+// Audit
+
+type AuditEventId = Opaque<'AuditEventId', Id>;
+type AuditEventIdString = Opaque<'AuditEventIdString', string>;
+
 // Keys
 
 type CertId = Opaque<'CertId', Id>;
@@ -100,6 +105,8 @@ type NotificationIdEncoded = Opaque<'NotificationIdEncoded', string>;
 export type {
   PermissionId,
   PermissionIdString,
+  AuditEventId,
+  AuditEventIdString,
   CertId,
   CertIdString,
   CertIdEncoded,

--- a/src/ids/types.ts
+++ b/src/ids/types.ts
@@ -10,6 +10,7 @@ type PermissionIdString = Opaque<'PermissionIdString', string>;
 
 type AuditEventId = Opaque<'AuditEventId', Id>;
 type AuditEventIdString = Opaque<'AuditEventIdString', string>;
+type AuditEventIdEncoded = Opaque<'AuditEventIdEncoded', string>;
 
 // Keys
 
@@ -107,6 +108,7 @@ export type {
   PermissionIdString,
   AuditEventId,
   AuditEventIdString,
+  AuditEventIdEncoded,
   CertId,
   CertIdString,
   CertIdEncoded,

--- a/src/network/types.ts
+++ b/src/network/types.ts
@@ -28,7 +28,7 @@ type TLSConfig = {
 };
 
 /**
- * Used for the connection event when receiving a reverse connection.
+ * Used for the connection event when creating a forward connection or receiving a reverse connection.
  */
 type ConnectionData = {
   remoteNodeId: NodeId;

--- a/src/nodes/NodeConnectionManager.ts
+++ b/src/nodes/NodeConnectionManager.ts
@@ -1080,6 +1080,16 @@ class NodeConnectionManager {
     const newConnAndTimer = this.addConnection(nodeId, connection);
     // We can assume connection was established and destination was valid, we can add the target to the nodeGraph
     connectionsResults.set(nodeIdString, newConnAndTimer);
+    const connectionData: ConnectionData = {
+      remoteNodeId: connection.nodeId,
+      remoteHost: connection.host,
+      remotePort: connection.port,
+    };
+    this.dispatchEvent(
+      new nodesEvents.EventNodeConnectionManagerConnectionForward({
+        detail: connectionData,
+      }),
+    );
     this.logger.debug(
       `Created NodeConnection for ${nodesUtils.encodeNodeId(
         nodeId,
@@ -1248,7 +1258,7 @@ class NodeConnectionManager {
       remotePort: nodeConnection.port,
     };
     this.dispatchEvent(
-      new nodesEvents.EventNodeConnectionManagerConnection({
+      new nodesEvents.EventNodeConnectionManagerConnectionReverse({
         detail: connectionData,
       }),
     );

--- a/src/nodes/NodeManager.ts
+++ b/src/nodes/NodeManager.ts
@@ -207,8 +207,8 @@ class NodeManager {
   public readonly checkSeedConnectionsHandlerId: TaskHandlerId =
     `${this.basePath}.${this.checkSeedConnectionsHandler.name}.checkSeedConnectionsHandler` as TaskHandlerId;
 
-  protected handleNodeConnectionEvent = async (
-    e: nodesEvents.EventNodeConnectionManagerConnection,
+  protected handleEventNodeConnectionManagerConnectionReverse = async (
+    e: nodesEvents.EventNodeConnectionManagerConnectionReverse,
   ) => {
     await this.setNode(
       e.detail.remoteNodeId,
@@ -296,8 +296,8 @@ class NodeManager {
     });
     // Add handling for connections
     this.nodeConnectionManager.addEventListener(
-      nodesEvents.EventNodeConnectionManagerConnection.name,
-      this.handleNodeConnectionEvent,
+      nodesEvents.EventNodeConnectionManagerConnectionReverse.name,
+      this.handleEventNodeConnectionManagerConnectionReverse,
     );
     this.logger.info(`Started ${this.constructor.name}`);
   }
@@ -306,8 +306,8 @@ class NodeManager {
     this.logger.info(`Stopping ${this.constructor.name}`);
     // Remove handling for connections
     this.nodeConnectionManager.removeEventListener(
-      nodesEvents.EventNodeConnectionManagerConnection.name,
-      this.handleNodeConnectionEvent,
+      nodesEvents.EventNodeConnectionManagerConnectionReverse.name,
+      this.handleEventNodeConnectionManagerConnectionReverse,
     );
     this.logger.info('Cancelling ephemeral tasks');
     if (this.taskManager.isProcessing()) {

--- a/src/nodes/events.ts
+++ b/src/nodes/events.ts
@@ -32,7 +32,11 @@ class EventNodeConnectionManagerClose extends EventNodeConnectionManager {}
 
 class EventNodeConnectionManagerConnection extends EventNodeConnectionManager<ConnectionData> {}
 
-class EventNodeConnectionManagerConnectionFailure extends EventNodeConnectionManager<
+class EventNodeConnectionManagerConnectionForward extends EventNodeConnectionManagerConnection {}
+
+class EventNodeConnectionManagerConnectionReverse extends EventNodeConnectionManagerConnection {}
+
+class EventNodeConnectionManagerConnectionReverseFailure extends EventNodeConnectionManager<
   Error | EventNodeConnectionError
 > {}
 
@@ -76,7 +80,9 @@ export {
   EventNodeConnectionManagerError,
   EventNodeConnectionManagerClose,
   EventNodeConnectionManagerConnection,
-  EventNodeConnectionManagerConnectionFailure,
+  EventNodeConnectionManagerConnectionForward,
+  EventNodeConnectionManagerConnectionReverse,
+  EventNodeConnectionManagerConnectionReverseFailure,
   EventNodeGraph,
   EventNodeGraphStart,
   EventNodeGraphStarted,

--- a/tests/audit/Audit.test.ts
+++ b/tests/audit/Audit.test.ts
@@ -1,0 +1,257 @@
+import type { Key } from '@/keys/types';
+import type { ConnectionData, Host, Port } from '@/network/types';
+import type NodeConnectionManager from '@/nodes/NodeConnectionManager';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
+import { DB } from '@matrixai/db';
+import Audit from '@/audit/Audit';
+import * as utils from '@/utils';
+import * as auditErrors from '@/audit/errors';
+import * as keysUtils from '@/keys/utils';
+import * as nodeEvents from '@/nodes/events';
+import * as nodeUtils from '@/nodes/utils';
+import * as ids from '@/ids';
+import * as testNodesUtils from '../nodes/utils';
+
+describe(Audit.name, () => {
+  const logger = new Logger(`${Audit.name} test`, LogLevel.WARN, [
+    new StreamHandler(),
+  ]);
+
+  let dataDir: string;
+  let db: DB;
+  let mockNodeConnectionManager: NodeConnectionManager;
+  beforeEach(async () => {
+    dataDir = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'polykey-test-'),
+    );
+    const dbKey = keysUtils.generateKey();
+    const dbPath = `${dataDir}/db`;
+    db = await DB.createDB({
+      dbPath,
+      logger,
+      crypto: {
+        key: dbKey,
+        ops: {
+          encrypt: async (key, plainText) => {
+            return keysUtils.encryptWithKey(
+              utils.bufferWrap(key) as Key,
+              utils.bufferWrap(plainText),
+            );
+          },
+          decrypt: async (key, cipherText) => {
+            return keysUtils.decryptWithKey(
+              utils.bufferWrap(key) as Key,
+              utils.bufferWrap(cipherText),
+            );
+          },
+        },
+      },
+    });
+    mockNodeConnectionManager = new EventTarget() as NodeConnectionManager;
+  });
+  afterEach(async () => {
+    await db.stop();
+    await fs.promises.rm(dataDir, {
+      force: true,
+      recursive: true,
+    });
+  });
+  test('audit readiness', async () => {
+    const audit = await Audit.createAudit({
+      db,
+      nodeConnectionManager: new EventTarget() as any,
+      logger,
+    });
+    await expect(async () => {
+      await audit.destroy();
+    }).rejects.toThrow(auditErrors.ErrorAuditRunning);
+    // Should be a noop
+    await audit.start();
+    await audit.stop();
+    await audit.destroy();
+    await expect(async () => {
+      await audit.start();
+    }).rejects.toThrow(auditErrors.ErrorAuditDestroyed);
+    await expect(audit.getLastAuditEventId()).rejects.toThrow(
+      auditErrors.ErrorAuditNotRunning,
+    );
+    await expect(audit.getAuditMetric(['node', 'connection'])).rejects.toThrow(
+      auditErrors.ErrorAuditNotRunning,
+    );
+  });
+  describe('AuditEvent', () => {
+    test('node connection', async () => {
+      const nodeId = testNodesUtils.generateRandomNodeId();
+      const audit = await Audit.createAudit({
+        db,
+        nodeConnectionManager: mockNodeConnectionManager,
+        logger,
+      });
+      const eventDetail: ConnectionData = {
+        remoteHost: '::' as Host,
+        remoteNodeId: nodeId,
+        remotePort: 0 as Port,
+      };
+      const auditEventData = {
+        ...eventDetail,
+        remoteNodeId: nodeUtils.encodeNodeId(eventDetail.remoteNodeId),
+      };
+      // @ts-ignore: kidnap protected
+      const handlerMap = audit.eventHandlerMap;
+      await handlerMap
+        .get(nodeEvents.EventNodeConnectionManagerConnectionReverse)
+        ?.handler(
+          new nodeEvents.EventNodeConnectionManagerConnectionReverse({
+            detail: eventDetail,
+          }),
+        );
+      await handlerMap
+        .get(nodeEvents.EventNodeConnectionManagerConnectionForward)
+        ?.handler(
+          new nodeEvents.EventNodeConnectionManagerConnectionForward({
+            detail: eventDetail,
+          }),
+        );
+      let iterator = audit.getAuditEvents(['node', 'connection']);
+      await expect(iterator.next().then((e) => e.value!.data)).resolves.toEqual(
+        {
+          ...auditEventData,
+          type: 'forward',
+        },
+      );
+      await expect(iterator.next().then((e) => e.value!.data)).resolves.toEqual(
+        {
+          ...auditEventData,
+          type: 'reverse',
+        },
+      );
+      iterator = audit.getAuditEvents(['node', 'connection', 'forward']);
+      await expect(iterator.next().then((e) => e.value!.data)).resolves.toEqual(
+        {
+          ...auditEventData,
+          type: 'forward',
+        },
+      );
+      iterator = audit.getAuditEvents(['node', 'connection', 'reverse']);
+      await expect(iterator.next().then((e) => e.value!.data)).resolves.toEqual(
+        {
+          ...auditEventData,
+          type: 'reverse',
+        },
+      );
+      await audit.stop();
+    });
+  });
+  describe('AuditMetric', () => {
+    test('node connection', async () => {
+      const audit = await Audit.createAudit({
+        db,
+        nodeConnectionManager: mockNodeConnectionManager,
+        logger,
+      });
+      const nodeId = testNodesUtils.generateRandomNodeId();
+      const auditEventData = {
+        remoteHost: '::',
+        remoteNodeId: nodeUtils.encodeNodeId(nodeId),
+        remotePort: 0,
+      };
+      const date = Date.now();
+      const date1MinuteAgo = date - 60_000;
+      const date1HourAgo = date - 60 * 60_000;
+      const date1DayAgo = date - 24 * 60 * 60_000;
+      const date1MonthAgo = date - 30 * 24 * 60 * 60_000;
+      const dates = [
+        date,
+        date1MinuteAgo,
+        date1HourAgo,
+        date1DayAgo,
+        date1MonthAgo,
+      ];
+      for (const iterDate of dates) {
+        // @ts-ignore: kidnap protected
+        await audit.setAuditEvent(
+          ['node', 'connection', 'reverse'],
+          ids.generateAuditEventIdFromEpoch(iterDate),
+          {
+            data: {
+              ...auditEventData,
+              type: 'reverse',
+            },
+          },
+        );
+      }
+      for (const iterDate of dates) {
+        // @ts-ignore: kidnap protected
+        await audit.setAuditEvent(
+          ['node', 'connection', 'forward'],
+          ids.generateAuditEventIdFromEpoch(iterDate),
+          {
+            data: {
+              ...auditEventData,
+              type: 'forward',
+            },
+          },
+        );
+      }
+      // Range from first element to now
+      await expect(
+        audit
+          .getAuditMetric(['node', 'connection', 'inbound'])
+          .then((e) => e.data),
+      ).resolves.toEqual({
+        total: dates.length,
+        averagePerDay: dates.length / 30,
+        averagePerHour: dates.length / (30 * 24),
+        averagePerMinute: dates.length / (30 * 24 * 60),
+      });
+      await expect(
+        audit
+          .getAuditMetric(['node', 'connection', 'outbound'])
+          .then((e) => e.data),
+      ).resolves.toEqual({
+        total: dates.length,
+        averagePerDay: dates.length / 30,
+        averagePerHour: dates.length / (30 * 24),
+        averagePerMinute: dates.length / (30 * 24 * 60),
+      });
+      await expect(
+        audit.getAuditMetric(['node', 'connection']).then((e) => e.data),
+      ).resolves.toEqual({
+        total: dates.length * 2,
+        averagePerDay: (dates.length * 2) / 30,
+        averagePerHour: (dates.length * 2) / (30 * 24),
+        averagePerMinute: (dates.length * 2) / (30 * 24 * 60),
+      });
+      // Range from day to now
+      await expect(
+        audit
+          .getAuditMetric(['node', 'connection', 'inbound'], {
+            from: date1DayAgo,
+          })
+          .then((e) => e.data),
+      ).resolves.toEqual({
+        total: dates.length - 1,
+        averagePerDay: dates.length - 1,
+        averagePerHour: (dates.length - 1) / 24,
+        averagePerMinute: (dates.length - 1) / (24 * 60),
+      });
+      // Range from first element to minute
+      await expect(
+        audit
+          .getAuditMetric(['node', 'connection', 'inbound'], {
+            to: date1MinuteAgo,
+          })
+          .then((e) => e.data),
+      ).resolves.toEqual({
+        total: dates.length - 1,
+        averagePerDay: (dates.length - 1) / 30,
+        averagePerHour: (dates.length - 1) / (30 * 24),
+        averagePerMinute: (dates.length - 1) / (60 * 30 * 24 - 1),
+      });
+      await audit.stop();
+    });
+  });
+});

--- a/tests/audit/Audit.test.ts
+++ b/tests/audit/Audit.test.ts
@@ -82,6 +82,37 @@ describe(Audit.name, () => {
       auditErrors.ErrorAuditNotRunning,
     );
   });
+  // Test('long running', async () => {
+  //   const nodeId = testNodesUtils.generateRandomNodeId();
+  //   const audit = await Audit.createAudit({
+  //     db,
+  //     nodeConnectionManager: mockNodeConnectionManager,
+  //     logger,
+  //   });
+  //   const eventDetail: ConnectionData = {
+  //     remoteHost: '::' as Host,
+  //     remoteNodeId: nodeId,
+  //     remotePort: 0 as Port,
+  //   };
+  //   const auditEventData = {
+  //     ...eventDetail,
+  //     remoteNodeId: nodeUtils.encodeNodeId(eventDetail.remoteNodeId),
+  //   };
+  //   // @ts-ignore: kidnap protected
+  //   const handlerMap = audit.eventHandlerMap;
+  //   await handlerMap
+  //     .get(nodeEvents.EventNodeConnectionManagerConnectionReverse)
+  //     ?.handler(
+  //       new nodeEvents.EventNodeConnectionManagerConnectionReverse({
+  //         detail: eventDetail,
+  //       }),
+  //     );
+
+  //   for await (const s of audit.getAuditEventsLongRunning(['node'])) {
+
+  //   }
+  //   await audit.stop();
+  // });
   describe('AuditEvent', () => {
     test('node connection', async () => {
       const nodeId = testNodesUtils.generateRandomNodeId();
@@ -172,29 +203,23 @@ describe(Audit.name, () => {
       ];
       for (const iterDate of dates) {
         // @ts-ignore: kidnap protected
-        await audit.setAuditEvent(
-          ['node', 'connection', 'reverse'],
-          ids.generateAuditEventIdFromEpoch(iterDate),
-          {
-            data: {
-              ...auditEventData,
-              type: 'reverse',
-            },
+        await audit.setAuditEvent(['node', 'connection', 'reverse'], {
+          id: ids.generateAuditEventIdFromEpoch(iterDate),
+          data: {
+            ...auditEventData,
+            type: 'reverse',
           },
-        );
+        });
       }
       for (const iterDate of dates) {
         // @ts-ignore: kidnap protected
-        await audit.setAuditEvent(
-          ['node', 'connection', 'forward'],
-          ids.generateAuditEventIdFromEpoch(iterDate),
-          {
-            data: {
-              ...auditEventData,
-              type: 'forward',
-            },
+        await audit.setAuditEvent(['node', 'connection', 'forward'], {
+          id: ids.generateAuditEventIdFromEpoch(iterDate),
+          data: {
+            ...auditEventData,
+            type: 'forward',
           },
-        );
+        });
       }
       // Range from first element to now
       await expect(

--- a/tests/client/handlers/audit.test.ts
+++ b/tests/client/handlers/audit.test.ts
@@ -1,0 +1,268 @@
+import type { ConnectionData, Host, Port, TLSConfig } from '@/network/types';
+import type { OverrideRPClientType } from '@/client/types';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import Logger, { formatting, LogLevel, StreamHandler } from '@matrixai/logger';
+import { DB } from '@matrixai/db';
+import { RPCClient } from '@matrixai/rpc';
+import { WebSocketClient } from '@matrixai/ws';
+import KeyRing from '@/keys/KeyRing';
+import ClientService from '@/client/ClientService';
+import { auditEventsGet } from '@/client/callers';
+import * as keysUtils from '@/keys/utils';
+import * as nodesUtils from '@/nodes/utils';
+import * as nodesEvents from '@/nodes/events';
+import * as networkUtils from '@/network/utils';
+import AuditEventsGet from '@/client/handlers/AuditEventsGet';
+import { Audit } from '@/audit';
+import AuditMetricGet from '@/client/handlers/AuditMetricGet';
+import auditMetricGet from '@/client/callers/auditMetricGet';
+import * as testNodesUtils from '../../nodes/utils';
+import * as testsUtils from '../../utils';
+
+describe('auditEventGet', () => {
+  const logger = new Logger('auditEventsGet test', LogLevel.WARN, [
+    new StreamHandler(
+      formatting.format`${formatting.level}:${formatting.keys}:${formatting.msg}`,
+    ),
+  ]);
+  const password = 'password';
+  const localhost = '127.0.0.1';
+  let audit: Audit;
+  let dataDir: string;
+  let db: DB;
+  let keyRing: KeyRing;
+  let clientService: ClientService;
+  let webSocketClient: WebSocketClient;
+  let rpcClient: OverrideRPClientType<
+    RPCClient<{
+      auditEventsGet: typeof auditEventsGet;
+    }>
+  >;
+  let tlsConfig: TLSConfig;
+
+  beforeEach(async () => {
+    dataDir = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'polykey-test-'),
+    );
+    const keysPath = path.join(dataDir, 'keys');
+    const dbPath = path.join(dataDir, 'db');
+    db = await DB.createDB({
+      dbPath,
+      logger,
+    });
+    keyRing = await KeyRing.createKeyRing({
+      password,
+      keysPath,
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
+      logger,
+    });
+    tlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);
+    clientService = new ClientService({
+      tlsConfig,
+      logger: logger.getChild(ClientService.name),
+    });
+    audit = await Audit.createAudit({
+      db,
+      nodeConnectionManager: new EventTarget() as any,
+      logger: logger.getChild(Audit.name),
+    });
+    clientService = new ClientService({
+      tlsConfig,
+      logger: logger.getChild(ClientService.name),
+    });
+    await clientService.start({
+      manifest: {
+        auditEventsGet: new AuditEventsGet({
+          audit,
+        }),
+      },
+      host: localhost,
+    });
+    webSocketClient = await WebSocketClient.createWebSocketClient({
+      config: {
+        verifyPeer: false,
+      },
+      host: localhost,
+      logger: logger.getChild(WebSocketClient.name),
+      port: clientService.port,
+    });
+    rpcClient = new RPCClient({
+      manifest: {
+        auditEventsGet,
+      },
+      streamFactory: () => webSocketClient.connection.newStream(),
+      toError: networkUtils.toError,
+      logger: logger.getChild(RPCClient.name),
+    }) as any;
+  });
+  afterEach(async () => {
+    await clientService.stop({ force: true });
+    await webSocketClient.destroy({ force: true });
+    await keyRing.stop();
+    await audit.stop();
+    await fs.promises.rm(dataDir, {
+      force: true,
+      recursive: true,
+    });
+  });
+  test('cancels', async () => {
+    const callerInterface = await rpcClient.methods.auditEventsGet({
+      path: [],
+    });
+    const reader = callerInterface.getReader();
+    await reader.cancel();
+    await expect(reader.closed).toResolve();
+  });
+  test('gets connection events', async () => {
+    const nodeId = testNodesUtils.generateRandomNodeId();
+    const eventDetail: ConnectionData = {
+      remoteHost: '::' as Host,
+      remoteNodeId: nodeId,
+      remotePort: 0 as Port,
+    };
+    const auditEventData = {
+      ...eventDetail,
+      remoteNodeId: nodesUtils.encodeNodeId(eventDetail.remoteNodeId),
+    };
+    // @ts-ignore: kidnap protected
+    const handlerMap = audit.eventHandlerMap;
+    await handlerMap
+      .get(nodesEvents.EventNodeConnectionManagerConnectionReverse)
+      ?.handler(
+        new nodesEvents.EventNodeConnectionManagerConnectionReverse({
+          detail: eventDetail,
+        }),
+      );
+    const callerInterface = await rpcClient.methods.auditEventsGet({
+      path: ['node', 'connection', 'reverse'],
+    });
+    const reader = callerInterface.getReader();
+    await expect(reader.read().then((e) => e.value!.data)).resolves.toEqual({
+      ...auditEventData,
+      type: 'reverse',
+    });
+  });
+});
+
+describe('auditMetricGet', () => {
+  const logger = new Logger('auditMetricGet test', LogLevel.WARN, [
+    new StreamHandler(
+      formatting.format`${formatting.level}:${formatting.keys}:${formatting.msg}`,
+    ),
+  ]);
+  const password = 'password';
+  const localhost = '127.0.0.1';
+  let audit: Audit;
+  let dataDir: string;
+  let db: DB;
+  let keyRing: KeyRing;
+  let clientService: ClientService;
+  let webSocketClient: WebSocketClient;
+  let rpcClient: OverrideRPClientType<
+    RPCClient<{
+      auditEventsGet: typeof auditEventsGet;
+    }>
+  >;
+  let tlsConfig: TLSConfig;
+
+  beforeEach(async () => {
+    dataDir = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'polykey-test-'),
+    );
+    const keysPath = path.join(dataDir, 'keys');
+    const dbPath = path.join(dataDir, 'db');
+    db = await DB.createDB({
+      dbPath,
+      logger,
+    });
+    keyRing = await KeyRing.createKeyRing({
+      password,
+      keysPath,
+      passwordOpsLimit: keysUtils.passwordOpsLimits.min,
+      passwordMemLimit: keysUtils.passwordMemLimits.min,
+      strictMemoryLock: false,
+      logger,
+    });
+    tlsConfig = await testsUtils.createTLSConfig(keyRing.keyPair);
+    clientService = new ClientService({
+      tlsConfig,
+      logger: logger.getChild(ClientService.name),
+    });
+    audit = await Audit.createAudit({
+      db,
+      nodeConnectionManager: new EventTarget() as any,
+      logger: logger.getChild(Audit.name),
+    });
+    clientService = new ClientService({
+      tlsConfig,
+      logger: logger.getChild(ClientService.name),
+    });
+    await clientService.start({
+      manifest: {
+        auditMetricGet: new AuditMetricGet({
+          audit,
+        }),
+      },
+      host: localhost,
+    });
+    webSocketClient = await WebSocketClient.createWebSocketClient({
+      config: {
+        verifyPeer: false,
+      },
+      host: localhost,
+      logger: logger.getChild(WebSocketClient.name),
+      port: clientService.port,
+    });
+    rpcClient = new RPCClient({
+      manifest: {
+        auditMetricGet,
+      },
+      streamFactory: () => webSocketClient.connection.newStream(),
+      toError: networkUtils.toError,
+      logger: logger.getChild(RPCClient.name),
+    }) as any;
+  });
+  afterEach(async () => {
+    await clientService.stop({ force: true });
+    await webSocketClient.destroy({ force: true });
+    await keyRing.stop();
+    await audit.stop();
+    await fs.promises.rm(dataDir, {
+      force: true,
+      recursive: true,
+    });
+  });
+  test('gets connection metrics', async () => {
+    const nodeId = testNodesUtils.generateRandomNodeId();
+    const eventDetail: ConnectionData = {
+      remoteHost: '::' as Host,
+      remoteNodeId: nodeId,
+      remotePort: 0 as Port,
+    };
+    // @ts-ignore: kidnap protected
+    const handlerMap = audit.eventHandlerMap;
+    await handlerMap
+      .get(nodesEvents.EventNodeConnectionManagerConnectionReverse)
+      ?.handler(
+        new nodesEvents.EventNodeConnectionManagerConnectionReverse({
+          detail: eventDetail,
+        }),
+      );
+    await expect(
+      rpcClient.methods
+        .auditMetricGet({
+          path: ['node', 'connection', 'inbound'],
+        })
+        .then((e) => e.data),
+    ).resolves.toEqual({
+      total: 1,
+      averagePerMinute: 1,
+      averagePerHour: 1,
+      averagePerDay: 1,
+    });
+  });
+});


### PR DESCRIPTION
### Description
This PR implements an `audit` domain that collects events from various domains and stores them in `js-db`, serving them via a `js-rpc` API to external applications. 

This PR currently only implements AuditEvents and AuditMetrics for `['node', 'connection']` topics/metrics.

More will be implemented incrementally as needed.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #628 

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Design Topic and Event types
- [x] 2. Audit Domain
- [x] 3. Implement Audit domain js-rpc handlers

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
