### PR TITLE
Adding `secrets env command` RPC logic

### DIFF
--- a/src/client/callers/index.ts
+++ b/src/client/callers/index.ts
@@ -60,6 +60,7 @@ import vaultsRename from './vaultsRename';
 import vaultsScan from './vaultsScan';
 import vaultsSecretsDelete from './vaultsSecretsDelete';
 import vaultsSecretsEdit from './vaultsSecretsEdit';
+import vaultsSecretsEnv from './vaultsSecretsEnv';
 import vaultsSecretsGet from './vaultsSecretsGet';
 import vaultsSecretsList from './vaultsSecretsList';
 import vaultsSecretsMkdir from './vaultsSecretsMkdir';
@@ -135,6 +136,7 @@ const clientManifest = {
   vaultsScan,
   vaultsSecretsDelete,
   vaultsSecretsEdit,
+  vaultsSecretsEnv,
   vaultsSecretsGet,
   vaultsSecretsList,
   vaultsSecretsMkdir,
@@ -209,6 +211,7 @@ export {
   vaultsScan,
   vaultsSecretsDelete,
   vaultsSecretsEdit,
+  vaultsSecretsEnv,
   vaultsSecretsGet,
   vaultsSecretsList,
   vaultsSecretsMkdir,

--- a/src/client/callers/vaultsSecretsEnv.ts
+++ b/src/client/callers/vaultsSecretsEnv.ts
@@ -1,0 +1,12 @@
+import type { HandlerTypes } from '@matrixai/rpc';
+import type VaultsSecretsEnv from '../handlers/VaultsSecretsEnv';
+import { DuplexCaller } from '@matrixai/rpc';
+
+type CallerTypes = HandlerTypes<VaultsSecretsEnv>;
+
+const vaultsSecretsEnv = new DuplexCaller<
+  CallerTypes['input'],
+  CallerTypes['output']
+>();
+
+export default vaultsSecretsEnv;

--- a/src/client/handlers/VaultsSecretsEnv.ts
+++ b/src/client/handlers/VaultsSecretsEnv.ts
@@ -1,0 +1,89 @@
+import type { DB } from '@matrixai/db';
+import type {
+  ClientRPCRequestParams,
+  ClientRPCResponseResult,
+  SecretIdentifierMessage,
+  SecretContentMessage,
+} from '../types';
+import type VaultManager from '../../vaults/VaultManager';
+import { DuplexHandler } from '@matrixai/rpc';
+import * as vaultsUtils from '../../vaults/utils';
+import * as vaultsErrors from '../../vaults/errors';
+
+class VaultsSecretsList extends DuplexHandler<
+  {
+    vaultManager: VaultManager;
+    db: DB;
+  },
+  ClientRPCRequestParams<SecretIdentifierMessage>,
+  ClientRPCResponseResult<SecretContentMessage>
+> {
+  public handle = async function* (
+    input: AsyncIterableIterator<
+      ClientRPCRequestParams<SecretIdentifierMessage>
+    >,
+    _cancel,
+    _meta,
+    ctx,
+  ): AsyncGenerator<ClientRPCResponseResult<SecretContentMessage>> {
+    if (ctx.signal.aborted) throw ctx.signal.reason;
+    const { vaultManager, db }: { vaultManager: VaultManager; db: DB } =
+      this.container;
+
+    return yield* db.withTransactionG(async function* (tran): AsyncGenerator<
+      ClientRPCResponseResult<SecretContentMessage>
+    > {
+      if (ctx.signal.aborted) throw ctx.signal.reason;
+      for await (const secretIdentifierMessage of input) {
+        const { nameOrId, secretName } = secretIdentifierMessage;
+        const vaultIdFromName = await vaultManager.getVaultId(nameOrId, tran);
+        const vaultId = vaultIdFromName ?? vaultsUtils.decodeVaultId(nameOrId);
+        if (vaultId == null) {
+          throw new vaultsErrors.ErrorVaultsVaultUndefined();
+        }
+        const secrets = await vaultManager.withVaults(
+          [vaultId],
+          async (vault) => {
+            const results: Array<{
+              filePath: string;
+              value: string;
+            }> = [];
+            return await vault.readF(async (fs) => {
+              try {
+                for await (const filePath of vaultsUtils.walkFs(
+                  fs,
+                  secretName,
+                )) {
+                  const fileContents = await fs.readFile(filePath);
+                  results.push({
+                    filePath,
+                    value: fileContents.toString(),
+                  });
+                }
+              } catch (e) {
+                if (e.code === 'ENOENT') {
+                  throw new vaultsErrors.ErrorSecretsSecretUndefined(
+                    `Secret with name: ${secretName} does not exist`,
+                    { cause: e },
+                  );
+                }
+                throw e;
+              }
+              return results;
+            });
+          },
+          tran,
+        );
+        for (const { filePath, value } of secrets) {
+          yield {
+            nameOrId: nameOrId,
+            secretName: filePath,
+            secretContent: value,
+          };
+        }
+      }
+    });
+  };
+}
+
+export default VaultsSecretsList;

--- a/src/client/handlers/index.ts
+++ b/src/client/handlers/index.ts
@@ -75,6 +75,7 @@ import VaultsRename from './VaultsRename';
 import VaultsScan from './VaultsScan';
 import VaultsSecretsDelete from './VaultsSecretsDelete';
 import VaultsSecretsEdit from './VaultsSecretsEdit';
+import VaultsSecretsEnv from './VaultsSecretsEnv';
 import VaultsSecretsGet from './VaultsSecretsGet';
 import VaultsSecretsList from './VaultsSecretsList';
 import VaultsSecretsMkdir from './VaultsSecretsMkdir';
@@ -175,6 +176,7 @@ const serverManifest = (container: {
     vaultsScan: new VaultsScan(container),
     vaultsSecretsDelete: new VaultsSecretsDelete(container),
     vaultsSecretsEdit: new VaultsSecretsEdit(container),
+    vaultsSecretsEnv: new VaultsSecretsEnv(container),
     vaultsSecretsGet: new VaultsSecretsGet(container),
     vaultsSecretsList: new VaultsSecretsList(container),
     vaultsSecretsMkdir: new VaultsSecretsMkdir(container),
@@ -249,6 +251,7 @@ export {
   VaultsScan,
   VaultsSecretsDelete,
   VaultsSecretsEdit,
+  VaultsSecretsEnv,
   VaultsSecretsGet,
   VaultsSecretsList,
   VaultsSecretsMkdir,

--- a/src/git/utils.ts
+++ b/src/git/utils.ts
@@ -192,7 +192,7 @@ async function listRefs(
   const packedMap = packedRefs(fs, gitdir);
   let files: string[] = [];
   try {
-    for await (const file of vaultsUtils.readdirRecursively(
+    for await (const file of vaultsUtils.readDirRecursively(
       fs,
       path.join(gitdir, filepath),
     )) {

--- a/src/vaults/VaultOps.ts
+++ b/src/vaults/VaultOps.ts
@@ -204,7 +204,7 @@ async function addSecretDirectory(
   const absoluteDirPath = path.resolve(secretDirectory);
 
   await vault.writeF(async (efs) => {
-    for await (const secretPath of vaultsUtils.readdirRecursively(
+    for await (const secretPath of vaultsUtils.readDirRecursively(
       fs,
       absoluteDirPath,
     )) {
@@ -253,7 +253,7 @@ async function addSecretDirectory(
 async function listSecrets(vault: Vault): Promise<string[]> {
   return await vault.readF(async (efs) => {
     const secrets: string[] = [];
-    for await (const secret of vaultsUtils.readdirRecursively(efs)) {
+    for await (const secret of vaultsUtils.readDirRecursively(efs)) {
       secrets.push(secret);
     }
     return secrets;

--- a/tests/vaults/utils.test.ts
+++ b/tests/vaults/utils.test.ts
@@ -40,14 +40,14 @@ describe('Vaults utils', () => {
     const filePath1 = path.join('dir', 'file');
     await efs.promises.writeFile(filePath1, 'content');
     let files: string[] = [];
-    for await (const file of vaultsUtils.readdirRecursively(efs, './')) {
+    for await (const file of vaultsUtils.readDirRecursively(efs, './')) {
       files.push(file);
     }
     expect(files).toStrictEqual([filePath1]);
     files = [];
     const filePath2 = path.join('dir', 'dir2', 'dir3', 'file');
     await efs.promises.writeFile(filePath2, 'content');
-    for await (const file of vaultsUtils.readdirRecursively(efs)) {
+    for await (const file of vaultsUtils.readDirRecursively(efs)) {
       files.push(file);
     }
     expect(files.sort()).toStrictEqual([filePath1, filePath2].sort());
@@ -60,14 +60,14 @@ describe('Vaults utils', () => {
     const filePath1 = path.join(dataDir, 'dir', 'file');
     await fs.promises.writeFile(filePath1, 'content');
     let files: string[] = [];
-    for await (const file of vaultsUtils.readdirRecursively(fs, dataDir)) {
+    for await (const file of vaultsUtils.readDirRecursively(fs, dataDir)) {
       files.push(file);
     }
     expect(files).toStrictEqual([filePath1]);
     files = [];
     const filePath2 = path.join(dataDir, 'dir', 'dir2', 'dir3', 'file');
     await fs.promises.writeFile(filePath2, 'content');
-    for await (const file of vaultsUtils.readdirRecursively(fs, dataDir)) {
+    for await (const file of vaultsUtils.readDirRecursively(fs, dataDir)) {
       files.push(file);
     }
     expect(files.sort()).toStrictEqual([filePath1, filePath2].sort());


### PR DESCRIPTION
### Description

This PR adds the RPC method required by the `Polykey-CLI` `pk secrets env` command.

### Issues Fixed

* Related https://github.com/MatrixAI/Polykey-CLI/pull/129

### Tasks
- [x] 1. Add `VaultsSecretsEnv` RPC method.
- [x] 2. Needs to stream back requested ENV variables and their contents.
- ~3. Needs to support globbing and possibly regex selection~ To complex for now, focusing on basic functionality
- [x] 4. Specifying a directory path will get all contents of that directory

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
