### PR TITLE
fix: fixed vaults cloning handling duplicate vault name

### DIFF
--- a/src/vaults/VaultManager.ts
+++ b/src/vaults/VaultManager.ts
@@ -720,10 +720,10 @@ class VaultManager {
         let newVaultName = baseVaultName;
         let attempts = 1;
         while (true) {
-          const existingVaultId = await tran.get([
-            ...this.vaultsNamesDbPath,
-            newVaultName,
-          ]);
+          const existingVaultId = await tran.get(
+            [...this.vaultsNamesDbPath, newVaultName],
+            true,
+          );
           if (existingVaultId == null) break;
           newVaultName = `${baseVaultName}-${attempts}`;
           if (attempts >= 50) {


### PR DESCRIPTION
### Description

This PR addresses the issue where cloning a vault with a name that already exists fails.

### Issues Fixed

Fixes #652 

### Tasks
- [x] 1. Find and fix problem
- [x] 2. Add a test to check for regressions

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
