### PR TITLE
Adding discovery feedback functionality

### DIFF
--- a/src/PolykeyAgent.ts
+++ b/src/PolykeyAgent.ts
@@ -445,6 +445,7 @@ class PolykeyAgent {
       audit = await Audit.createAudit({
         db,
         nodeConnectionManager,
+        discovery,
         fresh,
         logger: logger.getChild(Audit.name),
       });

--- a/src/audit/types.ts
+++ b/src/audit/types.ts
@@ -1,14 +1,24 @@
 import type { AuditEventId, AuditEventIdEncoded } from '../ids';
-import type { POJO } from '../types';
+import type { ObjectEmpty, POJO } from '../types';
 import type {
   nodeConnectionInboundMetricPath,
   nodeConnectionReverseTopicPath,
   nodeConnectionOutboundMetricPath,
   nodeConnectionForwardTopicPath,
+  discoveryVertexQueuedTopicPath,
+  discoveryVertexProcessedTopicPath,
+  discoveryVertexFailedTopicPath,
+  discoveryVertexCulledTopicPath,
+  discoveryVertexCancelledTopicPath,
+  discoveryCheckRediscoveryTopicPath,
   nodeConnectionMetricPath,
   topicPaths,
   metricPaths,
 } from './utils';
+import type {
+  VertexEventError,
+  VertexEventIdentifier,
+} from '../discovery/types';
 
 // Events
 
@@ -70,7 +80,14 @@ type TopicSubPath<T = TopicPath> =
 type TopicSubPathToAuditEvent<T extends TopicSubPath> =
   // Nodes
   | InferAuditEventFromSubpath<T, AuditEventNodeConnectionReverse>
-  | InferAuditEventFromSubpath<T, AuditEventNodeConnectionForward>;
+  | InferAuditEventFromSubpath<T, AuditEventNodeConnectionForward>
+  // Discovery
+  | InferAuditEventFromSubpath<T, AuditEventDiscoveryVertexQueued>
+  | InferAuditEventFromSubpath<T, AuditEventDiscoveryVertexProcessed>
+  | InferAuditEventFromSubpath<T, AuditEventDiscoveryVertexFailed>
+  | InferAuditEventFromSubpath<T, AuditEventDiscoveryVertexCulled>
+  | InferAuditEventFromSubpath<T, AuditEventDiscoveryVertexCancelled>
+  | InferAuditEventFromSubpath<T, AuditEventDiscoveryCheckRediscovery>;
 
 // Nodes
 
@@ -99,6 +116,47 @@ type AuditEventNodeConnectionForward = AuditEventNodeConnectionBase &
     },
     typeof nodeConnectionForwardTopicPath
   >;
+
+type AuditEventDiscovery =
+  | AuditEventDiscoveryVertex
+  | AuditEventDiscoveryCheckRediscovery;
+
+type AuditEventDiscoveryVertex =
+  | AuditEventDiscoveryVertexQueued
+  | AuditEventDiscoveryVertexProcessed
+  | AuditEventDiscoveryVertexFailed
+  | AuditEventDiscoveryVertexCulled
+  | AuditEventDiscoveryVertexCancelled;
+
+type AuditEventDiscoveryVertexQueued = AuditEventBase<
+  VertexEventIdentifier,
+  typeof discoveryVertexQueuedTopicPath
+>;
+
+type AuditEventDiscoveryVertexProcessed = AuditEventBase<
+  VertexEventIdentifier,
+  typeof discoveryVertexProcessedTopicPath
+>;
+
+type AuditEventDiscoveryVertexFailed = AuditEventBase<
+  VertexEventError,
+  typeof discoveryVertexFailedTopicPath
+>;
+
+type AuditEventDiscoveryVertexCulled = AuditEventBase<
+  VertexEventIdentifier,
+  typeof discoveryVertexCulledTopicPath
+>;
+
+type AuditEventDiscoveryVertexCancelled = AuditEventBase<
+  VertexEventIdentifier,
+  typeof discoveryVertexCancelledTopicPath
+>;
+
+type AuditEventDiscoveryCheckRediscovery = AuditEventBase<
+  ObjectEmpty,
+  typeof discoveryCheckRediscoveryTopicPath
+>;
 
 // Metrics
 
