### PR TITLE
Adding `NodeConnectionAddress` limit for each node

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -287,6 +287,13 @@ const config = {
      * a node and resource usage per node and across the network.
      */
     nodesGraphBucketLimit: 20,
+    /**
+     * Node graph node specific NodeContactAddress limit. The node graph keeps
+     * a list of addresses for each node. This sets the limit on the number of
+     * different addresses we keep track of. If an added address exceeds this
+     * limit then the oldest addresses are removed first.
+     */
+    nodesGraphNodeContactAddressLimit: 5,
 
     /**
      * Multicast group addresses that the MDNS stack will operate on.

--- a/src/nodes/NodeGraph.ts
+++ b/src/nodes/NodeGraph.ts
@@ -428,7 +428,7 @@ class NodeGraph {
       nodeContactAddressData.connectedTime,
       tran,
     );
-    await this.purgeAddresses(nodeId, this.nodeContactAddressLimit);
+    await this.purgeAddresses(nodeId, this.nodeContactAddressLimit, tran);
   }
 
   /**
@@ -1022,15 +1022,15 @@ class NodeGraph {
     }
 
     // Start by getting all the existing addresses
-    const asd = await this.getNodeContact(nodeId, tran);
-    if (asd == null) return;
-    if (Object.keys(asd).length <= num) return;
+    const nodeContact = await this.getNodeContact(nodeId, tran);
+    if (nodeContact == null) return;
+    if (Object.keys(nodeContact).length <= num) return;
 
     const list: Array<[NodeContactAddress, number]> = [];
-    for (const nodeAddress of Object.keys(asd)) {
+    for (const nodeAddress of Object.keys(nodeContact)) {
       list.push([
         nodeAddress as NodeContactAddress,
-        asd[nodeAddress].connectedTime,
+        nodeContact[nodeAddress].connectedTime,
       ]);
     }
     list.sort(([, connectedTimeA], [, connectedTimeB]) => {

--- a/src/nodes/NodeGraph.ts
+++ b/src/nodes/NodeGraph.ts
@@ -57,6 +57,8 @@ class NodeGraph {
     keyRing,
     nodeIdBits = 256,
     nodeBucketLimit = config.defaultsSystem.nodesGraphBucketLimit,
+    nodeContactAddressLimit = config.defaultsSystem
+      .nodesGraphNodeContactAddressLimit,
     logger = new Logger(this.name),
     fresh = false,
   }: {
@@ -64,6 +66,7 @@ class NodeGraph {
     keyRing: KeyRing;
     nodeIdBits?: number;
     nodeBucketLimit?: number;
+    nodeContactAddressLimit?: number;
     logger?: Logger;
     fresh?: boolean;
   }): Promise<NodeGraph> {
@@ -73,6 +76,7 @@ class NodeGraph {
       keyRing,
       nodeIdBits,
       nodeBucketLimit,
+      nodeContactAddressLimit,
       logger,
     });
     await nodeGraph.start({ fresh });
@@ -90,6 +94,10 @@ class NodeGraph {
    * Max number of nodes in each bucket.
    */
   public readonly nodeBucketLimit: number;
+  /**
+   * Max number of nodeContactAddresses for each node.
+   */
+  public readonly nodeContactAddressLimit: number;
 
   protected logger: Logger;
   protected db: DB;
@@ -119,12 +127,14 @@ class NodeGraph {
     keyRing,
     nodeIdBits,
     nodeBucketLimit,
+    nodeContactAddressLimit,
     logger,
   }: {
     db: DB;
     keyRing: KeyRing;
     nodeIdBits: number;
     nodeBucketLimit: number;
+    nodeContactAddressLimit: number;
     logger: Logger;
   }) {
     this.logger = logger;
@@ -132,6 +142,7 @@ class NodeGraph {
     this.keyRing = keyRing;
     this.nodeIdBits = nodeIdBits;
     this.nodeBucketLimit = nodeBucketLimit;
+    this.nodeContactAddressLimit = nodeContactAddressLimit;
   }
 
   public async start({
@@ -361,6 +372,7 @@ class NodeGraph {
       );
     }
     await this.setConnectedTime(nodeId, connectedTimeMax, tran);
+    await this.purgeAddresses(nodeId, this.nodeContactAddressLimit, tran);
   }
 
   /**
@@ -416,6 +428,7 @@ class NodeGraph {
       nodeContactAddressData.connectedTime,
       tran,
     );
+    await this.purgeAddresses(nodeId, this.nodeContactAddressLimit);
   }
 
   /**
@@ -992,6 +1005,44 @@ class NodeGraph {
     }
     // `nodeGraphConnectedDbPath` will contain 2 entries for each `NodeId` within the `NodeGraph`
     return (await tran.count(this.nodeGraphConnectedDbPath)) / 2;
+  }
+
+  /**
+   * This utility will clean out the oldest addresses until a set amount remain
+   */
+  protected async purgeAddresses(
+    nodeId: NodeId,
+    num: number,
+    tran?: DBTransaction,
+  ): Promise<void> {
+    if (tran == null) {
+      return this.db.withTransactionF((tran) =>
+        this.purgeAddresses(nodeId, num, tran),
+      );
+    }
+
+    // Start by getting all the existing addresses
+    const asd = await this.getNodeContact(nodeId, tran);
+    if (asd == null) return;
+    if (Object.keys(asd).length <= num) return;
+
+    const list: Array<[NodeContactAddress, number]> = [];
+    for (const nodeAddress of Object.keys(asd)) {
+      list.push([
+        nodeAddress as NodeContactAddress,
+        asd[nodeAddress].connectedTime,
+      ]);
+    }
+    list.sort(([, connectedTimeA], [, connectedTimeB]) => {
+      if (connectedTimeA === connectedTimeB) return 0;
+      if (connectedTimeA > connectedTimeB) return 1;
+      return -1;
+    });
+    const removeNum = list.length - num;
+    for (let i = 0; i < removeNum; i++) {
+      const [addressRemove] = list.shift()!;
+      await this.unsetNodeContactAddress(nodeId, addressRemove, tran);
+    }
   }
 }
 

