### PR TITLE
fix: changed umask to 0007

### DIFF
--- a/src/bootstrap/utils.ts
+++ b/src/bootstrap/utils.ts
@@ -61,7 +61,7 @@ async function bootstrapState({
   fs?: FileSystem;
   logger?: Logger;
 }): Promise<RecoveryCode | undefined> {
-  const umask = 0o077;
+  const umask = 0o007;
   logger.info(`Setting umask to ${umask.toString(8).padStart(3, '0')}`);
   process.umask(umask);
   logger.info(`Setting node path to ${nodePath}`);


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->
This PR changes the default `umask` on all files Polykey Agent creates to a value of `0007` (translates to 0770 permissions), allowing users in a given group, like `polykey` for example, to access/interact with the files and CLI commands without error.

The idea here is that the files were originally only able to be accessed by the user who created them. This has implementations when trying to "daemonise" Polykey Agent using a Docker daemon-like approach. The only way to make this idea work is to set a default of `0770` permissions on the state files, allowing users outside of the user that created the file to interact with the state directory, as long as they are in the appropriate group to interact with the files it creates.

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Change the `umask` value

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [ ] Domain specific tests
* [ ] Full tests
* [ ] Updated inline-comment documentation
* [ ] Lint fixed
* [ ] Squash and rebased
* [ ] Sanity check the final build