@@ -147,6 +205,14 @@ export type {
   AuditEventNodeConnection,
   AuditEventNodeConnectionReverse,
   AuditEventNodeConnectionForward,
+  AuditEventDiscovery,
+  AuditEventDiscoveryVertex,
+  AuditEventDiscoveryVertexQueued,
+  AuditEventDiscoveryVertexProcessed,
+  AuditEventDiscoveryVertexFailed,
+  AuditEventDiscoveryVertexCulled,
+  AuditEventDiscoveryVertexCancelled,
+  AuditEventDiscoveryCheckRediscovery,
   // Metric
   MetricPath,
   MetricPathToAuditMetric,

--- a/src/audit/utils.ts
+++ b/src/audit/utils.ts
@@ -1,8 +1,15 @@
 import type {
   AuditEventNodeConnectionForward,
   AuditEventNodeConnectionReverse,
+  AuditEventDiscoveryVertexQueued,
+  AuditEventDiscoveryVertexProcessed,
+  AuditEventDiscoveryVertexFailed,
+  AuditEventDiscoveryVertexCulled,
+  AuditEventDiscoveryVertexCancelled,
+  AuditEventDiscoveryCheckRediscovery,
 } from './types';
 import type * as nodesEvents from '../nodes/events';
+import type * as discoveryEvents from '../discovery/events';
 import type { AuditEventId } from '../ids';
 import { IdInternal } from '@matrixai/id';
 import * as sortableIdUtils from '@matrixai/id/dist/IdSortable';
@@ -77,11 +84,107 @@ function fromEventNodeConnectionManagerConnectionForward(
   };
 }
 
+// Discovery
+
+const discoveryVertexQueuedTopicPath = [
+  'discovery',
+  'vertex',
+  'queued',
+] as const;
+
+function fromEventDiscoveryVertexQueued(
+  evt: discoveryEvents.EventDiscoveryVertexQueued,
+): AuditEventDiscoveryVertexQueued['data'] {
+  return {
+    vertex: evt.detail.vertex,
+    parent: evt.detail.parent,
+  };
+}
+
+const discoveryVertexProcessedTopicPath = [
+  'discovery',
+  'vertex',
+  'processed',
+] as const;
+
+function fromEventDiscoveryVertexProcessed(
+  evt: discoveryEvents.EventDiscoveryVertexProcessed,
+): AuditEventDiscoveryVertexProcessed['data'] {
+  return {
+    vertex: evt.detail.vertex,
+    parent: evt.detail.parent,
+  };
+}
+
+const discoveryVertexFailedTopicPath = [
+  'discovery',
+  'vertex',
+  'failed',
+] as const;
+
+function fromEventDiscoveryVertexFailed(
+  evt: discoveryEvents.EventDiscoveryVertexFailed,
+): AuditEventDiscoveryVertexFailed['data'] {
+  return {
+    vertex: evt.detail.vertex,
+    parent: evt.detail.parent,
+    message: evt.detail.message,
+    code: evt.detail.code,
+  };
+}
+
+const discoveryVertexCulledTopicPath = [
+  'discovery',
+  'vertex',
+  'culled',
+] as const;
+
+function fromEventDiscoveryVertexCulled(
+  evt: discoveryEvents.EventDiscoveryVertexCulled,
+): AuditEventDiscoveryVertexCulled['data'] {
+  return {
+    vertex: evt.detail.vertex,
+    parent: evt.detail.parent,
+  };
+}
+
+const discoveryVertexCancelledTopicPath = [
+  'discovery',
+  'vertex',
+  'cancelled',
+] as const;
+
+function fromEventDiscoveryVertexCancelled(
+  evt: discoveryEvents.EventDiscoveryVertexCancelled,
+): AuditEventDiscoveryVertexCancelled['data'] {
+  return {
+    vertex: evt.detail.vertex,
+    parent: evt.detail.parent,
+  };
+}
+
+const discoveryCheckRediscoveryTopicPath = [
+  'discovery',
+  'checkRediscovery',
+] as const;
+
+function fromEventDiscoveryCheckRediscovery(
+  _evt: discoveryEvents.EventDiscoveryCheckRediscovery,
+): AuditEventDiscoveryCheckRediscovery['data'] {
+  return {};
+}
+
 const nodeGraphTopicPath = ['node', 'graph'] as const;
 
 const topicPaths = [
   nodeConnectionForwardTopicPath,
   nodeConnectionReverseTopicPath,
+  discoveryVertexQueuedTopicPath,
+  discoveryVertexProcessedTopicPath,
+  discoveryVertexFailedTopicPath,
+  discoveryVertexCulledTopicPath,
+  discoveryVertexCancelledTopicPath,
+  discoveryCheckRediscoveryTopicPath,
 ] as const;
 
 // Metrics