--- a/src/nodes/NodeManager.ts
+++ b/src/nodes/NodeManager.ts
@@ -217,7 +217,7 @@ class NodeManager {
 
   protected syncNodeGraphHandler = async (
     ctx: ContextTimed,
-    taskInfo: TaskInfo | undefined,
+    _taskInfo: TaskInfo | undefined,
     initialNodes: Array<[NodeIdEncoded, NodeAddress]>,
     connectionConnectTimeoutTime: number | undefined,
   ) => {

--- a/src/nodes/agent/handlers/NodesClosestLocalNodesGet.ts
+++ b/src/nodes/agent/handlers/NodesClosestLocalNodesGet.ts
@@ -7,6 +7,11 @@ import type {
 } from '../types';
 import type NodeGraph from '../../NodeGraph';
 import type { NodeId } from '../../../ids';
+import type {
+  NodeBucket,
+  NodeContact,
+  NodeContactAddressData,
+} from '../../types';
 import { ServerHandler } from '@matrixai/rpc';
 import * as ids from '../../../ids';
 import * as validation from '../../../validation';
@@ -48,15 +53,24 @@ class NodesClosestLocalNodesGet extends ServerHandler<
     return yield* db.withTransactionG(async function* (tran): AsyncGenerator<
       AgentRPCResponseResult<NodeContactMessage>
     > {
-      const closestNodes = await nodeGraph.getClosestNodes(
+      const closestNodes: NodeBucket = await nodeGraph.getClosestNodes(
         nodeId,
         undefined,
         tran,
       );
       for (const [nodeId, nodeContact] of closestNodes) {
+        // Filter out local scoped addresses
+        const nodeContactOutput: NodeContact = {};
+        for (const key of Object.keys(nodeContact)) {
+          const nodeContactData: NodeContactAddressData = nodeContact[key];
+          if (nodeContactData.scopes.includes('global')) {
+            nodeContactOutput[key] = nodeContactData;
+          }
+        }
+        if (Object.keys(nodeContactOutput).length === 0) continue;
         yield {
           nodeIdEncoded: nodesUtils.encodeNodeId(nodeId),
-          nodeContact,
+          nodeContact: nodeContactOutput,
         };
       }
     });

--- a/tests/nodes/NodeGraph.test.ts
+++ b/tests/nodes/NodeGraph.test.ts
@@ -213,6 +213,34 @@ describe(`${NodeGraph.name} test`, () => {
         );
       },
     );
+    test.prop(
+      [
+        testNodesUtils.nodeIdArb,
+        fc.array(testNodesUtils.nodeContactPairArb, {
+          minLength: 2,
+          maxLength: 10,
+        }),
+      ],
+      { numRuns: 19 },
+    )(
+      'Addresses are limited by NodeContactAddressLimit',
+      async (nodeId, nodeContactPairs) => {
+        const nodeContact: NodeContact = {};
+        for (const {
+          nodeContactAddress,
+          nodeContactAddressData,
+        } of nodeContactPairs) {
+          nodeContact[nodeContactAddress] = nodeContactAddressData;
+        }
+        await nodeGraph.setNodeContact(nodeId, nodeContact);
+
+        // Number of contacts should be truncated by NodeContactAddressLimit
+        const nodeContactsResult = await nodeGraph.getNodeContact(nodeId);
+        expect(Object.keys(nodeContactsResult!).length).toBeLessThanOrEqual(
+          nodeGraph.nodeContactAddressLimit,
+        );
+      },
+    );
   });
   describe('getNodeContact', () => {
     test.prop([testNodesUtils.nodeIdArb, testNodesUtils.nodeContactPairArb], {

--- a/tests/nodes/NodeGraph.test.ts
+++ b/tests/nodes/NodeGraph.test.ts
@@ -20,7 +20,6 @@ import * as nodesUtils from '@/nodes/utils';
 import * as utils from '@/utils';
 import { encodeNodeId } from '@/ids';
 import * as testNodesUtils from './utils';
-import { nodeIdContactPairArb } from './utils';
 
 describe(`${NodeGraph.name} test`, () => {
   const password = 'password';
@@ -1280,9 +1279,16 @@ describe(`${NodeGraph.name} test`, () => {
     });
   });
   describe('nodesTotal', () => {
-    test.prop([fc.array(nodeIdContactPairArb, { maxLength: 20 }).noShrink()], {
-      numRuns: 1,
-    })('should get total nodes', async (nodes) => {
+    test.prop(
+      [
+        fc
+          .array(testNodesUtils.nodeIdContactPairArb, { maxLength: 20 })
+          .noShrink(),
+      ],
+      {
+        numRuns: 1,
+      },
+    )('should get total nodes', async (nodes) => {
       for (const { nodeId, nodeContact } of nodes) {
         await nodeGraph.setNodeContact(nodeId, nodeContact);
       }

--- a/tests/nodes/agent/handlers/nodesClosestActiveConnectionsGet.test.ts
+++ b/tests/nodes/agent/handlers/nodesClosestActiveConnectionsGet.test.ts
@@ -82,7 +82,7 @@ describe('nodesClosestLocalNode', () => {
   });
 
   test('should get closest active nodes', async () => {
-    // Need to mock sone nodes
+    // Need to mock some nodes
     const connection = await nodeConnectionManagerLocal.createConnection(
       [nodeIdPeer1],
       localHost,

--- a/tests/nodes/agent/handlers/nodesClosestLocalNode.test.ts
+++ b/tests/nodes/agent/handlers/nodesClosestLocalNode.test.ts
@@ -169,7 +169,7 @@ describe('nodesClosestLocalNode', () => {
       const nodeId = testNodesUtils.generateRandomNodeId();
       await nodeGraph.setNodeContactAddressData(
         nodeId,
-        ['localhost' as Host, 55555 as Port],
+        ['localhost-2' as Host, 55555 as Port],
         {
           mode: 'direct',
           connectedTime: Date.now(),
@@ -189,5 +189,34 @@ describe('nodesClosestLocalNode', () => {
       resultNodes.push(result.nodeIdEncoded);
     }
     expect(nodes.sort()).toEqual(resultNodes.sort());
+  });
+  test('local only scoped addresses are filtered out', async () => {
+    // Adding 10 nodes
+    const nodes: Array<NodeIdEncoded> = [];
+    for (let i = 0; i < 10; i++) {
+      const nodeId = testNodesUtils.generateRandomNodeId();
+      await nodeGraph.setNodeContactAddressData(
+        nodeId,
+        ['localhost' as Host, 55555 as Port],
+        {
+          mode: 'direct',
+          connectedTime: Date.now(),
+          scopes: ['local'],
+        },
+      );
+      nodes.push(nodesUtils.encodeNodeId(nodeId));
+    }
+    const nodeIdEncoded = nodesUtils.encodeNodeId(
+      testNodesUtils.generateRandomNodeId(),
+    );
+    const results = await rpcClient.methods.nodesClosestLocalNodesGet({
+      nodeIdEncoded,
+    });
+    const resultNodes: Array<NodeIdEncoded> = [];
+    for await (const result of results) {
+      resultNodes.push(result.nodeIdEncoded);
+    }
+    // There should be no nodes provided
+    expect(resultNodes).toHaveLength(0);
   });
 });


### PR DESCRIPTION
### Description

This PR aims to solve the last task for #537 by adding a limit for the number of addresses stored for each NodeId and removing the oldest addresses when full.

### Issues Fixed

* Fixes #537 

### Tasks

- [x] 1. Add a `NodeConnectionAddressLimit` config to the `NodeGraph`
- [x] 2. Add logic for enforcing this limit on a per `NodeId` basis.

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
