### PR TITLE
DNS-SD SRV Record Discovery of Polykey Seednodes for Polykey Agent Bootstrapping

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,32 +1,7 @@
 import type { PasswordMemLimit, PasswordOpsLimit } from './keys/types';
-import type { NodeAddress } from './nodes/types';
-import type { Host, Port } from './network/types';
 import { getDefaultNodePath } from './utils';
 // @ts-ignore package.json is outside rootDir
 import { version } from '../package.json';
-
-/**
- * Configuration for testnet node addresses.
- * Extracted here to enforce types properly.
- */
-const testnet: Record<string, NodeAddress> = {
-  v7v9ptvcdbdf8p4upok3prpmu3938ns8v4g45dib7sm5hqvvehv70: {
-    host: 'testnet.polykey.com' as Host,
-    port: 1314 as Port,
-    scopes: ['global'],
-  },
-  v270ktdd3cs3mp1r3q3dkmick92bn927mii9or4sgroeogd1peqb0: {
-    host: 'testnet.polykey.com' as Host,
-    port: 1314 as Port,
-    scopes: ['global'],
-  },
-};
-
-/**
- * Configuration for main net node addresses.
- * Extracted here to enforce types properly.
- */
-const mainnet: Record<string, NodeAddress> = {};
 
 /**
  * Polykey static configuration
@@ -91,8 +66,7 @@ const config = {
   },
   /**
    * This is not used by the `PolykeyAgent` which defaults to `{}`
-   * In the future this will be replaced by `mainnet.polykey.com` and `testnet.polykey.com`.
-   * Along with the domain we will have the root public key too.
+   * In the future this will have the root public key too.
    *
    * Information that is pre-configured during distribution:
    *
@@ -110,8 +84,8 @@ const config = {
    * providing an extra level of confidence. However this is not required.
    */
   network: {
-    mainnet: mainnet,
-    testnet: testnet,
+    mainnet: 'mainnet.polykey.com',
+    testnet: 'testnet.polykey.com',
   },
   /**
    * Default system configuration.

--- a/src/nodes/errors.ts
+++ b/src/nodes/errors.ts
@@ -179,6 +179,11 @@ class ErrorNodePermissionDenied<T> extends ErrorNodes<T> {
   exitCode = sysexits.NOHOST;
 }
 
+class ErrorNodeLookupNotFound<T> extends ErrorNodes<T> {
+  static description = 'No seednodes were found for the given cluster hostname';
+  exitCode = sysexits.NOHOST;
+}
+
 export {
   ErrorNodes,
   ErrorNodeManager,
@@ -213,4 +218,5 @@ export {
   ErrorNodeConnectionManagerRequestRateExceeded,
   ErrorNodePingFailed,
   ErrorNodePermissionDenied,
+  ErrorNodeLookupNotFound,
 };


### PR DESCRIPTION
### Description

This PR changes how bootstrapping by users of the library must occur in order to accommodate for SRV record resolution of seednodes for a given network.

This is the new flow:

```ts
const networkHostname: Hostname = nodesUtils.parseNetwork('testnet');
const nodeAddresses = nodesUtils.resolveSeednodes(networkHostname);
```

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Related #599
* Related #618  

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Create utility function for resolving NodeAddresses from a Hostname
- [x] 2. Amend parseNetwork so that it returns the associated hostname instead (`testnet.polykey.com`)

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests - N/A
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