@@ -117,6 +220,18 @@ export {
   fromEventNodeConnectionManagerConnectionReverse,
   nodeConnectionForwardTopicPath,
   fromEventNodeConnectionManagerConnectionForward,
+  discoveryVertexQueuedTopicPath,
+  fromEventDiscoveryVertexQueued,
+  discoveryVertexProcessedTopicPath,
+  fromEventDiscoveryVertexProcessed,
+  discoveryVertexFailedTopicPath,
+  fromEventDiscoveryVertexFailed,
+  discoveryVertexCulledTopicPath,
+  fromEventDiscoveryVertexCulled,
+  discoveryVertexCancelledTopicPath,
+  fromEventDiscoveryVertexCancelled,
+  discoveryCheckRediscoveryTopicPath,
+  fromEventDiscoveryCheckRediscovery,
   nodeGraphTopicPath,
   topicPaths,
   nodeConnectionMetricPath,

--- a/src/client/callers/gestaltsDiscoveryQueue.ts
+++ b/src/client/callers/gestaltsDiscoveryQueue.ts
@@ -1,0 +1,12 @@
+import type { HandlerTypes } from '@matrixai/rpc';
+import type GestaltsDiscoveryQueue from '../handlers/GestaltsDiscoveryQueue';
+import { ServerCaller } from '@matrixai/rpc';
+
+type CallerTypes = HandlerTypes<GestaltsDiscoveryQueue>;
+
+const gestaltsDiscoveryQueue = new ServerCaller<
+  CallerTypes['input'],
+  CallerTypes['output']
+>();
+
+export default gestaltsDiscoveryQueue;

--- a/src/client/callers/index.ts
+++ b/src/client/callers/index.ts
@@ -14,6 +14,7 @@ import gestaltsDiscoveryByIdentity from './gestaltsDiscoveryByIdentity';
 import gestaltsDiscoveryByNode from './gestaltsDiscoveryByNode';
 import gestaltsGestaltGetByIdentity from './gestaltsGestaltGetByIdentity';
 import gestaltsGestaltGetByNode from './gestaltsGestaltGetByNode';
+import gestaltsDiscoveryQueue from './gestaltsDiscoveryQueue';
 import gestaltsGestaltList from './gestaltsGestaltList';
 import gestaltsGestaltTrustByIdentity from './gestaltsGestaltTrustByIdentity';
 import gestaltsGestaltTrustByNode from './gestaltsGestaltTrustByNode';
@@ -90,6 +91,7 @@ const clientManifest = {
   gestaltsDiscoveryByNode,
   gestaltsGestaltGetByIdentity,
   gestaltsGestaltGetByNode,
+  gestaltsDiscoveryQueue,
   gestaltsGestaltList,
   gestaltsGestaltTrustByIdentity,
   gestaltsGestaltTrustByNode,
@@ -165,6 +167,7 @@ export {
   gestaltsDiscoveryByNode,
   gestaltsGestaltGetByIdentity,
   gestaltsGestaltGetByNode,
+  gestaltsDiscoveryQueue,
   gestaltsGestaltList,
   gestaltsGestaltTrustByIdentity,
   gestaltsGestaltTrustByNode,

--- a/src/client/handlers/GestaltsDiscoveryQueue.ts
+++ b/src/client/handlers/GestaltsDiscoveryQueue.ts
@@ -1,0 +1,23 @@
+import type { ClientRPCRequestParams, ClientRPCResponseResult } from '../types';
+import type Discovery from '../../discovery/Discovery';
+import type { DiscoveryQueueInfo } from '../../discovery/types';
+import { ServerHandler } from '@matrixai/rpc';
+
+class GestaltsDiscoveryQueue extends ServerHandler<
+  {
+    discovery: Discovery;
+  },
+  ClientRPCRequestParams,
+  ClientRPCResponseResult<DiscoveryQueueInfo>
+> {
+  public async *handle(): AsyncGenerator<
+    ClientRPCResponseResult<DiscoveryQueueInfo>
+  > {
+    const { discovery } = this.container;
+    for await (const discoveryQueueInfo of discovery.getDiscoveryQueue()) {
+      yield discoveryQueueInfo;
+    }
+  }
+}
+
+export default GestaltsDiscoveryQueue;

--- a/src/client/handlers/GestaltsDiscoveryQueue.ts
+++ b/src/client/handlers/GestaltsDiscoveryQueue.ts
@@ -1,6 +1,7 @@
 import type { ClientRPCRequestParams, ClientRPCResponseResult } from '../types';
 import type Discovery from '../../discovery/Discovery';
 import type { DiscoveryQueueInfo } from '../../discovery/types';
+import type { ContextTimed } from '@matrixai/contexts';
 import { ServerHandler } from '@matrixai/rpc';
 
 class GestaltsDiscoveryQueue extends ServerHandler<
@@ -10,11 +11,15 @@ class GestaltsDiscoveryQueue extends ServerHandler<
   ClientRPCRequestParams,
   ClientRPCResponseResult<DiscoveryQueueInfo>
 > {
-  public async *handle(): AsyncGenerator<
-    ClientRPCResponseResult<DiscoveryQueueInfo>
-  > {
+  public async *handle(
+    _input: ClientRPCRequestParams,
+    _cancel,
+    _meta,
+    ctx: ContextTimed,
+  ): AsyncGenerator<ClientRPCResponseResult<DiscoveryQueueInfo>> {
     const { discovery } = this.container;
     for await (const discoveryQueueInfo of discovery.getDiscoveryQueue()) {
+      ctx.signal.throwIfAborted();
       yield discoveryQueueInfo;
     }
   }

--- a/src/client/handlers/index.ts
+++ b/src/client/handlers/index.ts
@@ -32,6 +32,7 @@ import GestaltsGestaltGetByNode from './GestaltsGestaltGetByNode';
 import GestaltsGestaltList from './GestaltsGestaltList';
 import GestaltsGestaltTrustByIdentity from './GestaltsGestaltTrustByIdentity';
 import GestaltsGestaltTrustByNode from './GestaltsGestaltTrustByNode';
+import GestaltsDiscoveryQueue from './GestaltsDiscoveryQueue';
 import IdentitiesAuthenticate from './IdentitiesAuthenticate';
 import IdentitiesAuthenticatedGet from './IdentitiesAuthenticatedGet';
 import IdentitiesClaim from './IdentitiesClaim';
@@ -133,6 +134,7 @@ const serverManifest = (container: {
       container,
     ),
     gestaltsGestaltTrustByNode: new GestaltsGestaltTrustByNode(container),
+    gestaltsDiscoveryQueue: new GestaltsDiscoveryQueue(container),
     identitiesAuthenticate: new IdentitiesAuthenticate(container),
     identitiesAuthenticatedGet: new IdentitiesAuthenticatedGet(container),
     identitiesClaim: new IdentitiesClaim(container),
@@ -203,6 +205,7 @@ export {
   GestaltsActionsUnsetByNode,
   GestaltsDiscoveryByIdentity,
   GestaltsDiscoveryByNode,
+  GestaltsDiscoveryQueue,
   GestaltsGestaltGetByIdentity,
   GestaltsGestaltGetByNode,
   GestaltsGestaltList,

--- a/src/discovery/events.ts
+++ b/src/discovery/events.ts
@@ -1,3 +1,4 @@
+import type { VertexEventIdentifier, VertexEventError } from './types';
 import EventPolykey from '../EventPolykey';
 
 abstract class EventDiscovery<T> extends EventPolykey<T> {}
@@ -14,6 +15,39 @@ class EventDiscoveryDestroy extends EventDiscovery<undefined> {}
 
 class EventDiscoveryDestroyed extends EventDiscovery<undefined> {}
 
+/**
+ * Emitted when a vertex is queued to be processed.
+ * Will include details about the vertex and it's parent.
+ */
+class EventDiscoveryVertexQueued extends EventDiscovery<VertexEventIdentifier> {}
+
+/**
+ * Emitted when a vertex has been processed.
+ * Will include details about the vertex and it's parent.
+ */
+class EventDiscoveryVertexProcessed extends EventDiscovery<VertexEventIdentifier> {}
+
+/**
+ * Emitted when a vertex failed to process.
+ * Includes details about the failure, the vertex and it's parent.
+ */
+class EventDiscoveryVertexFailed extends EventDiscovery<VertexEventError> {}
+
+/**
+ * Emitted when a vertex is removed from consideration for rediscover.
+ * This happens when if fails to process for too long.
+ * Will include details about the vertex and it's parent.
+ */
+class EventDiscoveryVertexCulled extends EventDiscovery<VertexEventIdentifier> {}
+
+/**
+ * Emitted when a vertex is removed from the queue without being processed.
+ * Will include details about the vertex and it's parent.
+ */
+class EventDiscoveryVertexCancelled extends EventDiscovery<VertexEventIdentifier> {}
+
+class EventDiscoveryCheckRediscovery extends EventDiscovery<undefined> {}
+
 export {
   EventDiscovery,
   EventDiscoveryStart,
@@ -22,4 +56,10 @@ export {
   EventDiscoveryStopped,
   EventDiscoveryDestroy,
   EventDiscoveryDestroyed,
+  EventDiscoveryVertexQueued,
+  EventDiscoveryVertexProcessed,
+  EventDiscoveryVertexFailed,
+  EventDiscoveryVertexCulled,
+  EventDiscoveryVertexCancelled,
+  EventDiscoveryCheckRediscovery,
 };

--- a/src/discovery/index.ts
+++ b/src/discovery/index.ts
@@ -1,3 +1,4 @@
 export { default as Discovery } from './Discovery';
 export * as errors from './errors';
 export * as events from './events';
+export type * as types from './types';

--- a/src/discovery/types.ts
+++ b/src/discovery/types.ts
@@ -1,0 +1,13 @@
+import type { GestaltIdEncoded } from '../ids';
+
+type VertexEventIdentifier = {
+  vertex: GestaltIdEncoded;
+  parent?: GestaltIdEncoded;
+};
+
+type VertexEventError = VertexEventIdentifier & {
+  message?: string;
+  code?: number;
+};
+
+export type { VertexEventIdentifier, VertexEventError };

--- a/src/discovery/types.ts
+++ b/src/discovery/types.ts
@@ -1,4 +1,6 @@
 import type { GestaltIdEncoded } from '../ids';
+import type { TaskIdEncoded } from '../ids';
+import type { TaskParameters, TaskStatus } from '../tasks/types';
 
 type VertexEventIdentifier = {
   vertex: GestaltIdEncoded;
@@ -10,4 +12,15 @@ type VertexEventError = VertexEventIdentifier & {
   code?: number;
 };
 
-export type { VertexEventIdentifier, VertexEventError };
+type DiscoveryQueueInfo = {
+  id: TaskIdEncoded;
+  status: TaskStatus;
+  parameters: TaskParameters;
+  delay: number;
+  deadline: number;
+  priority: number;
+  created: number;
+  scheduled: number;
+};
+
+export type { VertexEventIdentifier, VertexEventError, DiscoveryQueueInfo };

--- a/tests/audit/Audit.test.ts
+++ b/tests/audit/Audit.test.ts
@@ -64,6 +64,7 @@ describe(Audit.name, () => {
     const audit = await Audit.createAudit({
       db,
       nodeConnectionManager: new EventTarget() as any,
+      discovery: new EventTarget() as any,
       logger,
     });
     await expect(async () => {
@@ -88,6 +89,7 @@ describe(Audit.name, () => {
     const audit = await Audit.createAudit({
       db,
       nodeConnectionManager: new EventTarget() as any,
+      discovery: new EventTarget() as any,
       logger,
     });
     // @ts-ignore: kidnap protected
@@ -133,6 +135,7 @@ describe(Audit.name, () => {
       const audit = await Audit.createAudit({
         db,
         nodeConnectionManager: mockNodeConnectionManager,
+        discovery: new EventTarget() as any,
         logger,
       });
       const eventDetail: ConnectionData = {
@@ -173,6 +176,7 @@ describe(Audit.name, () => {
       const audit = await Audit.createAudit({
         db,
         nodeConnectionManager: mockNodeConnectionManager,
+        discovery: new EventTarget() as any,
         logger,
       });
       const eventDetail: ConnectionData = {
@@ -223,6 +227,7 @@ describe(Audit.name, () => {
       const audit = await Audit.createAudit({
         db,
         nodeConnectionManager: mockNodeConnectionManager,
+        discovery: new EventTarget() as any,
         logger,
       });
       const eventDetail: ConnectionData = {
@@ -257,6 +262,7 @@ describe(Audit.name, () => {
       const audit = await Audit.createAudit({
         db,
         nodeConnectionManager: mockNodeConnectionManager,
+        discovery: new EventTarget() as any,
         logger,
       });
       const eventDetail: ConnectionData = {
@@ -289,6 +295,7 @@ describe(Audit.name, () => {
       const audit = await Audit.createAudit({
         db,
         nodeConnectionManager: mockNodeConnectionManager,
+        discovery: new EventTarget() as any,
         logger,
       });
       const eventDetail: ConnectionData = {
@@ -316,7 +323,10 @@ describe(Audit.name, () => {
             detail: eventDetail,
           }),
         );
-      let iterator = audit.getAuditEvents(['node', 'connection']);
+      let iterator: AsyncGenerator<any, any, any> = audit.getAuditEvents([
+        'node',
+        'connection',
+      ]);
       await expect(iterator.next().then((e) => e.value!.data)).resolves.toEqual(
         {
           ...auditEventData,
@@ -362,6 +372,7 @@ describe(Audit.name, () => {
       const audit = await Audit.createAudit({
         db,
         nodeConnectionManager: mockNodeConnectionManager,
+        discovery: new EventTarget() as any,
         logger,
       });
       const eventDetail: ConnectionData = {
@@ -409,6 +420,7 @@ describe(Audit.name, () => {
       const audit = await Audit.createAudit({
         db,
         nodeConnectionManager: mockNodeConnectionManager,
+        discovery: new EventTarget() as any,
         logger,
       });
       const eventDetail: ConnectionData = {
@@ -478,6 +490,7 @@ describe(Audit.name, () => {
       const audit = await Audit.createAudit({
         db,
         nodeConnectionManager: mockNodeConnectionManager,
+        discovery: new EventTarget() as any,
         logger,
       });
       const eventDetail: ConnectionData = {
@@ -530,6 +543,7 @@ describe(Audit.name, () => {
       const audit = await Audit.createAudit({
         db,
         nodeConnectionManager: mockNodeConnectionManager,
+        discovery: new EventTarget() as any,
         logger,
       });
       const eventDetail: ConnectionData = {
@@ -557,7 +571,10 @@ describe(Audit.name, () => {
             detail: eventDetail,
           }),
         );
-      let iterator = audit.getAuditEvents(['node', 'connection']);
+      let iterator: AsyncGenerator<any, any, any> = audit.getAuditEvents([
+        'node',
+        'connection',
+      ]);
       await expect(iterator.next().then((e) => e.value!.data)).resolves.toEqual(
         {
           ...auditEventData,
@@ -592,6 +609,7 @@ describe(Audit.name, () => {
       const audit = await Audit.createAudit({
         db,
         nodeConnectionManager: mockNodeConnectionManager,
+        discovery: new EventTarget() as any,
         logger,
       });
       const nodeId = testNodesUtils.generateRandomNodeId();

--- a/tests/discovery/Discovery.test.ts
+++ b/tests/discovery/Discovery.test.ts
@@ -11,10 +11,12 @@ import os from 'os';
 import Logger, { LogLevel, StreamHandler } from '@matrixai/logger';
 import { DB } from '@matrixai/db';
 import { PromiseCancellable } from '@matrixai/async-cancellable';
+import { EventAll } from '@matrixai/events';
 import { AsyncIterableX as AsyncIterable } from 'ix/asynciterable';
 import TaskManager from '@/tasks/TaskManager';
 import PolykeyAgent from '@/PolykeyAgent';
 import Discovery from '@/discovery/Discovery';
+import * as discoveryEvents from '@/discovery/events';
 import GestaltGraph from '@/gestalts/GestaltGraph';
 import IdentitiesManager from '@/identities/IdentitiesManager';
 import NodeConnectionManager from '@/nodes/NodeConnectionManager';
@@ -563,6 +565,42 @@ describe('Discovery', () => {
     } while (existingTasks > 0);
     // All vertices should be reprocessed
     expect(processVertexMock).toHaveBeenCalledTimes(3);
+
+    await taskManager.stopProcessing();
+    await discovery.stop();
+    await discovery.destroy();
+  });
+  test('discovery events', async () => {
+    const discovery = await Discovery.createDiscovery({
+      db,
+      keyRing,
+      gestaltGraph,
+      identitiesManager,
+      nodeManager,
+      taskManager,
+      logger,
+      fresh: true,
+    });
+    const eventMap: Map<string, number> = new Map();
+    discovery.addEventListener(EventAll.name, async (evt: EventAll) => {
+      const event = evt.detail;
+      const eventName = event.constructor.name;
+      eventMap.set(eventName, (eventMap.get(eventName) ?? 0) + 1);
+    });
+    await taskManager.startProcessing();
+    await discovery.queueDiscoveryByNode(nodeA.keyRing.getNodeId());
+    let existingTasks: number = 0;
+    do {
+      existingTasks = await discovery.waitForDiscoveryTasks();
+    } while (existingTasks > 0);
+
+    // Just checking basic functionality of queued and processed
+    expect(eventMap.get(discoveryEvents.EventDiscoveryVertexQueued.name)).toBe(
+      3,
+    );
+    expect(
+      eventMap.get(discoveryEvents.EventDiscoveryVertexProcessed.name),
+    ).toBe(3);
 
     await taskManager.stopProcessing();
     await discovery.stop();


### PR DESCRIPTION
### Description

This PR addresses discovery feedback by adding events to the `Discovery` domain and RPC for streaming these events.

### Issues Fixed

* Fixes: ENG-28

### Tasks

- [x] 1. Add `Discovery` events relating to vertex processing.
- [x] 2. Add RPC command for streaming these `Discovery` events.
- [x] 3. Add tests validating these features.

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
