### PR TITLE
Fixes the vault cloning issue when trying to clone a vault with the same name as one already present 

### DIFF
--- a/src/client/handlers/VaultsClone.ts
+++ b/src/client/handlers/VaultsClone.ts
@@ -39,9 +39,10 @@ class VaultsClone extends UnaryHandler<
         nodeId: input.nodeIdEncoded,
       },
     );
+    const force = input.force ?? false;
     // Vault id
     await db.withTransactionF(async (tran) => {
-      await vaultManager.cloneVault(nodeId, input.nameOrId, tran);
+      await vaultManager.cloneVault(nodeId, input.nameOrId, tran, force);
     });
     return {
       success: true,

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -228,7 +228,10 @@ type VaultIdentifierMessage = {
   nameOrId: VaultIdEncoded | VaultName;
 };
 
-type CloneMessage = NodeIdMessage & VaultIdentifierMessage;
+type CloneMessage = NodeIdMessage &
+  VaultIdentifierMessage & {
+    force?: boolean;
+  };
 
 type VaultListMessage = VaultNameMessage & VaultIdMessage;
 


### PR DESCRIPTION

### Description

The vaults clone handler now has a force flag to override the default cloning behaviour of throwing undefined when the name was  already in the Vault Map.

The override flag has also been amended in the types.

```ts

        // Get the list of existing vaults
        const existingVaults = await this.listVaults(tran);

        if (existingVaults.has(newVaultName)) {
          if (force) {
            newVaultName = `${newVaultName}_1`;
          } else {
            throw new vaultsErrors.ErrorVaultsNameConflict(
              `A vault with the name '${newVaultName}' already exists. Use --override to force cloning.`,
            );
          }
        }
```

Now the vaultsClone function checks with listVaults if a vault with the same name exists and then throws a error (default behaviour) 

The user can use the --override call to force clone the vault, the new vault name is appended with a "_1".

The default error message includes the information about the override call.

### Issues Fixed

* Fixes #652

### Tasks

- [x] 1. Update VaultClone method
- [x] 2. Update the types for the handler
- [x] 3. Update the handler

### Final checklist

* [ ] Domain specific tests
* [ ] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [ ] Sanity check the final build
